### PR TITLE
refactor: allocate AST in oxc_allocator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@
 ## Example
 
 ```rust
-use oxc_css_parser::{ast::Stylesheet, Parser, Syntax};
+use oxc_css_parser::{Allocator, Parser, Syntax, ast::Stylesheet};
 
-let mut parser = Parser::new("a { color: green }", Syntax::Css);
+let allocator = Allocator::default();
+let mut parser = Parser::new(&allocator, "a { color: green }", Syntax::Css);
 let ast = parser.parse::<Stylesheet>().unwrap();
 println!("{:#?}", ast);
 ```

--- a/benches/self.rs
+++ b/benches/self.rs
@@ -1,5 +1,5 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use oxc_css_parser::{Parser, Syntax, ast::Stylesheet};
+use oxc_css_parser::{Allocator, Parser, Syntax, ast::Stylesheet};
 use std::{fs, hint::black_box, path::Path, time::Duration};
 
 fn bench_parser(c: &mut Criterion) {
@@ -31,8 +31,9 @@ fn bench_parser(c: &mut Criterion) {
 
             group.bench_with_input(BenchmarkId::from_parameter(name), &code, |b, code| {
                 b.iter(|| {
-                    let mut parser = Parser::new(code, syntax);
-                    black_box(parser.parse::<Stylesheet>().unwrap())
+                    let allocator = Allocator::default();
+                    let mut parser = Parser::new(&allocator, code, syntax);
+                    black_box(parser.parse::<Stylesheet>().unwrap());
                 });
             });
         });

--- a/crates/oxc_css_parser/Cargo.toml
+++ b/crates/oxc_css_parser/Cargo.toml
@@ -10,8 +10,8 @@ exclude = ["/tests"]
 
 [dependencies]
 oxc-css-parser-macro = { path = "../oxc_css_parser_macro", version = "0.0.1" }
+oxc_allocator = ">=0.137.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
-smallvec = { version = "1.15", features = ["const_generics"] }
 
 [dev-dependencies]
 codespan-reporting = "0.13"
@@ -23,7 +23,7 @@ serde_json = "1.0"
 default = []
 codspeed = ["criterion2/codspeed"]
 config_serde = ["serde"]
-serialize = ["serde", "smallvec/serde"]
+serialize = ["serde", "oxc_allocator/serialize"]
 span_ignored_eq = []
 variant_helpers = []
 

--- a/crates/oxc_css_parser/src/ast.rs
+++ b/crates/oxc_css_parser/src/ast.rs
@@ -1,6 +1,7 @@
 //! All kinds of AST nodes are here.
 
 use crate::{pos::Span, tokenizer::TokenWithSpan};
+use oxc_allocator::{Box, Vec};
 #[cfg(feature = "variant_helpers")]
 use oxc_css_parser_macro::EnumAsIs;
 #[cfg(feature = "span_ignored_eq")]
@@ -8,10 +9,8 @@ use oxc_css_parser_macro::SpanIgnoredEq;
 use oxc_css_parser_macro::Spanned;
 #[cfg(feature = "serialize")]
 use serde::Serialize;
-use smallvec::SmallVec;
-use std::borrow::Cow;
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -21,74 +20,74 @@ pub struct AnPlusB {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct AtRule<'s> {
-    pub name: Ident<'s>,
-    pub prelude: Option<AtRulePrelude<'s>>,
-    pub block: Option<SimpleBlock<'s>>,
+pub struct AtRule<'a> {
+    pub name: Ident<'a>,
+    pub prelude: Option<AtRulePrelude<'a>>,
+    pub block: Option<SimpleBlock<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum AtRulePrelude<'s> {
-    Charset(Str<'s>),
-    ColorProfile(ColorProfilePrelude<'s>),
-    Container(ContainerPrelude<'s>),
-    CounterStyle(InterpolableIdent<'s>),
-    CustomMedia(Box<CustomMedia<'s>>),
-    CustomSelector(Box<CustomSelectorPrelude<'s>>),
-    Document(DocumentPrelude<'s>),
-    FontFeatureValues(FontFamilyName<'s>),
-    FontPaletteValues(InterpolableIdent<'s>),
-    Import(Box<ImportPrelude<'s>>),
-    Keyframes(KeyframesName<'s>),
-    Layer(LayerNames<'s>),
-    LessImport(Box<LessImportPrelude<'s>>),
-    LessPlugin(Box<LessPlugin<'s>>),
-    Media(MediaQueryList<'s>),
-    Namespace(Box<NamespacePrelude<'s>>),
-    Nest(SelectorList<'s>),
-    Page(PageSelectorList<'s>),
-    PositionTry(InterpolableIdent<'s>),
-    Property(InterpolableIdent<'s>),
-    SassAtRoot(SassAtRoot<'s>),
-    SassContent(SassContent<'s>),
-    SassEach(Box<SassEach<'s>>),
-    SassExpr(Box<ComponentValue<'s>>),
-    SassExtend(Box<SassExtend<'s>>),
-    SassFor(Box<SassFor<'s>>),
-    SassForward(Box<SassForward<'s>>),
-    SassFunction(Box<SassFunction<'s>>),
-    SassImport(SassImportPrelude<'s>),
-    SassInclude(Box<SassInclude<'s>>),
-    SassMixin(Box<SassMixin<'s>>),
-    SassUse(Box<SassUse<'s>>),
-    Scope(Box<ScopePrelude<'s>>),
-    ScrollTimeline(InterpolableIdent<'s>),
-    Supports(SupportsCondition<'s>),
-    Unknown(Box<UnknownAtRulePrelude<'s>>),
+pub enum AtRulePrelude<'a> {
+    Charset(Str<'a>),
+    ColorProfile(ColorProfilePrelude<'a>),
+    Container(ContainerPrelude<'a>),
+    CounterStyle(InterpolableIdent<'a>),
+    CustomMedia(Box<'a, CustomMedia<'a>>),
+    CustomSelector(Box<'a, CustomSelectorPrelude<'a>>),
+    Document(DocumentPrelude<'a>),
+    FontFeatureValues(FontFamilyName<'a>),
+    FontPaletteValues(InterpolableIdent<'a>),
+    Import(Box<'a, ImportPrelude<'a>>),
+    Keyframes(KeyframesName<'a>),
+    Layer(LayerNames<'a>),
+    LessImport(Box<'a, LessImportPrelude<'a>>),
+    LessPlugin(Box<'a, LessPlugin<'a>>),
+    Media(MediaQueryList<'a>),
+    Namespace(Box<'a, NamespacePrelude<'a>>),
+    Nest(SelectorList<'a>),
+    Page(PageSelectorList<'a>),
+    PositionTry(InterpolableIdent<'a>),
+    Property(InterpolableIdent<'a>),
+    SassAtRoot(SassAtRoot<'a>),
+    SassContent(SassContent<'a>),
+    SassEach(Box<'a, SassEach<'a>>),
+    SassExpr(Box<'a, ComponentValue<'a>>),
+    SassExtend(Box<'a, SassExtend<'a>>),
+    SassFor(Box<'a, SassFor<'a>>),
+    SassForward(Box<'a, SassForward<'a>>),
+    SassFunction(Box<'a, SassFunction<'a>>),
+    SassImport(SassImportPrelude<'a>),
+    SassInclude(Box<'a, SassInclude<'a>>),
+    SassMixin(Box<'a, SassMixin<'a>>),
+    SassUse(Box<'a, SassUse<'a>>),
+    Scope(Box<'a, ScopePrelude<'a>>),
+    ScrollTimeline(InterpolableIdent<'a>),
+    Supports(SupportsCondition<'a>),
+    Unknown(Box<'a, UnknownAtRulePrelude<'a>>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct AttributeSelector<'s> {
-    pub name: WqName<'s>,
+pub struct AttributeSelector<'a> {
+    pub name: WqName<'a>,
     pub matcher: Option<AttributeSelectorMatcher>,
-    pub value: Option<AttributeSelectorValue<'s>>,
-    pub modifier: Option<AttributeSelectorModifier<'s>>,
+    pub value: Option<AttributeSelectorValue<'a>>,
+    pub modifier: Option<AttributeSelectorModifier<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -97,7 +96,7 @@ pub struct AttributeSelectorMatcher {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 pub enum AttributeSelectorMatcherKind {
@@ -115,48 +114,48 @@ pub enum AttributeSelectorMatcherKind {
     Substring,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct AttributeSelectorModifier<'s> {
-    pub ident: InterpolableIdent<'s>,
+pub struct AttributeSelectorModifier<'a> {
+    pub ident: InterpolableIdent<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum AttributeSelectorValue<'s> {
-    Ident(InterpolableIdent<'s>),
-    Str(InterpolableStr<'s>),
-    Percentage(Percentage<'s>),
-    LessEscapedStr(LessEscapedStr<'s>),
+pub enum AttributeSelectorValue<'a> {
+    Ident(InterpolableIdent<'a>),
+    Str(InterpolableStr<'a>),
+    Percentage(Percentage<'a>),
+    LessEscapedStr(LessEscapedStr<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct BracketBlock<'s> {
-    pub value: Vec<ComponentValue<'s>>,
+pub struct BracketBlock<'a> {
+    pub value: Vec<'a, ComponentValue<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct Calc<'s> {
-    pub left: Box<ComponentValue<'s>>,
+pub struct Calc<'a> {
+    pub left: Box<'a, ComponentValue<'a>>,
     pub op: CalcOperator,
-    pub right: Box<ComponentValue<'s>>,
+    pub right: Box<'a, ComponentValue<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -165,7 +164,7 @@ pub struct CalcOperator {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 pub enum CalcOperatorKind {
@@ -175,26 +174,26 @@ pub enum CalcOperatorKind {
     Division,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct ClassSelector<'s> {
-    pub name: InterpolableIdent<'s>,
+pub struct ClassSelector<'a> {
+    pub name: InterpolableIdent<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum ColorProfilePrelude<'s> {
-    DashedIdent(InterpolableIdent<'s>),
-    DeviceCmyk(Ident<'s>),
+pub enum ColorProfilePrelude<'a> {
+    DashedIdent(InterpolableIdent<'a>),
+    DeviceCmyk(Ident<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -203,7 +202,7 @@ pub struct Combinator {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 pub enum CombinatorKind {
@@ -219,241 +218,241 @@ pub enum CombinatorKind {
     Column,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct ComplexSelector<'s> {
-    pub children: SmallVec<[ComplexSelectorChild<'s>; 3]>,
+pub struct ComplexSelector<'a> {
+    pub children: Vec<'a, ComplexSelectorChild<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum ComplexSelectorChild<'s> {
-    CompoundSelector(CompoundSelector<'s>),
+pub enum ComplexSelectorChild<'a> {
+    CompoundSelector(CompoundSelector<'a>),
     Combinator(Combinator),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum ComponentValue<'s> {
-    BracketBlock(BracketBlock<'s>),
-    Calc(Calc<'s>),
+pub enum ComponentValue<'a> {
+    BracketBlock(BracketBlock<'a>),
+    Calc(Calc<'a>),
     Delimiter(Delimiter),
-    Dimension(Dimension<'s>),
-    Function(Function<'s>),
-    HexColor(HexColor<'s>),
-    IdSelector(IdSelector<'s>),
-    ImportantAnnotation(ImportantAnnotation<'s>),
-    InterpolableIdent(InterpolableIdent<'s>),
-    InterpolableStr(InterpolableStr<'s>),
-    LayerName(LayerName<'s>),
-    LessBinaryOperation(LessBinaryOperation<'s>),
-    LessCondition(Box<LessCondition<'s>>),
-    LessDetachedRuleset(LessDetachedRuleset<'s>),
-    LessEscapedStr(LessEscapedStr<'s>),
-    LessJavaScriptSnippet(LessJavaScriptSnippet<'s>),
-    LessList(LessList<'s>),
-    LessMixinCall(LessMixinCall<'s>),
-    LessNamespaceValue(Box<LessNamespaceValue<'s>>),
-    LessNegativeValue(LessNegativeValue<'s>),
-    LessParenthesizedOperation(LessParenthesizedOperation<'s>),
+    Dimension(Dimension<'a>),
+    Function(Function<'a>),
+    HexColor(HexColor<'a>),
+    IdSelector(IdSelector<'a>),
+    ImportantAnnotation(ImportantAnnotation<'a>),
+    InterpolableIdent(InterpolableIdent<'a>),
+    InterpolableStr(InterpolableStr<'a>),
+    LayerName(LayerName<'a>),
+    LessBinaryOperation(LessBinaryOperation<'a>),
+    LessCondition(Box<'a, LessCondition<'a>>),
+    LessDetachedRuleset(LessDetachedRuleset<'a>),
+    LessEscapedStr(LessEscapedStr<'a>),
+    LessJavaScriptSnippet(LessJavaScriptSnippet<'a>),
+    LessList(LessList<'a>),
+    LessMixinCall(LessMixinCall<'a>),
+    LessNamespaceValue(Box<'a, LessNamespaceValue<'a>>),
+    LessNegativeValue(LessNegativeValue<'a>),
+    LessParenthesizedOperation(LessParenthesizedOperation<'a>),
     LessPercentKeyword(LessPercentKeyword),
-    LessPropertyVariable(LessPropertyVariable<'s>),
-    LessVariable(LessVariable<'s>),
-    LessVariableVariable(LessVariableVariable<'s>),
-    Number(Number<'s>),
-    Percentage(Percentage<'s>),
-    Placeholder(Placeholder<'s>),
-    Ratio(Ratio<'s>),
-    SassArbitraryArgument(SassArbitraryArgument<'s>),
-    SassBinaryExpression(SassBinaryExpression<'s>),
-    SassKeywordArgument(SassKeywordArgument<'s>),
-    SassList(SassList<'s>),
-    SassMap(SassMap<'s>),
-    SassQualifiedName(SassQualifiedName<'s>),
-    SassNestingDeclaration(SassNestingDeclaration<'s>),
-    SassParenthesizedExpression(SassParenthesizedExpression<'s>),
-    SassParentSelector(NestingSelector<'s>),
-    SassUnaryExpression(SassUnaryExpression<'s>),
-    SassVariable(SassVariable<'s>),
-    TokenWithSpan(TokenWithSpan<'s>),
-    UnicodeRange(UnicodeRange<'s>),
-    Url(Url<'s>),
+    LessPropertyVariable(LessPropertyVariable<'a>),
+    LessVariable(LessVariable<'a>),
+    LessVariableVariable(LessVariableVariable<'a>),
+    Number(Number<'a>),
+    Percentage(Percentage<'a>),
+    Placeholder(Placeholder<'a>),
+    Ratio(Ratio<'a>),
+    SassArbitraryArgument(SassArbitraryArgument<'a>),
+    SassBinaryExpression(SassBinaryExpression<'a>),
+    SassKeywordArgument(SassKeywordArgument<'a>),
+    SassList(SassList<'a>),
+    SassMap(SassMap<'a>),
+    SassQualifiedName(SassQualifiedName<'a>),
+    SassNestingDeclaration(SassNestingDeclaration<'a>),
+    SassParenthesizedExpression(SassParenthesizedExpression<'a>),
+    SassParentSelector(NestingSelector<'a>),
+    SassUnaryExpression(SassUnaryExpression<'a>),
+    SassVariable(SassVariable<'a>),
+    TokenWithSpan(TokenWithSpan<'a>),
+    UnicodeRange(UnicodeRange<'a>),
+    Url(Url<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct ComponentValues<'s> {
-    pub values: Vec<ComponentValue<'s>>,
+pub struct ComponentValues<'a> {
+    pub values: Vec<'a, ComponentValue<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct CompoundSelector<'s> {
-    pub children: Vec<SimpleSelector<'s>>,
+pub struct CompoundSelector<'a> {
+    pub children: Vec<'a, SimpleSelector<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct CompoundSelectorList<'s> {
-    pub selectors: Vec<CompoundSelector<'s>>,
-    pub comma_spans: Vec<Span>,
+pub struct CompoundSelectorList<'a> {
+    pub selectors: Vec<'a, CompoundSelector<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct ContainerCondition<'s> {
-    pub conditions: Vec<ContainerConditionKind<'s>>,
+pub struct ContainerCondition<'a> {
+    pub conditions: Vec<'a, ContainerConditionKind<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum ContainerConditionKind<'s> {
-    QueryInParens(QueryInParens<'s>),
-    And(ContainerConditionAnd<'s>),
-    Or(ContainerConditionOr<'s>),
-    Not(ContainerConditionNot<'s>),
+pub enum ContainerConditionKind<'a> {
+    QueryInParens(QueryInParens<'a>),
+    And(ContainerConditionAnd<'a>),
+    Or(ContainerConditionOr<'a>),
+    Not(ContainerConditionNot<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct ContainerConditionAnd<'s> {
-    pub keyword: Ident<'s>,
-    pub query_in_parens: QueryInParens<'s>,
+pub struct ContainerConditionAnd<'a> {
+    pub keyword: Ident<'a>,
+    pub query_in_parens: QueryInParens<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct ContainerConditionNot<'s> {
-    pub keyword: Ident<'s>,
-    pub query_in_parens: QueryInParens<'s>,
+pub struct ContainerConditionNot<'a> {
+    pub keyword: Ident<'a>,
+    pub query_in_parens: QueryInParens<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct ContainerConditionOr<'s> {
-    pub keyword: Ident<'s>,
-    pub query_in_parens: QueryInParens<'s>,
+pub struct ContainerConditionOr<'a> {
+    pub keyword: Ident<'a>,
+    pub query_in_parens: QueryInParens<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct ContainerPrelude<'s> {
-    pub name: Option<InterpolableIdent<'s>>,
-    pub condition: ContainerCondition<'s>,
+pub struct ContainerPrelude<'a> {
+    pub name: Option<InterpolableIdent<'a>>,
+    pub condition: ContainerCondition<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct CustomMedia<'s> {
-    pub name: InterpolableIdent<'s>,
-    pub value: CustomMediaValue<'s>,
+pub struct CustomMedia<'a> {
+    pub name: InterpolableIdent<'a>,
+    pub value: CustomMediaValue<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum CustomMediaValue<'s> {
-    MediaQueryList(MediaQueryList<'s>),
-    True(Ident<'s>),
-    False(Ident<'s>),
+pub enum CustomMediaValue<'a> {
+    MediaQueryList(MediaQueryList<'a>),
+    True(Ident<'a>),
+    False(Ident<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct CustomSelector<'s> {
-    pub prefix_arg: Option<CustomSelectorArg<'s>>,
-    pub name: Ident<'s>,
-    pub args: Option<CustomSelectorArgs<'s>>,
+pub struct CustomSelector<'a> {
+    pub prefix_arg: Option<CustomSelectorArg<'a>>,
+    pub name: Ident<'a>,
+    pub args: Option<CustomSelectorArgs<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct CustomSelectorArg<'s> {
-    pub name: Ident<'s>,
+pub struct CustomSelectorArg<'a> {
+    pub name: Ident<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct CustomSelectorArgs<'s> {
-    pub args: Vec<CustomSelectorArg<'s>>,
-    pub comma_spans: Vec<Span>,
+pub struct CustomSelectorArgs<'a> {
+    pub args: Vec<'a, CustomSelectorArg<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct CustomSelectorPrelude<'s> {
-    pub custom_selector: CustomSelector<'s>,
-    pub selector: SelectorList<'s>,
+pub struct CustomSelectorPrelude<'a> {
+    pub custom_selector: CustomSelector<'a>,
+    pub selector: SelectorList<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct Declaration<'s> {
-    pub name: InterpolableIdent<'s>,
+pub struct Declaration<'a> {
+    pub name: InterpolableIdent<'a>,
     pub name_suffix: Option<char>,
     pub colon_span: Span,
-    pub value: Vec<ComponentValue<'s>>,
-    pub important: Option<ImportantAnnotation<'s>>,
+    pub value: Vec<'a, ComponentValue<'a>>,
+    pub important: Option<ImportantAnnotation<'a>>,
     pub less_property_merge: Option<LessPropertyMerge>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -462,7 +461,7 @@ pub struct Delimiter {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 pub enum DelimiterKind {
@@ -471,18 +470,18 @@ pub enum DelimiterKind {
     Semicolon,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct Dimension<'s> {
-    pub value: Number<'s>,
-    pub unit: Ident<'s>,
+pub struct Dimension<'a> {
+    pub value: Number<'a>,
+    pub unit: Ident<'a>,
     pub kind: DimensionKind,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 pub enum DimensionKind {
@@ -495,304 +494,304 @@ pub enum DimensionKind {
     Unknown,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct DocumentPrelude<'s> {
-    pub matchers: Vec<DocumentPreludeMatcher<'s>>,
-    pub comma_spans: Vec<Span>,
+pub struct DocumentPrelude<'a> {
+    pub matchers: Vec<'a, DocumentPreludeMatcher<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum DocumentPreludeMatcher<'s> {
-    Url(Url<'s>),
-    Function(Function<'s>),
+pub enum DocumentPreludeMatcher<'a> {
+    Url(Url<'a>),
+    Function(Function<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum FontFamilyName<'s> {
-    Str(InterpolableStr<'s>),
-    Unquoted(UnquotedFontFamilyName<'s>),
+pub enum FontFamilyName<'a> {
+    Str(InterpolableStr<'a>),
+    Unquoted(UnquotedFontFamilyName<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct Function<'s> {
-    pub name: FunctionName<'s>,
-    pub args: Vec<ComponentValue<'s>>,
+pub struct Function<'a> {
+    pub name: FunctionName<'a>,
+    pub args: Vec<'a, ComponentValue<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum FunctionName<'s> {
-    Ident(InterpolableIdent<'s>),
-    SassQualifiedName(Box<SassQualifiedName<'s>>),
+pub enum FunctionName<'a> {
+    Ident(InterpolableIdent<'a>),
+    SassQualifiedName(Box<'a, SassQualifiedName<'a>>),
     LessListFunction(LessListFunction),
     LessFormatFunction(LessFormatFunction),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct HexColor<'s> {
-    pub value: Cow<'s, str>,
-    pub raw: &'s str,
+pub struct HexColor<'a> {
+    pub value: &'a str,
+    pub raw: &'a str,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct Ident<'s> {
-    pub name: Cow<'s, str>,
-    pub raw: &'s str,
+pub struct Ident<'a> {
+    pub name: &'a str,
+    pub raw: &'a str,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct ImportPrelude<'s> {
-    pub href: ImportPreludeHref<'s>,
-    pub layer: Option<ImportPreludeLayer<'s>>,
-    pub supports: Option<ImportPreludeSupports<'s>>,
-    pub media: Option<MediaQueryList<'s>>,
+pub struct ImportPrelude<'a> {
+    pub href: ImportPreludeHref<'a>,
+    pub layer: Option<ImportPreludeLayer<'a>>,
+    pub supports: Option<ImportPreludeSupports<'a>>,
+    pub media: Option<MediaQueryList<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum ImportPreludeHref<'s> {
-    Str(InterpolableStr<'s>),
-    Url(Url<'s>),
+pub enum ImportPreludeHref<'a> {
+    Str(InterpolableStr<'a>),
+    Url(Url<'a>),
     /// Sass only: `url(...)` whose content is not a parsable URL but is
     /// valid SassScript, e.g. `@import url($dir+"/path");`.
-    Function(Function<'s>),
+    Function(Function<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum ImportPreludeLayer<'s> {
-    Empty(Ident<'s>),
-    WithName(Function<'s>),
+pub enum ImportPreludeLayer<'a> {
+    Empty(Ident<'a>),
+    WithName(Function<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct ImportPreludeSupports<'s> {
-    pub kind: ImportPreludeSupportsKind<'s>,
+pub struct ImportPreludeSupports<'a> {
+    pub kind: ImportPreludeSupportsKind<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum ImportPreludeSupportsKind<'s> {
-    SupportsCondition(SupportsCondition<'s>),
-    Declaration(Declaration<'s>),
+pub enum ImportPreludeSupportsKind<'a> {
+    SupportsCondition(SupportsCondition<'a>),
+    Declaration(Declaration<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum InterpolableIdent<'s> {
-    Literal(Ident<'s>),
-    SassInterpolated(SassInterpolatedIdent<'s>),
-    LessInterpolated(LessInterpolatedIdent<'s>),
-    Placeholder(Placeholder<'s>),
+pub enum InterpolableIdent<'a> {
+    Literal(Ident<'a>),
+    SassInterpolated(SassInterpolatedIdent<'a>),
+    LessInterpolated(LessInterpolatedIdent<'a>),
+    Placeholder(Placeholder<'a>),
 }
 
 /// An atomic backtick-delimited template placeholder node (see
 /// [`ParserOptions::template_placeholder`](crate::config::ParserOptions)),
 /// carrying the parsed decimal index. Appears in value, selector, and
 /// statement positions where a downstream formatter substitutes interpolations.
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct Placeholder<'s> {
+pub struct Placeholder<'a> {
     pub index: u32,
     /// An ident-continuation run glued directly after the placeholder
     /// (`` `PLACEHOLDER-0`px `` -> index 0, suffix `"px"`), empty when none.
     /// Mirrors `#{$x}px` being a single identifier rather than two tokens.
-    pub suffix: &'s str,
+    pub suffix: &'a str,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct InterpolableIdentStaticPart<'s> {
-    pub value: Cow<'s, str>,
-    pub raw: &'s str,
+pub struct InterpolableIdentStaticPart<'a> {
+    pub value: &'a str,
+    pub raw: &'a str,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum InterpolableStr<'s> {
-    Literal(Str<'s>),
-    SassInterpolated(SassInterpolatedStr<'s>),
-    LessInterpolated(LessInterpolatedStr<'s>),
+pub enum InterpolableStr<'a> {
+    Literal(Str<'a>),
+    SassInterpolated(SassInterpolatedStr<'a>),
+    LessInterpolated(LessInterpolatedStr<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct InterpolableStrStaticPart<'s> {
-    pub value: Cow<'s, str>,
-    pub raw: &'s str,
+pub struct InterpolableStrStaticPart<'a> {
+    pub value: &'a str,
+    pub raw: &'a str,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct InterpolableUrlStaticPart<'s> {
-    pub value: Cow<'s, str>,
-    pub raw: &'s str,
+pub struct InterpolableUrlStaticPart<'a> {
+    pub value: &'a str,
+    pub raw: &'a str,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct IdSelector<'s> {
-    pub name: InterpolableIdent<'s>,
+pub struct IdSelector<'a> {
+    pub name: InterpolableIdent<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct ImportantAnnotation<'s> {
-    pub ident: Ident<'s>,
+pub struct ImportantAnnotation<'a> {
+    pub ident: Ident<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct KeyframeBlock<'s> {
-    pub selectors: Vec<KeyframeSelector<'s>>,
-    pub comma_spans: Vec<Span>,
-    pub block: SimpleBlock<'s>,
+pub struct KeyframeBlock<'a> {
+    pub selectors: Vec<'a, KeyframeSelector<'a>>,
+    pub comma_spans: Vec<'a, Span>,
+    pub block: SimpleBlock<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum KeyframeSelector<'s> {
-    Ident(InterpolableIdent<'s>),
-    Percentage(Percentage<'s>),
+pub enum KeyframeSelector<'a> {
+    Ident(InterpolableIdent<'a>),
+    Percentage(Percentage<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum KeyframesName<'s> {
-    Ident(InterpolableIdent<'s>),
-    Str(InterpolableStr<'s>),
-    LessVariable(LessVariable<'s>),
-    LessEscapedStr(LessEscapedStr<'s>),
+pub enum KeyframesName<'a> {
+    Ident(InterpolableIdent<'a>),
+    Str(InterpolableStr<'a>),
+    LessVariable(LessVariable<'a>),
+    LessEscapedStr(LessEscapedStr<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum LanguageRange<'s> {
-    Str(InterpolableStr<'s>),
-    Ident(InterpolableIdent<'s>),
+pub enum LanguageRange<'a> {
+    Str(InterpolableStr<'a>),
+    Ident(InterpolableIdent<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LanguageRangeList<'s> {
-    pub ranges: Vec<LanguageRange<'s>>,
-    pub comma_spans: Vec<Span>,
+pub struct LanguageRangeList<'a> {
+    pub ranges: Vec<'a, LanguageRange<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LayerName<'s> {
-    pub idents: Vec<InterpolableIdent<'s>>,
+pub struct LayerName<'a> {
+    pub idents: Vec<'a, InterpolableIdent<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LayerNames<'s> {
-    pub names: Vec<LayerName<'s>>,
-    pub comma_spans: Vec<Span>,
+pub struct LayerNames<'a> {
+    pub names: Vec<'a, LayerName<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessBinaryCondition<'s> {
-    pub left: Box<LessCondition<'s>>,
+pub struct LessBinaryCondition<'a> {
+    pub left: Box<'a, LessCondition<'a>>,
     pub op: LessBinaryConditionOperator,
-    pub right: Box<LessCondition<'s>>,
+    pub right: Box<'a, LessCondition<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -801,7 +800,7 @@ pub struct LessBinaryConditionOperator {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 pub enum LessBinaryConditionOperatorKind {
@@ -816,101 +815,101 @@ pub enum LessBinaryConditionOperatorKind {
     Or,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessBinaryOperation<'s> {
-    pub left: Box<ComponentValue<'s>>,
+pub struct LessBinaryOperation<'a> {
+    pub left: Box<'a, ComponentValue<'a>>,
     pub op: LessOperationOperator,
-    pub right: Box<ComponentValue<'s>>,
+    pub right: Box<'a, ComponentValue<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum LessCondition<'s> {
-    Binary(LessBinaryCondition<'s>),
-    Negated(LessNegatedCondition<'s>),
-    Parenthesized(LessParenthesizedCondition<'s>),
-    Value(ComponentValue<'s>),
+pub enum LessCondition<'a> {
+    Binary(LessBinaryCondition<'a>),
+    Negated(LessNegatedCondition<'a>),
+    Parenthesized(LessParenthesizedCondition<'a>),
+    Value(ComponentValue<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessConditionalQualifiedRule<'s> {
-    pub selector: SelectorList<'s>,
-    pub guard: LessConditions<'s>,
-    pub block: SimpleBlock<'s>,
+pub struct LessConditionalQualifiedRule<'a> {
+    pub selector: SelectorList<'a>,
+    pub guard: LessConditions<'a>,
+    pub block: SimpleBlock<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessConditions<'s> {
-    pub conditions: Vec<LessCondition<'s>>,
+pub struct LessConditions<'a> {
+    pub conditions: Vec<'a, LessCondition<'a>>,
     pub when_span: Span,
-    pub comma_spans: Vec<Span>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessDetachedRuleset<'s> {
-    pub block: SimpleBlock<'s>,
+pub struct LessDetachedRuleset<'a> {
+    pub block: SimpleBlock<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessEscapedStr<'s> {
-    pub str: Str<'s>,
+pub struct LessEscapedStr<'a> {
+    pub str: Str<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessExtend<'s> {
-    pub selector: ComplexSelector<'s>,
-    pub all: Option<Ident<'s>>,
+pub struct LessExtend<'a> {
+    pub selector: ComplexSelector<'a>,
+    pub all: Option<Ident<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessExtendList<'s> {
-    pub elements: Vec<LessExtend<'s>>,
-    pub comma_spans: Vec<Span>,
+pub struct LessExtendList<'a> {
+    pub elements: Vec<'a, LessExtend<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessExtendRule<'s> {
-    pub nesting_selector: NestingSelector<'s>,
-    pub name_of_extend: Ident<'s>,
-    pub extend: LessExtendList<'s>,
+pub struct LessExtendRule<'a> {
+    pub nesting_selector: NestingSelector<'a>,
+    pub name_of_extend: Ident<'a>,
+    pub extend: LessExtendList<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -918,89 +917,89 @@ pub struct LessFormatFunction {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessImportOptions<'s> {
-    pub names: Vec<Ident<'s>>,
-    pub comma_spans: Vec<Span>,
+pub struct LessImportOptions<'a> {
+    pub names: Vec<'a, Ident<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessImportPrelude<'s> {
-    pub href: ImportPreludeHref<'s>,
-    pub options: LessImportOptions<'s>,
-    pub media: Option<MediaQueryList<'s>>,
+pub struct LessImportPrelude<'a> {
+    pub href: ImportPreludeHref<'a>,
+    pub options: LessImportOptions<'a>,
+    pub media: Option<MediaQueryList<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessInterpolatedIdent<'s> {
-    pub elements: Vec<LessInterpolatedIdentElement<'s>>,
+pub struct LessInterpolatedIdent<'a> {
+    pub elements: Vec<'a, LessInterpolatedIdentElement<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum LessInterpolatedIdentElement<'s> {
-    Variable(LessVariableInterpolation<'s>),
-    Property(LessPropertyInterpolation<'s>),
-    Static(InterpolableIdentStaticPart<'s>),
+pub enum LessInterpolatedIdentElement<'a> {
+    Variable(LessVariableInterpolation<'a>),
+    Property(LessPropertyInterpolation<'a>),
+    Static(InterpolableIdentStaticPart<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessInterpolatedStr<'s> {
-    pub elements: Vec<LessInterpolatedStrElement<'s>>,
+pub struct LessInterpolatedStr<'a> {
+    pub elements: Vec<'a, LessInterpolatedStrElement<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum LessInterpolatedStrElement<'s> {
-    Variable(LessVariableInterpolation<'s>),
-    Property(LessPropertyInterpolation<'s>),
-    Static(InterpolableStrStaticPart<'s>),
+pub enum LessInterpolatedStrElement<'a> {
+    Variable(LessVariableInterpolation<'a>),
+    Property(LessPropertyInterpolation<'a>),
+    Static(InterpolableStrStaticPart<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessJavaScriptSnippet<'s> {
-    pub code: &'s str,
-    pub raw: &'s str,
+pub struct LessJavaScriptSnippet<'a> {
+    pub code: &'a str,
+    pub raw: &'a str,
     pub escaped: bool,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessList<'s> {
-    pub elements: Vec<ComponentValue<'s>>,
-    pub comma_spans: Option<Vec<Span>>,
+pub struct LessList<'a> {
+    pub elements: Vec<'a, ComponentValue<'a>>,
+    pub comma_spans: Option<Vec<'a, Span>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -1008,239 +1007,239 @@ pub struct LessListFunction {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessLookup<'s> {
-    pub name: Option<LessLookupName<'s>>,
+pub struct LessLookup<'a> {
+    pub name: Option<LessLookupName<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum LessLookupName<'s> {
-    LessVariable(LessVariable<'s>),
-    LessVariableVariable(LessVariableVariable<'s>),
-    LessPropertyVariable(LessPropertyVariable<'s>),
-    Ident(Ident<'s>),
+pub enum LessLookupName<'a> {
+    LessVariable(LessVariable<'a>),
+    LessVariableVariable(LessVariableVariable<'a>),
+    LessPropertyVariable(LessPropertyVariable<'a>),
+    Ident(Ident<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessLookups<'s> {
-    pub lookups: Vec<LessLookup<'s>>,
+pub struct LessLookups<'a> {
+    pub lookups: Vec<'a, LessLookup<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum LessMixinArgument<'s> {
-    Named(LessMixinNamedArgument<'s>),
-    Value(ComponentValue<'s>),
-    Variadic(LessMixinVariadicArgument<'s>),
+pub enum LessMixinArgument<'a> {
+    Named(LessMixinNamedArgument<'a>),
+    Value(ComponentValue<'a>),
+    Variadic(LessMixinVariadicArgument<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessMixinArguments<'s> {
-    pub args: Vec<LessMixinArgument<'s>>,
+pub struct LessMixinArguments<'a> {
+    pub args: Vec<'a, LessMixinArgument<'a>>,
     pub is_comma_separated: bool,
-    pub separator_spans: Vec<Span>,
+    pub separator_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessMixinCall<'s> {
-    pub callee: LessMixinCallee<'s>,
-    pub args: Option<LessMixinArguments<'s>>,
-    pub important: Option<ImportantAnnotation<'s>>,
+pub struct LessMixinCall<'a> {
+    pub callee: LessMixinCallee<'a>,
+    pub args: Option<LessMixinArguments<'a>>,
+    pub important: Option<ImportantAnnotation<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessMixinCallee<'s> {
-    pub children: Vec<LessMixinCalleeChild<'s>>,
+pub struct LessMixinCallee<'a> {
+    pub children: Vec<'a, LessMixinCalleeChild<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessMixinCalleeChild<'s> {
-    pub name: LessMixinName<'s>,
+pub struct LessMixinCalleeChild<'a> {
+    pub name: LessMixinName<'a>,
     pub combinator: Option<Combinator>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessMixinDefinition<'s> {
-    pub name: LessMixinName<'s>,
-    pub params: LessMixinParameters<'s>,
-    pub guard: Option<LessConditions<'s>>,
-    pub block: SimpleBlock<'s>,
+pub struct LessMixinDefinition<'a> {
+    pub name: LessMixinName<'a>,
+    pub params: LessMixinParameters<'a>,
+    pub guard: Option<LessConditions<'a>>,
+    pub block: SimpleBlock<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum LessMixinName<'s> {
-    ClassSelector(ClassSelector<'s>),
-    IdSelector(IdSelector<'s>),
+pub enum LessMixinName<'a> {
+    ClassSelector(ClassSelector<'a>),
+    IdSelector(IdSelector<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessMixinNamedArgument<'s> {
-    pub name: LessMixinParameterName<'s>,
+pub struct LessMixinNamedArgument<'a> {
+    pub name: LessMixinParameterName<'a>,
     pub colon_span: Span,
-    pub value: ComponentValue<'s>,
+    pub value: ComponentValue<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessMixinNamedParameter<'s> {
-    pub name: LessMixinParameterName<'s>,
-    pub value: Option<LessMixinNamedParameterDefaultValue<'s>>,
+pub struct LessMixinNamedParameter<'a> {
+    pub name: LessMixinParameterName<'a>,
+    pub value: Option<LessMixinNamedParameterDefaultValue<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessMixinNamedParameterDefaultValue<'s> {
+pub struct LessMixinNamedParameterDefaultValue<'a> {
     pub colon_span: Span,
-    pub value: ComponentValue<'s>,
+    pub value: ComponentValue<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum LessMixinParameter<'s> {
-    Named(LessMixinNamedParameter<'s>),
-    Unnamed(LessMixinUnnamedParameter<'s>),
-    Variadic(LessMixinVariadicParameter<'s>),
+pub enum LessMixinParameter<'a> {
+    Named(LessMixinNamedParameter<'a>),
+    Unnamed(LessMixinUnnamedParameter<'a>),
+    Variadic(LessMixinVariadicParameter<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessMixinParameters<'s> {
-    pub params: Vec<LessMixinParameter<'s>>,
+pub struct LessMixinParameters<'a> {
+    pub params: Vec<'a, LessMixinParameter<'a>>,
     pub is_comma_separated: bool,
-    pub separator_spans: Vec<Span>,
+    pub separator_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum LessMixinParameterName<'s> {
-    Variable(LessVariable<'s>),
-    PropertyVariable(LessPropertyVariable<'s>),
+pub enum LessMixinParameterName<'a> {
+    Variable(LessVariable<'a>),
+    PropertyVariable(LessPropertyVariable<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessMixinUnnamedParameter<'s> {
-    pub value: ComponentValue<'s>,
+pub struct LessMixinUnnamedParameter<'a> {
+    pub value: ComponentValue<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessMixinVariadicArgument<'s> {
-    pub name: LessMixinParameterName<'s>,
+pub struct LessMixinVariadicArgument<'a> {
+    pub name: LessMixinParameterName<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessMixinVariadicParameter<'s> {
-    pub name: Option<LessMixinParameterName<'s>>,
+pub struct LessMixinVariadicParameter<'a> {
+    pub name: Option<LessMixinParameterName<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessNamespaceValue<'s> {
-    pub callee: LessNamespaceValueCallee<'s>,
-    pub lookups: LessLookups<'s>,
+pub struct LessNamespaceValue<'a> {
+    pub callee: LessNamespaceValueCallee<'a>,
+    pub lookups: LessLookups<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum LessNamespaceValueCallee<'s> {
-    LessMixinCall(LessMixinCall<'s>),
-    LessVariable(LessVariable<'s>),
+pub enum LessNamespaceValueCallee<'a> {
+    LessMixinCall(LessMixinCall<'a>),
+    LessVariable(LessVariable<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessNegatedCondition<'s> {
-    pub condition: Box<LessCondition<'s>>,
+pub struct LessNegatedCondition<'a> {
+    pub condition: Box<'a, LessCondition<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessNegativeValue<'s> {
-    pub value: Box<ComponentValue<'s>>,
+pub struct LessNegativeValue<'a> {
+    pub value: Box<'a, ComponentValue<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -1249,7 +1248,7 @@ pub struct LessOperationOperator {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 pub enum LessOperationOperatorKind {
@@ -1259,25 +1258,25 @@ pub enum LessOperationOperatorKind {
     Minus,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessParenthesizedCondition<'s> {
-    pub condition: Box<LessCondition<'s>>,
+pub struct LessParenthesizedCondition<'a> {
+    pub condition: Box<'a, LessCondition<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessParenthesizedOperation<'s> {
-    pub operation: Box<ComponentValue<'s>>,
+pub struct LessParenthesizedOperation<'a> {
+    pub operation: Box<'a, ComponentValue<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -1285,36 +1284,36 @@ pub struct LessPercentKeyword {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessPlugin<'s> {
-    pub path: LessPluginPath<'s>,
-    pub args: Option<TokenSeq<'s>>,
+pub struct LessPlugin<'a> {
+    pub path: LessPluginPath<'a>,
+    pub args: Option<TokenSeq<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum LessPluginPath<'s> {
-    Str(Str<'s>),
-    Url(Url<'s>),
+pub enum LessPluginPath<'a> {
+    Str(Str<'a>),
+    Url(Url<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessPropertyInterpolation<'s> {
-    pub name: Ident<'s>,
+pub struct LessPropertyInterpolation<'a> {
+    pub name: Ident<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -1323,7 +1322,7 @@ pub struct LessPropertyMerge {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 pub enum LessPropertyMergeKind {
@@ -1331,116 +1330,116 @@ pub enum LessPropertyMergeKind {
     Space,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessPropertyVariable<'s> {
-    pub name: Ident<'s>,
+pub struct LessPropertyVariable<'a> {
+    pub name: Ident<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessVariable<'s> {
-    pub name: Ident<'s>,
+pub struct LessVariable<'a> {
+    pub name: Ident<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessVariableCall<'s> {
-    pub variable: LessVariable<'s>,
+pub struct LessVariableCall<'a> {
+    pub variable: LessVariable<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessVariableDeclaration<'s> {
-    pub name: LessVariable<'s>,
+pub struct LessVariableDeclaration<'a> {
+    pub name: LessVariable<'a>,
     pub colon_span: Span,
-    pub value: ComponentValue<'s>,
+    pub value: ComponentValue<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessVariableInterpolation<'s> {
-    pub name: Ident<'s>,
+pub struct LessVariableInterpolation<'a> {
+    pub name: Ident<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct LessVariableVariable<'s> {
-    pub variable: LessVariable<'s>,
+pub struct LessVariableVariable<'a> {
+    pub variable: LessVariable<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct MediaAnd<'s> {
-    pub keyword: Ident<'s>,
-    pub media_in_parens: MediaInParens<'s>,
+pub struct MediaAnd<'a> {
+    pub keyword: Ident<'a>,
+    pub media_in_parens: MediaInParens<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct MediaCondition<'s> {
-    pub conditions: Vec<MediaConditionKind<'s>>,
+pub struct MediaCondition<'a> {
+    pub conditions: Vec<'a, MediaConditionKind<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct MediaConditionAfterMediaType<'s> {
-    pub and: Ident<'s>,
-    pub condition: MediaCondition<'s>,
+pub struct MediaConditionAfterMediaType<'a> {
+    pub and: Ident<'a>,
+    pub condition: MediaCondition<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum MediaConditionKind<'s> {
-    MediaInParens(MediaInParens<'s>),
-    And(MediaAnd<'s>),
-    Or(MediaOr<'s>),
-    Not(MediaNot<'s>),
+pub enum MediaConditionKind<'a> {
+    MediaInParens(MediaInParens<'a>),
+    And(MediaAnd<'a>),
+    Or(MediaOr<'a>),
+    Not(MediaNot<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum MediaFeature<'s> {
-    Plain(MediaFeaturePlain<'s>),
-    Boolean(MediaFeatureBoolean<'s>),
-    Range(MediaFeatureRange<'s>),
-    RangeInterval(MediaFeatureRangeInterval<'s>),
+pub enum MediaFeature<'a> {
+    Plain(MediaFeaturePlain<'a>),
+    Boolean(MediaFeatureBoolean<'a>),
+    Range(MediaFeatureRange<'a>),
+    RangeInterval(MediaFeatureRangeInterval<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -1449,7 +1448,7 @@ pub struct MediaFeatureComparison {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 pub enum MediaFeatureComparisonKind {
@@ -1460,183 +1459,183 @@ pub enum MediaFeatureComparisonKind {
     Equal,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum MediaFeatureName<'s> {
-    Ident(InterpolableIdent<'s>),
-    SassVariable(SassVariable<'s>),
+pub enum MediaFeatureName<'a> {
+    Ident(InterpolableIdent<'a>),
+    SassVariable(SassVariable<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct MediaFeatureBoolean<'s> {
-    pub name: MediaFeatureName<'s>,
+pub struct MediaFeatureBoolean<'a> {
+    pub name: MediaFeatureName<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct MediaFeaturePlain<'s> {
-    pub name: MediaFeatureName<'s>,
+pub struct MediaFeaturePlain<'a> {
+    pub name: MediaFeatureName<'a>,
     pub colon_span: Span,
-    pub value: ComponentValue<'s>,
+    pub value: ComponentValue<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct MediaFeatureRange<'s> {
-    pub left: ComponentValue<'s>,
+pub struct MediaFeatureRange<'a> {
+    pub left: ComponentValue<'a>,
     pub comparison: MediaFeatureComparison,
-    pub right: ComponentValue<'s>,
+    pub right: ComponentValue<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct MediaFeatureRangeInterval<'s> {
-    pub left: ComponentValue<'s>,
+pub struct MediaFeatureRangeInterval<'a> {
+    pub left: ComponentValue<'a>,
     pub left_comparison: MediaFeatureComparison,
-    pub name: MediaFeatureName<'s>,
+    pub name: MediaFeatureName<'a>,
     pub right_comparison: MediaFeatureComparison,
-    pub right: ComponentValue<'s>,
+    pub right: ComponentValue<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct MediaInParens<'s> {
-    pub kind: MediaInParensKind<'s>,
+pub struct MediaInParens<'a> {
+    pub kind: MediaInParensKind<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum MediaInParensKind<'s> {
-    MediaCondition(MediaCondition<'s>),
-    MediaFeature(Box<MediaFeature<'s>>),
-    SassInterpolation(SassInterpolatedIdent<'s>),
+pub enum MediaInParensKind<'a> {
+    MediaCondition(MediaCondition<'a>),
+    MediaFeature(Box<'a, MediaFeature<'a>>),
+    SassInterpolation(SassInterpolatedIdent<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct MediaNot<'s> {
-    pub keyword: Ident<'s>,
-    pub media_in_parens: MediaInParens<'s>,
+pub struct MediaNot<'a> {
+    pub keyword: Ident<'a>,
+    pub media_in_parens: MediaInParens<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct MediaOr<'s> {
-    pub keyword: Ident<'s>,
-    pub media_in_parens: MediaInParens<'s>,
+pub struct MediaOr<'a> {
+    pub keyword: Ident<'a>,
+    pub media_in_parens: MediaInParens<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum MediaQuery<'s> {
-    ConditionOnly(MediaCondition<'s>),
-    WithType(MediaQueryWithType<'s>),
-    Function(Function<'s>),
-    LessVariable(LessVariable<'s>),
-    LessNamespaceValue(Box<LessNamespaceValue<'s>>),
+pub enum MediaQuery<'a> {
+    ConditionOnly(MediaCondition<'a>),
+    WithType(MediaQueryWithType<'a>),
+    Function(Function<'a>),
+    LessVariable(LessVariable<'a>),
+    LessNamespaceValue(Box<'a, LessNamespaceValue<'a>>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct MediaQueryList<'s> {
-    pub queries: Vec<MediaQuery<'s>>,
-    pub comma_spans: Vec<Span>,
+pub struct MediaQueryList<'a> {
+    pub queries: Vec<'a, MediaQuery<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct MediaQueryWithType<'s> {
-    pub modifier: Option<Ident<'s>>,
-    pub media_type: InterpolableIdent<'s>,
-    pub condition: Option<MediaConditionAfterMediaType<'s>>,
+pub struct MediaQueryWithType<'a> {
+    pub modifier: Option<Ident<'a>>,
+    pub media_type: InterpolableIdent<'a>,
+    pub condition: Option<MediaConditionAfterMediaType<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct NamespacePrelude<'s> {
-    pub prefix: Option<InterpolableIdent<'s>>,
-    pub uri: NamespacePreludeUri<'s>,
+pub struct NamespacePrelude<'a> {
+    pub prefix: Option<InterpolableIdent<'a>>,
+    pub uri: NamespacePreludeUri<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum NamespacePreludeUri<'s> {
-    Str(InterpolableStr<'s>),
-    Url(Url<'s>),
+pub enum NamespacePreludeUri<'a> {
+    Str(InterpolableStr<'a>),
+    Url(Url<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct NestingSelector<'s> {
-    pub suffix: Option<InterpolableIdent<'s>>,
+pub struct NestingSelector<'a> {
+    pub suffix: Option<InterpolableIdent<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct NsPrefix<'s> {
-    pub kind: Option<NsPrefixKind<'s>>,
+pub struct NsPrefix<'a> {
+    pub kind: Option<NsPrefixKind<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum NsPrefixKind<'s> {
-    Ident(InterpolableIdent<'s>),
+pub enum NsPrefixKind<'a> {
+    Ident(InterpolableIdent<'a>),
     Universal(NsPrefixUniversal),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -1644,268 +1643,268 @@ pub struct NsPrefixUniversal {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct Nth<'s> {
-    pub index: NthIndex<'s>,
-    pub matcher: Option<NthMatcher<'s>>,
+pub struct Nth<'a> {
+    pub index: NthIndex<'a>,
+    pub matcher: Option<NthMatcher<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum NthIndex<'s> {
-    Odd(Ident<'s>),
-    Even(Ident<'s>),
-    Integer(Number<'s>),
+pub enum NthIndex<'a> {
+    Odd(Ident<'a>),
+    Even(Ident<'a>),
+    Integer(Number<'a>),
     AnPlusB(AnPlusB),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct NthMatcher<'s> {
-    pub selector: Option<SelectorList<'s>>,
+pub struct NthMatcher<'a> {
+    pub selector: Option<SelectorList<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct Number<'s> {
+pub struct Number<'a> {
     pub value: f32,
-    pub raw: &'s str,
+    pub raw: &'a str,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct PageSelector<'s> {
-    pub name: Option<InterpolableIdent<'s>>,
-    pub pseudo: Vec<PseudoPage<'s>>,
+pub struct PageSelector<'a> {
+    pub name: Option<InterpolableIdent<'a>>,
+    pub pseudo: Vec<'a, PseudoPage<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct PageSelectorList<'s> {
-    pub selectors: Vec<PageSelector<'s>>,
-    pub comma_spans: Vec<Span>,
+pub struct PageSelectorList<'a> {
+    pub selectors: Vec<'a, PageSelector<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct Percentage<'s> {
-    pub value: Number<'s>,
+pub struct Percentage<'a> {
+    pub value: Number<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct PseudoClassSelector<'s> {
-    pub name: InterpolableIdent<'s>,
-    pub arg: Option<PseudoClassSelectorArg<'s>>,
+pub struct PseudoClassSelector<'a> {
+    pub name: InterpolableIdent<'a>,
+    pub arg: Option<PseudoClassSelectorArg<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct PseudoClassSelectorArg<'s> {
-    pub kind: PseudoClassSelectorArgKind<'s>,
+pub struct PseudoClassSelectorArg<'a> {
+    pub kind: PseudoClassSelectorArgKind<'a>,
     pub l_paren: Span,
     pub r_paren: Span,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum PseudoClassSelectorArgKind<'s> {
-    CompoundSelector(CompoundSelector<'s>),
-    CompoundSelectorList(CompoundSelectorList<'s>),
-    Ident(InterpolableIdent<'s>),
-    LanguageRangeList(LanguageRangeList<'s>),
-    Nth(Nth<'s>),
-    Number(Number<'s>),
-    RelativeSelectorList(RelativeSelectorList<'s>),
-    SelectorList(SelectorList<'s>),
-    LessExtendList(LessExtendList<'s>),
-    TokenSeq(TokenSeq<'s>),
+pub enum PseudoClassSelectorArgKind<'a> {
+    CompoundSelector(CompoundSelector<'a>),
+    CompoundSelectorList(CompoundSelectorList<'a>),
+    Ident(InterpolableIdent<'a>),
+    LanguageRangeList(LanguageRangeList<'a>),
+    Nth(Nth<'a>),
+    Number(Number<'a>),
+    RelativeSelectorList(RelativeSelectorList<'a>),
+    SelectorList(SelectorList<'a>),
+    LessExtendList(LessExtendList<'a>),
+    TokenSeq(TokenSeq<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct PseudoElementSelector<'s> {
-    pub name: InterpolableIdent<'s>,
-    pub arg: Option<PseudoElementSelectorArg<'s>>,
+pub struct PseudoElementSelector<'a> {
+    pub name: InterpolableIdent<'a>,
+    pub arg: Option<PseudoElementSelectorArg<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct PseudoElementSelectorArg<'s> {
-    pub kind: PseudoElementSelectorArgKind<'s>,
+pub struct PseudoElementSelectorArg<'a> {
+    pub kind: PseudoElementSelectorArgKind<'a>,
     pub l_paren: Span,
     pub r_paren: Span,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum PseudoElementSelectorArgKind<'s> {
-    CompoundSelector(CompoundSelector<'s>),
-    Ident(InterpolableIdent<'s>),
-    TokenSeq(TokenSeq<'s>),
+pub enum PseudoElementSelectorArgKind<'a> {
+    CompoundSelector(CompoundSelector<'a>),
+    Ident(InterpolableIdent<'a>),
+    TokenSeq(TokenSeq<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct PseudoPage<'s> {
-    pub name: InterpolableIdent<'s>,
+pub struct PseudoPage<'a> {
+    pub name: InterpolableIdent<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct QualifiedRule<'s> {
-    pub selector: SelectorList<'s>,
-    pub block: SimpleBlock<'s>,
+pub struct QualifiedRule<'a> {
+    pub selector: SelectorList<'a>,
+    pub block: SimpleBlock<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct QueryInParens<'s> {
-    pub kind: QueryInParensKind<'s>,
+pub struct QueryInParens<'a> {
+    pub kind: QueryInParensKind<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum QueryInParensKind<'s> {
-    ContainerCondition(ContainerCondition<'s>),
-    SizeFeature(Box<MediaFeature<'s>>),
-    StyleQuery(StyleQuery<'s>),
-    ScrollState(Box<MediaFeature<'s>>),
+pub enum QueryInParensKind<'a> {
+    ContainerCondition(ContainerCondition<'a>),
+    SizeFeature(Box<'a, MediaFeature<'a>>),
+    StyleQuery(StyleQuery<'a>),
+    ScrollState(Box<'a, MediaFeature<'a>>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct Ratio<'s> {
-    pub numerator: Number<'s>,
+pub struct Ratio<'a> {
+    pub numerator: Number<'a>,
     pub solidus_span: Span,
-    pub denominator: Number<'s>,
+    pub denominator: Number<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct RelativeSelector<'s> {
+pub struct RelativeSelector<'a> {
     pub combinator: Option<Combinator>,
-    pub complex_selector: ComplexSelector<'s>,
+    pub complex_selector: ComplexSelector<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct RelativeSelectorList<'s> {
-    pub selectors: Vec<RelativeSelector<'s>>,
-    pub comma_spans: Vec<Span>,
+pub struct RelativeSelectorList<'a> {
+    pub selectors: Vec<'a, RelativeSelector<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassArbitraryArgument<'s> {
-    pub value: Box<ComponentValue<'s>>,
+pub struct SassArbitraryArgument<'a> {
+    pub value: Box<'a, ComponentValue<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassArbitraryParameter<'s> {
-    pub name: SassVariable<'s>,
+pub struct SassArbitraryParameter<'a> {
+    pub name: SassVariable<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassAtRoot<'s> {
-    pub kind: SassAtRootKind<'s>,
+pub struct SassAtRoot<'a> {
+    pub kind: SassAtRootKind<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum SassAtRootKind<'s> {
-    Selector(SelectorList<'s>),
-    Query(SassAtRootQuery<'s>),
+pub enum SassAtRootKind<'a> {
+    Selector(SelectorList<'a>),
+    Query(SassAtRootQuery<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassAtRootQuery<'s> {
+pub struct SassAtRootQuery<'a> {
     pub modifier: SassAtRootQueryModifier,
     pub colon_span: Span,
     /// space-separated rule names
-    pub rules: Vec<SassAtRootQueryRule<'s>>,
+    pub rules: Vec<'a, SassAtRootQueryRule<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -1914,7 +1913,7 @@ pub struct SassAtRootQueryModifier {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 pub enum SassAtRootQueryModifierKind {
@@ -1922,28 +1921,28 @@ pub enum SassAtRootQueryModifierKind {
     Without,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum SassAtRootQueryRule<'s> {
-    Ident(InterpolableIdent<'s>),
-    Str(InterpolableStr<'s>),
+pub enum SassAtRootQueryRule<'a> {
+    Ident(InterpolableIdent<'a>),
+    Str(InterpolableStr<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassBinaryExpression<'s> {
-    pub left: Box<ComponentValue<'s>>,
+pub struct SassBinaryExpression<'a> {
+    pub left: Box<'a, ComponentValue<'a>>,
     pub op: SassBinaryOperator,
-    pub right: Box<ComponentValue<'s>>,
+    pub right: Box<'a, ComponentValue<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -1952,7 +1951,7 @@ pub struct SassBinaryOperator {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 pub enum SassBinaryOperatorKind {
@@ -1971,71 +1970,71 @@ pub enum SassBinaryOperatorKind {
     Or,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassConditionalClause<'s> {
-    pub condition: ComponentValue<'s>,
-    pub block: SimpleBlock<'s>,
+pub struct SassConditionalClause<'a> {
+    pub condition: ComponentValue<'a>,
+    pub block: SimpleBlock<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassContent<'s> {
-    pub args: Vec<ComponentValue<'s>>,
-    pub comma_spans: Vec<Span>,
+pub struct SassContent<'a> {
+    pub args: Vec<'a, ComponentValue<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassEach<'s> {
-    pub bindings: Vec<SassVariable<'s>>,
-    pub comma_spans: Vec<Span>,
+pub struct SassEach<'a> {
+    pub bindings: Vec<'a, SassVariable<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub in_span: Span,
-    pub expr: ComponentValue<'s>,
+    pub expr: ComponentValue<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassExtend<'s> {
-    pub selectors: CompoundSelectorList<'s>,
-    pub optional: Option<SassFlag<'s>>,
+pub struct SassExtend<'a> {
+    pub selectors: CompoundSelectorList<'a>,
+    pub optional: Option<SassFlag<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassFlag<'s> {
-    pub keyword: Ident<'s>,
+pub struct SassFlag<'a> {
+    pub keyword: Ident<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassFor<'s> {
-    pub binding: SassVariable<'s>,
+pub struct SassFor<'a> {
+    pub binding: SassVariable<'a>,
     pub from_span: Span,
-    pub start: ComponentValue<'s>,
-    pub end: ComponentValue<'s>,
+    pub start: ComponentValue<'a>,
+    pub end: ComponentValue<'a>,
     pub boundary: SassForBoundary,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -2044,7 +2043,7 @@ pub struct SassForBoundary {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 pub enum SassForBoundaryKind {
@@ -2052,50 +2051,50 @@ pub enum SassForBoundaryKind {
     Exclusive,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassForward<'s> {
-    pub path: InterpolableStr<'s>,
-    pub prefix: Option<SassForwardPrefix<'s>>,
-    pub visibility: Option<SassForwardVisibility<'s>>,
-    pub config: Option<SassModuleConfig<'s>>,
+pub struct SassForward<'a> {
+    pub path: InterpolableStr<'a>,
+    pub prefix: Option<SassForwardPrefix<'a>>,
+    pub visibility: Option<SassForwardVisibility<'a>>,
+    pub config: Option<SassModuleConfig<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum SassForwardMember<'s> {
-    Ident(Ident<'s>),
-    Variable(SassVariable<'s>),
+pub enum SassForwardMember<'a> {
+    Ident(Ident<'a>),
+    Variable(SassVariable<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassForwardPrefix<'s> {
+pub struct SassForwardPrefix<'a> {
     pub as_span: Span,
-    pub name: Ident<'s>,
+    pub name: Ident<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassForwardVisibility<'s> {
+pub struct SassForwardVisibility<'a> {
     pub modifier: SassForwardVisibilityModifier,
-    pub members: Vec<SassForwardMember<'s>>,
-    pub comma_spans: Vec<Span>,
+    pub members: Vec<'a, SassForwardMember<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -2104,7 +2103,7 @@ pub struct SassForwardVisibilityModifier {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 pub enum SassForwardVisibilityModifierKind {
@@ -2112,291 +2111,291 @@ pub enum SassForwardVisibilityModifierKind {
     Show,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassFunction<'s> {
-    pub name: Ident<'s>,
-    pub parameters: SassParameters<'s>,
+pub struct SassFunction<'a> {
+    pub name: Ident<'a>,
+    pub parameters: SassParameters<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassIfAtRule<'s> {
-    pub if_clause: SassConditionalClause<'s>,
-    pub else_if_clauses: Vec<SassConditionalClause<'s>>,
-    pub else_clause: Option<SimpleBlock<'s>>,
-    pub else_spans: Vec<Span>,
+pub struct SassIfAtRule<'a> {
+    pub if_clause: SassConditionalClause<'a>,
+    pub else_if_clauses: Vec<'a, SassConditionalClause<'a>>,
+    pub else_clause: Option<SimpleBlock<'a>>,
+    pub else_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassImportPrelude<'s> {
-    pub paths: Vec<Str<'s>>,
-    pub comma_spans: Vec<Span>,
+pub struct SassImportPrelude<'a> {
+    pub paths: Vec<'a, Str<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassInclude<'s> {
-    pub name: FunctionName<'s>,
-    pub arguments: Option<SassIncludeArgs<'s>>,
-    pub content_block_params: Option<SassIncludeContentBlockParams<'s>>,
+pub struct SassInclude<'a> {
+    pub name: FunctionName<'a>,
+    pub arguments: Option<SassIncludeArgs<'a>>,
+    pub content_block_params: Option<SassIncludeContentBlockParams<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassIncludeArgs<'s> {
-    pub args: Vec<ComponentValue<'s>>,
-    pub comma_spans: Vec<Span>,
+pub struct SassIncludeArgs<'a> {
+    pub args: Vec<'a, ComponentValue<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassIncludeContentBlockParams<'s> {
+pub struct SassIncludeContentBlockParams<'a> {
     pub using_span: Span,
-    pub params: SassParameters<'s>,
+    pub params: SassParameters<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassInterpolatedIdent<'s> {
-    pub elements: Vec<SassInterpolatedIdentElement<'s>>,
+pub struct SassInterpolatedIdent<'a> {
+    pub elements: Vec<'a, SassInterpolatedIdentElement<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum SassInterpolatedIdentElement<'s> {
-    Expression(ComponentValue<'s>),
-    Static(InterpolableIdentStaticPart<'s>),
+pub enum SassInterpolatedIdentElement<'a> {
+    Expression(ComponentValue<'a>),
+    Static(InterpolableIdentStaticPart<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassInterpolatedStr<'s> {
-    pub elements: Vec<SassInterpolatedStrElement<'s>>,
+pub struct SassInterpolatedStr<'a> {
+    pub elements: Vec<'a, SassInterpolatedStrElement<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum SassInterpolatedStrElement<'s> {
-    Expression(ComponentValue<'s>),
-    Static(InterpolableStrStaticPart<'s>),
+pub enum SassInterpolatedStrElement<'a> {
+    Expression(ComponentValue<'a>),
+    Static(InterpolableStrStaticPart<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassInterpolatedUrl<'s> {
-    pub elements: Vec<SassInterpolatedUrlElement<'s>>,
+pub struct SassInterpolatedUrl<'a> {
+    pub elements: Vec<'a, SassInterpolatedUrlElement<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum SassInterpolatedUrlElement<'s> {
-    Expression(ComponentValue<'s>),
-    Static(InterpolableUrlStaticPart<'s>),
+pub enum SassInterpolatedUrlElement<'a> {
+    Expression(ComponentValue<'a>),
+    Static(InterpolableUrlStaticPart<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassKeywordArgument<'s> {
-    pub name: SassVariable<'s>,
+pub struct SassKeywordArgument<'a> {
+    pub name: SassVariable<'a>,
     pub colon_span: Span,
-    pub value: Box<ComponentValue<'s>>,
+    pub value: Box<'a, ComponentValue<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassList<'s> {
-    pub elements: Vec<ComponentValue<'s>>,
-    pub comma_spans: Option<Vec<Span>>,
+pub struct SassList<'a> {
+    pub elements: Vec<'a, ComponentValue<'a>>,
+    pub comma_spans: Option<Vec<'a, Span>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassMap<'s> {
-    pub items: Vec<SassMapItem<'s>>,
-    pub comma_spans: Vec<Span>,
+pub struct SassMap<'a> {
+    pub items: Vec<'a, SassMapItem<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassMapItem<'s> {
-    pub key: ComponentValue<'s>,
+pub struct SassMapItem<'a> {
+    pub key: ComponentValue<'a>,
     pub colon_span: Span,
-    pub value: ComponentValue<'s>,
+    pub value: ComponentValue<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassMixin<'s> {
-    pub name: Ident<'s>,
-    pub parameters: Option<SassParameters<'s>>,
+pub struct SassMixin<'a> {
+    pub name: Ident<'a>,
+    pub parameters: Option<SassParameters<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassModuleConfig<'s> {
+pub struct SassModuleConfig<'a> {
     pub with_span: Span,
     pub lparen_span: Span,
-    pub items: Vec<SassModuleConfigItem<'s>>,
-    pub comma_spans: Vec<Span>,
+    pub items: Vec<'a, SassModuleConfigItem<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassModuleConfigItem<'s> {
-    pub variable: SassVariable<'s>,
+pub struct SassModuleConfigItem<'a> {
+    pub variable: SassVariable<'a>,
     pub colon_span: Span,
-    pub value: ComponentValue<'s>,
-    pub flags: Vec<SassFlag<'s>>,
+    pub value: ComponentValue<'a>,
+    pub flags: Vec<'a, SassFlag<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum SassModuleMemberName<'s> {
-    Ident(Ident<'s>),
-    Variable(SassVariable<'s>),
+pub enum SassModuleMemberName<'a> {
+    Ident(Ident<'a>),
+    Variable(SassVariable<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassNestingDeclaration<'s> {
-    pub block: SimpleBlock<'s>,
+pub struct SassNestingDeclaration<'a> {
+    pub block: SimpleBlock<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassParameter<'s> {
-    pub name: SassVariable<'s>,
-    pub default_value: Option<SassParameterDefaultValue<'s>>,
+pub struct SassParameter<'a> {
+    pub name: SassVariable<'a>,
+    pub default_value: Option<SassParameterDefaultValue<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassParameterDefaultValue<'s> {
+pub struct SassParameterDefaultValue<'a> {
     pub colon_span: Span,
-    pub value: ComponentValue<'s>,
+    pub value: ComponentValue<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassParameters<'s> {
-    pub params: Vec<SassParameter<'s>>,
-    pub arbitrary_param: Option<SassArbitraryParameter<'s>>,
-    pub comma_spans: Vec<Span>,
+pub struct SassParameters<'a> {
+    pub params: Vec<'a, SassParameter<'a>>,
+    pub arbitrary_param: Option<SassArbitraryParameter<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassParenthesizedExpression<'s> {
-    pub expr: Box<ComponentValue<'s>>,
+pub struct SassParenthesizedExpression<'a> {
+    pub expr: Box<'a, ComponentValue<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassPlaceholderSelector<'s> {
-    pub name: InterpolableIdent<'s>,
+pub struct SassPlaceholderSelector<'a> {
+    pub name: InterpolableIdent<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassQualifiedName<'s> {
-    pub module: Ident<'s>,
-    pub member: SassModuleMemberName<'s>,
+pub struct SassQualifiedName<'a> {
+    pub module: Ident<'a>,
+    pub member: SassModuleMemberName<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassUnaryExpression<'s> {
+pub struct SassUnaryExpression<'a> {
     pub op: SassUnaryOperator,
-    pub expr: Box<ComponentValue<'s>>,
+    pub expr: Box<'a, ComponentValue<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -2405,7 +2404,7 @@ pub struct SassUnaryOperator {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 pub enum SassUnaryOperatorKind {
@@ -2414,7 +2413,7 @@ pub enum SassUnaryOperatorKind {
     Not,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
@@ -2422,468 +2421,468 @@ pub struct SassUnnamedNamespace {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassUse<'s> {
-    pub path: InterpolableStr<'s>,
-    pub namespace: Option<SassUseNamespace<'s>>,
-    pub config: Option<SassModuleConfig<'s>>,
+pub struct SassUse<'a> {
+    pub path: InterpolableStr<'a>,
+    pub namespace: Option<SassUseNamespace<'a>>,
+    pub config: Option<SassModuleConfig<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassUseNamespace<'s> {
+pub struct SassUseNamespace<'a> {
     pub as_span: Span,
-    pub kind: SassUseNamespaceKind<'s>,
+    pub kind: SassUseNamespaceKind<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum SassUseNamespaceKind<'s> {
-    Named(Ident<'s>),
+pub enum SassUseNamespaceKind<'a> {
+    Named(Ident<'a>),
     Unnamed(SassUnnamedNamespace),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassVariable<'s> {
-    pub name: Ident<'s>,
+pub struct SassVariable<'a> {
+    pub name: Ident<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SassVariableDeclaration<'s> {
-    pub namespace: Option<Ident<'s>>,
-    pub name: SassVariable<'s>,
+pub struct SassVariableDeclaration<'a> {
+    pub namespace: Option<Ident<'a>>,
+    pub name: SassVariable<'a>,
     pub colon_span: Span,
-    pub value: ComponentValue<'s>,
-    pub flags: Vec<SassFlag<'s>>,
+    pub value: ComponentValue<'a>,
+    pub flags: Vec<'a, SassFlag<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct ScopeEnd<'s> {
+pub struct ScopeEnd<'a> {
     pub to_span: Span,
     pub lparen_span: Span,
-    pub selector: SelectorList<'s>,
+    pub selector: SelectorList<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum ScopePrelude<'s> {
-    StartOnly(ScopeStart<'s>),
-    EndOnly(ScopeEnd<'s>),
-    Both(ScopeStartWithEnd<'s>),
+pub enum ScopePrelude<'a> {
+    StartOnly(ScopeStart<'a>),
+    EndOnly(ScopeEnd<'a>),
+    Both(ScopeStartWithEnd<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct ScopeStart<'s> {
-    pub selector: SelectorList<'s>,
+pub struct ScopeStart<'a> {
+    pub selector: SelectorList<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct ScopeStartWithEnd<'s> {
-    pub start: ScopeStart<'s>,
-    pub end: ScopeEnd<'s>,
+pub struct ScopeStartWithEnd<'a> {
+    pub start: ScopeStart<'a>,
+    pub end: ScopeEnd<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SelectorList<'s> {
-    pub selectors: Vec<ComplexSelector<'s>>,
-    pub comma_spans: Vec<Span>,
+pub struct SelectorList<'a> {
+    pub selectors: Vec<'a, ComplexSelector<'a>>,
+    pub comma_spans: Vec<'a, Span>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SimpleBlock<'s> {
-    pub statements: Vec<Statement<'s>>,
+pub struct SimpleBlock<'a> {
+    pub statements: Vec<'a, Statement<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum SimpleSelector<'s> {
-    Class(ClassSelector<'s>),
-    Id(IdSelector<'s>),
-    Type(TypeSelector<'s>),
-    Attribute(AttributeSelector<'s>),
-    PseudoClass(PseudoClassSelector<'s>),
-    PseudoElement(PseudoElementSelector<'s>),
-    Nesting(NestingSelector<'s>),
-    SassPlaceholder(SassPlaceholderSelector<'s>),
+pub enum SimpleSelector<'a> {
+    Class(ClassSelector<'a>),
+    Id(IdSelector<'a>),
+    Type(TypeSelector<'a>),
+    Attribute(AttributeSelector<'a>),
+    PseudoClass(PseudoClassSelector<'a>),
+    PseudoElement(PseudoElementSelector<'a>),
+    Nesting(NestingSelector<'a>),
+    SassPlaceholder(SassPlaceholderSelector<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum Statement<'s> {
-    AtRule(AtRule<'s>),
-    Declaration(Declaration<'s>),
-    KeyframeBlock(KeyframeBlock<'s>),
-    LessConditionalQualifiedRule(LessConditionalQualifiedRule<'s>),
-    LessExtendRule(LessExtendRule<'s>),
-    LessFunctionCall(Function<'s>),
-    LessMixinCall(LessMixinCall<'s>),
-    LessMixinDefinition(LessMixinDefinition<'s>),
-    LessVariableCall(LessVariableCall<'s>),
-    LessVariableDeclaration(LessVariableDeclaration<'s>),
-    Placeholder(Placeholder<'s>),
-    QualifiedRule(QualifiedRule<'s>),
-    SassIfAtRule(SassIfAtRule<'s>),
-    SassVariableDeclaration(SassVariableDeclaration<'s>),
-    UnknownSassAtRule(Box<UnknownSassAtRule<'s>>),
+pub enum Statement<'a> {
+    AtRule(AtRule<'a>),
+    Declaration(Declaration<'a>),
+    KeyframeBlock(KeyframeBlock<'a>),
+    LessConditionalQualifiedRule(LessConditionalQualifiedRule<'a>),
+    LessExtendRule(LessExtendRule<'a>),
+    LessFunctionCall(Function<'a>),
+    LessMixinCall(LessMixinCall<'a>),
+    LessMixinDefinition(LessMixinDefinition<'a>),
+    LessVariableCall(LessVariableCall<'a>),
+    LessVariableDeclaration(LessVariableDeclaration<'a>),
+    Placeholder(Placeholder<'a>),
+    QualifiedRule(QualifiedRule<'a>),
+    SassIfAtRule(SassIfAtRule<'a>),
+    SassVariableDeclaration(SassVariableDeclaration<'a>),
+    UnknownSassAtRule(Box<'a, UnknownSassAtRule<'a>>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct Str<'s> {
-    pub value: Cow<'s, str>,
-    pub raw: &'s str,
+pub struct Str<'a> {
+    pub value: &'a str,
+    pub raw: &'a str,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct StyleCondition<'s> {
-    pub conditions: Vec<StyleConditionKind<'s>>,
+pub struct StyleCondition<'a> {
+    pub conditions: Vec<'a, StyleConditionKind<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum StyleConditionKind<'s> {
-    StyleInParens(StyleInParens<'s>),
-    And(StyleConditionAnd<'s>),
-    Or(StyleConditionOr<'s>),
-    Not(StyleConditionNot<'s>),
+pub enum StyleConditionKind<'a> {
+    StyleInParens(StyleInParens<'a>),
+    And(StyleConditionAnd<'a>),
+    Or(StyleConditionOr<'a>),
+    Not(StyleConditionNot<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct StyleConditionAnd<'s> {
-    pub keyword: Ident<'s>,
-    pub style_in_parens: StyleInParens<'s>,
+pub struct StyleConditionAnd<'a> {
+    pub keyword: Ident<'a>,
+    pub style_in_parens: StyleInParens<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct StyleConditionNot<'s> {
-    pub keyword: Ident<'s>,
-    pub style_in_parens: StyleInParens<'s>,
+pub struct StyleConditionNot<'a> {
+    pub keyword: Ident<'a>,
+    pub style_in_parens: StyleInParens<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct StyleConditionOr<'s> {
-    pub keyword: Ident<'s>,
-    pub style_in_parens: StyleInParens<'s>,
+pub struct StyleConditionOr<'a> {
+    pub keyword: Ident<'a>,
+    pub style_in_parens: StyleInParens<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct StyleInParens<'s> {
-    pub kind: StyleInParensKind<'s>,
+pub struct StyleInParens<'a> {
+    pub kind: StyleInParensKind<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum StyleInParensKind<'s> {
-    Condition(StyleCondition<'s>),
-    Feature(Declaration<'s>),
+pub enum StyleInParensKind<'a> {
+    Condition(StyleCondition<'a>),
+    Feature(Declaration<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum StyleQuery<'s> {
-    Condition(StyleCondition<'s>),
-    Feature(Declaration<'s>),
+pub enum StyleQuery<'a> {
+    Condition(StyleCondition<'a>),
+    Feature(Declaration<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct Stylesheet<'s> {
-    pub statements: Vec<Statement<'s>>,
+pub struct Stylesheet<'a> {
+    pub statements: Vec<'a, Statement<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SupportsAnd<'s> {
-    pub keyword: Ident<'s>,
-    pub condition: SupportsInParens<'s>,
+pub struct SupportsAnd<'a> {
+    pub keyword: Ident<'a>,
+    pub condition: SupportsInParens<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SupportsCondition<'s> {
-    pub conditions: Vec<SupportsConditionKind<'s>>,
+pub struct SupportsCondition<'a> {
+    pub conditions: Vec<'a, SupportsConditionKind<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum SupportsConditionKind<'s> {
-    Not(SupportsNot<'s>),
-    And(SupportsAnd<'s>),
-    Or(SupportsOr<'s>),
-    SupportsInParens(SupportsInParens<'s>),
+pub enum SupportsConditionKind<'a> {
+    Not(SupportsNot<'a>),
+    And(SupportsAnd<'a>),
+    Or(SupportsOr<'a>),
+    SupportsInParens(SupportsInParens<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SupportsDecl<'s> {
-    pub decl: Declaration<'s>,
+pub struct SupportsDecl<'a> {
+    pub decl: Declaration<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SupportsInParens<'s> {
-    pub kind: SupportsInParensKind<'s>,
+pub struct SupportsInParens<'a> {
+    pub kind: SupportsInParensKind<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum SupportsInParensKind<'s> {
-    SupportsCondition(SupportsCondition<'s>),
-    Feature(Box<SupportsDecl<'s>>),
-    Selector(SelectorList<'s>),
-    Function(Function<'s>),
+pub enum SupportsInParensKind<'a> {
+    SupportsCondition(SupportsCondition<'a>),
+    Feature(Box<'a, SupportsDecl<'a>>),
+    Selector(SelectorList<'a>),
+    Function(Function<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SupportsNot<'s> {
-    pub keyword: Ident<'s>,
-    pub condition: SupportsInParens<'s>,
+pub struct SupportsNot<'a> {
+    pub keyword: Ident<'a>,
+    pub condition: SupportsInParens<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct SupportsOr<'s> {
-    pub keyword: Ident<'s>,
-    pub condition: SupportsInParens<'s>,
+pub struct SupportsOr<'a> {
+    pub keyword: Ident<'a>,
+    pub condition: SupportsInParens<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct TagNameSelector<'s> {
-    pub name: WqName<'s>,
+pub struct TagNameSelector<'a> {
+    pub name: WqName<'a>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct TokenSeq<'s> {
-    pub tokens: Vec<TokenWithSpan<'s>>,
+pub struct TokenSeq<'a> {
+    pub tokens: Vec<'a, TokenWithSpan<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum TypeSelector<'s> {
-    TagName(TagNameSelector<'s>),
-    Universal(UniversalSelector<'s>),
+pub enum TypeSelector<'a> {
+    TagName(TagNameSelector<'a>),
+    Universal(UniversalSelector<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct UnicodeRange<'s> {
+pub struct UnicodeRange<'a> {
     pub prefix: char,
     pub start: u32,
-    pub start_raw: &'s str,
+    pub start_raw: &'a str,
     pub end: u32,
-    pub end_raw: Option<&'s str>,
+    pub end_raw: Option<&'a str>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct UniversalSelector<'s> {
-    pub prefix: Option<NsPrefix<'s>>,
+pub struct UniversalSelector<'a> {
+    pub prefix: Option<NsPrefix<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum UnknownAtRulePrelude<'s> {
-    ComponentValue(ComponentValue<'s>),
-    TokenSeq(TokenSeq<'s>),
+pub enum UnknownAtRulePrelude<'a> {
+    ComponentValue(ComponentValue<'a>),
+    TokenSeq(TokenSeq<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct UnknownSassAtRule<'s> {
-    pub name: InterpolableIdent<'s>,
-    pub prelude: Option<UnknownAtRulePrelude<'s>>,
-    pub block: Option<SimpleBlock<'s>>,
+pub struct UnknownSassAtRule<'a> {
+    pub name: InterpolableIdent<'a>,
+    pub prelude: Option<UnknownAtRulePrelude<'a>>,
+    pub block: Option<SimpleBlock<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct UnquotedFontFamilyName<'s> {
-    pub idents: Vec<InterpolableIdent<'s>>,
+pub struct UnquotedFontFamilyName<'a> {
+    pub idents: Vec<'a, InterpolableIdent<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct Url<'s> {
-    pub name: Ident<'s>,
-    pub value: Option<UrlValue<'s>>,
-    pub modifiers: Vec<UrlModifier<'s>>,
+pub struct Url<'a> {
+    pub name: Ident<'a>,
+    pub value: Option<UrlValue<'a>>,
+    pub modifiers: Vec<'a, UrlModifier<'a>>,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum UrlModifier<'s> {
-    Ident(InterpolableIdent<'s>),
-    Function(Function<'s>),
+pub enum UrlModifier<'a> {
+    Ident(InterpolableIdent<'a>),
+    Function(Function<'a>),
 }
 
 /// `)` is excluded
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct UrlRaw<'s> {
-    pub value: Cow<'s, str>,
-    pub raw: &'s str,
+pub struct UrlRaw<'a> {
+    pub value: &'a str,
+    pub raw: &'a str,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
 #[cfg_attr(feature = "variant_helpers", derive(EnumAsIs))]
-pub enum UrlValue<'s> {
-    Raw(UrlRaw<'s>),
-    SassInterpolated(SassInterpolatedUrl<'s>),
-    Str(InterpolableStr<'s>),
-    LessEscapedStr(LessEscapedStr<'s>),
+pub enum UrlValue<'a> {
+    Raw(UrlRaw<'a>),
+    SassInterpolated(SassInterpolatedUrl<'a>),
+    Str(InterpolableStr<'a>),
+    LessEscapedStr(LessEscapedStr<'a>),
 }
 
-#[derive(Clone, Debug, Spanned, PartialEq)]
+#[derive(Debug, Spanned)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(feature = "span_ignored_eq", derive(SpanIgnoredEq))]
-pub struct WqName<'s> {
-    pub name: InterpolableIdent<'s>,
-    pub prefix: Option<NsPrefix<'s>>,
+pub struct WqName<'a> {
+    pub name: InterpolableIdent<'a>,
+    pub prefix: Option<NsPrefix<'a>>,
     pub span: Span,
 }

--- a/crates/oxc_css_parser/src/lib.rs
+++ b/crates/oxc_css_parser/src/lib.rs
@@ -8,9 +8,10 @@
 //! then call the [`parse`](Parser::parse) method:
 //!
 //! ```rust
-//! use oxc_css_parser::{ast::Stylesheet, Parser, Syntax};
+//! use oxc_css_parser::{Allocator, Parser, Syntax, ast::Stylesheet};
 //!
-//! let mut parser = Parser::new("a {}", Syntax::Css); // syntax can also be `Scss`, `Sass` or `Less`
+//! let allocator = Allocator::default();
+//! let mut parser = Parser::new(&allocator, "a {}", Syntax::Css); // syntax can also be `Scss`, `Sass` or `Less`
 //! let result = parser.parse::<Stylesheet>();
 //! match result {
 //!     Ok(ast) => {
@@ -33,19 +34,22 @@
 //! For example, to collect comments:
 //!
 //! ```rust
-//! use oxc_css_parser::ParserBuilder;
+//! use oxc_css_parser::{Allocator, ParserBuilder, ast::Stylesheet};
 //!
-//! let mut comments = vec![];
-//! let builder = ParserBuilder::new("/* comment */ a {}").comments(&mut comments);
+//! let allocator = Allocator::default();
+//! let builder = ParserBuilder::new(&allocator, "/* comment */ a {}").comments();
 //! let mut parser = builder.build();
+//! parser.parse::<Stylesheet>().unwrap();
+//! let comments = parser.comments();
 //! ```
 //!
 //! By default, syntax is CSS when using parser builder. You can customize it:
 //!
 //! ```rust
-//! use oxc_css_parser::{ParserBuilder, Syntax};
+//! use oxc_css_parser::{Allocator, ParserBuilder, Syntax};
 //!
-//! let builder = ParserBuilder::new("a {}").syntax(Syntax::Scss);
+//! let allocator = Allocator::default();
+//! let builder = ParserBuilder::new(&allocator, "a {}").syntax(Syntax::Scss);
 //! ```
 //!
 //! ### Parser Options
@@ -58,13 +62,14 @@
 //! parser will fallback to parse as tokens if there're syntax errors.
 //!
 //! ```rust
-//! use oxc_css_parser::{ast::*, ParserBuilder, ParserOptions};
+//! use oxc_css_parser::{Allocator, ParserBuilder, ParserOptions, ast::*};
 //!
+//! let allocator = Allocator::default();
 //! let options = ParserOptions {
 //!     try_parsing_value_in_custom_property: true,
 //!     ..Default::default()
 //! };
-//! let builder = ParserBuilder::new("--foo: calc(var(--bar) + 1px)").options(options);
+//! let builder = ParserBuilder::new(&allocator, "--foo: calc(var(--bar) + 1px)").options(options);
 //! let mut parser = builder.build();
 //!
 //! let declaration = parser.parse::<Declaration>().unwrap();
@@ -80,13 +85,14 @@
 //! so they won't prevent parsing the rest of code.
 //!
 //! ```rust
-//! use oxc_css_parser::{ast::*, ParserBuilder, ParserOptions, Syntax};
+//! use oxc_css_parser::{Allocator, ParserBuilder, ParserOptions, Syntax, ast::*};
 //!
+//! let allocator = Allocator::default();
 //! let options = ParserOptions {
 //!     tolerate_semicolon_in_sass: true,
 //!     ..Default::default()
 //! };
-//! let builder = ParserBuilder::new("
+//! let builder = ParserBuilder::new(&allocator, "
 //! button
 //!   width: 12px;
 //!   height: 12px;
@@ -110,15 +116,16 @@
 //! used with [`Syntax::Scss`] (backtick is Less's inline-JS delimiter).
 //!
 //! ```rust
-//! use oxc_css_parser::{ast::*, TemplatePlaceholder, ParserBuilder, ParserOptions, Syntax};
+//! use oxc_css_parser::{Allocator, ParserBuilder, ParserOptions, Syntax, TemplatePlaceholder, ast::*};
 //!
+//! let allocator = Allocator::default();
 //! let options = ParserOptions {
 //!     template_placeholder: Some(TemplatePlaceholder {
 //!         prefix: "PLACEHOLDER-",
 //!     }),
 //!     ..Default::default()
 //! };
-//! let builder = ParserBuilder::new("a { width: `PLACEHOLDER-0`; }")
+//! let builder = ParserBuilder::new(&allocator, "a { width: `PLACEHOLDER-0`; }")
 //!     .syntax(Syntax::Scss)
 //!     .options(options);
 //! let mut parser = builder.build();
@@ -133,18 +140,20 @@
 //! All you need to do is to update the generics of the [`parse`](Parser::parse) method.
 //!
 //! ```rust
-//! use oxc_css_parser::{ast::QualifiedRule, Parser, Syntax};
+//! use oxc_css_parser::{Allocator, Parser, Syntax, ast::QualifiedRule};
 //!
-//! let mut parser = Parser::new("a {}", Syntax::Css);
+//! let allocator = Allocator::default();
+//! let mut parser = Parser::new(&allocator, "a {}", Syntax::Css);
 //! parser.parse::<QualifiedRule>();
 //! ```
 //!
 //! and
 //!
 //! ```rust
-//! use oxc_css_parser::{ast::Declaration, Parser, Syntax};
+//! use oxc_css_parser::{Allocator, Parser, Syntax, ast::Declaration};
 //!
-//! let mut parser = Parser::new("color: green", Syntax::Css);
+//! let allocator = Allocator::default();
+//! let mut parser = Parser::new(&allocator, "color: green", Syntax::Css);
 //! parser.parse::<Declaration>();
 //! ```
 //!
@@ -157,9 +166,10 @@
 //! To retrieve those errors, use [`recoverable_errors`](Parser::recoverable_errors).
 //!
 //! ```rust
-//! use oxc_css_parser::{ast::Stylesheet, Parser, Syntax};
+//! use oxc_css_parser::{Allocator, Parser, Syntax, ast::Stylesheet};
 //!
-//! let mut parser = Parser::new("@keyframes kf { invalid {} }", Syntax::Css);
+//! let allocator = Allocator::default();
+//! let mut parser = Parser::new(&allocator, "@keyframes kf { invalid {} }", Syntax::Css);
 //! let result = parser.parse::<Stylesheet>();
 //! assert!(result.is_ok());
 //! println!("{:?}", parser.recoverable_errors());
@@ -179,6 +189,7 @@
 //! Note that oxc-css-parser only supports serialization. Deserialization isn't supported.
 
 pub use config::{ParserOptions, Syntax, TemplatePlaceholder};
+pub use oxc_allocator::Allocator;
 pub use parser::{Parse, Parser, ParserBuilder};
 pub use pos::{Span, Spanned};
 pub use span_ignored_eq::SpanIgnoredEq;

--- a/crates/oxc_css_parser/src/parser/at_rule/color_profile.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/color_profile.rs
@@ -2,8 +2,8 @@ use super::Parser;
 use crate::{Parse, ast::*, error::PResult};
 
 // https://www.w3.org/TR/css-color-5/#at-profile
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ColorProfilePrelude<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for ColorProfilePrelude<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.parse_dashed_ident()? {
             InterpolableIdent::Literal(ident) if ident.name.eq_ignore_ascii_case("device-cmyk") => {
                 Ok(ColorProfilePrelude::DeviceCmyk(ident))

--- a/crates/oxc_css_parser/src/parser/at_rule/container.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/container.rs
@@ -1,6 +1,6 @@
 use super::Parser;
 use crate::{
-    Parse,
+    Parse, arena_box, arena_vec,
     ast::*,
     eat,
     error::{Error, ErrorKind, PResult},
@@ -9,21 +9,22 @@ use crate::{
     tokenizer::{Token, TokenWithSpan},
 };
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ContainerCondition<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for ContainerCondition<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &peek!(input).token {
             Token::Ident(ident) if ident.name().eq_ignore_ascii_case("not") => {
                 let container_condition_not = input.parse::<ContainerConditionNot>()?;
                 let span = container_condition_not.span.clone();
                 Ok(ContainerCondition {
-                    conditions: vec![ContainerConditionKind::Not(container_condition_not)],
+                    conditions: arena_vec!(input; ContainerConditionKind::Not(container_condition_not)),
                     span,
                 })
             }
             _ => {
                 let first = input.parse::<QueryInParens>()?;
                 let mut span = first.span.clone();
-                let mut conditions = vec![ContainerConditionKind::QueryInParens(first)];
+                let mut conditions =
+                    arena_vec!(input; ContainerConditionKind::QueryInParens(first));
                 if let Token::Ident(ident) = &peek!(input).token {
                     let name = ident.name();
                     if name.eq_ignore_ascii_case("and") {
@@ -55,8 +56,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ContainerCondition<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ContainerConditionAnd<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for ContainerConditionAnd<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let keyword = input.parse::<Ident>()?;
         if keyword.name.eq_ignore_ascii_case("and") {
             let query_in_parens = input.parse::<QueryInParens>()?;
@@ -68,8 +69,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ContainerConditionAnd<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ContainerConditionNot<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for ContainerConditionNot<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let keyword = input.parse::<Ident>()?;
         if keyword.name.eq_ignore_ascii_case("not") {
             let query_in_parens = input.parse::<QueryInParens>()?;
@@ -81,8 +82,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ContainerConditionNot<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ContainerConditionOr<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for ContainerConditionOr<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let keyword = input.parse::<Ident>()?;
         if keyword.name.eq_ignore_ascii_case("or") {
             let query_in_parens = input.parse::<QueryInParens>()?;
@@ -94,13 +95,13 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ContainerConditionOr<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for QueryInParens<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for QueryInParens<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if let Some((_, Span { start, .. })) = eat!(input, LParen) {
             let kind = if let Ok(container_condition) = input.try_parse(ContainerCondition::parse) {
                 QueryInParensKind::ContainerCondition(container_condition)
             } else {
-                QueryInParensKind::SizeFeature(Box::new(input.parse()?))
+                QueryInParensKind::SizeFeature(arena_box!(input, input.parse()?))
             };
             let (_, Span { end, .. }) = expect!(input, RParen);
             Ok(QueryInParens { kind, span: Span { start, end } })
@@ -115,8 +116,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for QueryInParens<'s> {
             } else if keyword.eq_ignore_ascii_case("scroll-state") {
                 // https://drafts.csswg.org/css-conditional-5/#scroll-state-container
                 expect_without_ws_or_comments!(input, LParen);
-                let kind =
-                    input.parse().map(|media| QueryInParensKind::ScrollState(Box::new(media)))?;
+                let media = input.parse()?;
+                let kind = QueryInParensKind::ScrollState(arena_box!(input, media));
                 let (_, Span { end, .. }) = expect!(input, RParen);
                 Ok(QueryInParens { kind, span: Span { start: ident_span.start, end } })
             } else {
@@ -126,21 +127,21 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for QueryInParens<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for StyleCondition<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for StyleCondition<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &peek!(input).token {
             Token::Ident(ident) if ident.name().eq_ignore_ascii_case("not") => {
                 let style_condition_not = input.parse::<StyleConditionNot>()?;
                 let span = style_condition_not.span.clone();
                 Ok(StyleCondition {
-                    conditions: vec![StyleConditionKind::Not(style_condition_not)],
+                    conditions: arena_vec!(input; StyleConditionKind::Not(style_condition_not)),
                     span,
                 })
             }
             _ => {
                 let first = input.parse::<StyleInParens>()?;
                 let mut span = first.span.clone();
-                let mut conditions = vec![StyleConditionKind::StyleInParens(first)];
+                let mut conditions = arena_vec!(input; StyleConditionKind::StyleInParens(first));
                 if let Token::Ident(ident) = &peek!(input).token {
                     let name = ident.name();
                     if name.eq_ignore_ascii_case("and") {
@@ -172,8 +173,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for StyleCondition<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for StyleConditionAnd<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for StyleConditionAnd<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let ident = input.parse::<Ident>()?;
         if ident.name.eq_ignore_ascii_case("and") {
             let style_in_parens = input.parse::<StyleInParens>()?;
@@ -185,8 +186,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for StyleConditionAnd<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for StyleConditionNot<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for StyleConditionNot<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let keyword = input.parse::<Ident>()?;
         if keyword.name.eq_ignore_ascii_case("not") {
             let style_in_parens = input.parse::<StyleInParens>()?;
@@ -198,8 +199,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for StyleConditionNot<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for StyleConditionOr<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for StyleConditionOr<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let keyword = input.parse::<Ident>()?;
         if keyword.name.eq_ignore_ascii_case("or") {
             let style_in_parens = input.parse::<StyleInParens>()?;
@@ -211,8 +212,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for StyleConditionOr<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for StyleInParens<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for StyleInParens<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = expect!(input, LParen);
         let kind = input.parse()?;
         let (_, Span { end, .. }) = expect!(input, RParen);
@@ -220,8 +221,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for StyleInParens<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for StyleInParensKind<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for StyleInParensKind<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if let Ok(style_condition) = input.try_parse(StyleCondition::parse) {
             Ok(StyleInParensKind::Condition(style_condition))
         } else {
@@ -230,8 +231,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for StyleInParensKind<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for StyleQuery<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for StyleQuery<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if let Ok(condition) = input.try_parse(StyleCondition::parse) {
             Ok(StyleQuery::Condition(condition))
         } else {
@@ -243,8 +244,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for StyleQuery<'s> {
 }
 
 // https://drafts.csswg.org/css-contain-3/#container-rule
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ContainerPrelude<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for ContainerPrelude<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let name = input.try_parse(|parser| match parser.parse()? {
             InterpolableIdent::Literal(ident)
                 if ident.name.eq_ignore_ascii_case("not")

--- a/crates/oxc_css_parser/src/parser/at_rule/counter_style.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/counter_style.rs
@@ -6,12 +6,12 @@ use crate::{
 };
 
 // https://www.w3.org/TR/css-counter-styles-3/#the-counter-style-rule
-impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
-    pub(super) fn parse_counter_style_prelude(&mut self) -> PResult<InterpolableIdent<'s>> {
+impl<'a> Parser<'a> {
+    pub(super) fn parse_counter_style_prelude(&mut self) -> PResult<InterpolableIdent<'a>> {
         let ident = self.parse()?;
         match &ident {
             InterpolableIdent::Literal(ident)
-                if util::is_css_wide_keyword(&ident.name)
+                if util::is_css_wide_keyword(ident.name)
                     || ident.name.eq_ignore_ascii_case("none") =>
             {
                 self.recoverable_errors.push(Error {

--- a/crates/oxc_css_parser/src/parser/at_rule/custom_media.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/custom_media.rs
@@ -9,8 +9,8 @@ use crate::{
 };
 
 // https://www.w3.org/TR/mediaqueries-5/#custom-mq
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for CustomMedia<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for CustomMedia<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let name = input.parse_dashed_ident()?;
         let value = input.parse::<CustomMediaValue>()?;
         let span = Span { start: name.span().start, end: value.span().end };
@@ -18,8 +18,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for CustomMedia<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for CustomMediaValue<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for CustomMediaValue<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &peek!(input).token {
             Token::Ident(ident) => {
                 let name = ident.name();

--- a/crates/oxc_css_parser/src/parser/at_rule/custom_selector.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/custom_selector.rs
@@ -1,8 +1,10 @@
 use super::Parser;
-use crate::{Parse, ast::*, error::PResult, expect, peek, pos::Span, tokenizer::Token, util};
+use crate::{
+    Parse, arena_vec, ast::*, error::PResult, expect, peek, pos::Span, tokenizer::Token, util,
+};
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for CustomSelector<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for CustomSelector<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let prefix_arg = if matches!(peek!(input).token, Token::DollarVar(..)) {
             Some(input.parse::<CustomSelectorArg>()?)
         } else {
@@ -33,26 +35,25 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for CustomSelector<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for CustomSelectorArg<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for CustomSelectorArg<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (dollar_var, dollar_var_span) = expect!(input, DollarVar);
         Ok(CustomSelectorArg {
-            name: (
+            name: input.ident(
                 dollar_var.ident,
                 Span { start: dollar_var_span.start + 1, end: dollar_var_span.end },
-            )
-                .into(),
+            ),
             span: dollar_var_span,
         })
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for CustomSelectorArgs<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for CustomSelectorArgs<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = expect!(input, LParen);
 
-        let mut args = vec![];
-        let mut comma_spans = vec![];
+        let mut args = arena_vec!(input);
+        let mut comma_spans = arena_vec!(input);
         while !matches!(peek!(input).token, Token::RParen(..)) {
             args.push(input.parse()?);
             if !matches!(peek!(input).token, Token::RParen(..)) {
@@ -66,8 +67,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for CustomSelectorArgs<'s> {
 }
 
 // https://drafts.csswg.org/css-extensions/#custom-selectors
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for CustomSelectorPrelude<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for CustomSelectorPrelude<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let custom_selector = input.parse::<CustomSelector>()?;
         let selector = input.parse::<SelectorList>()?;
         let span = Span { start: custom_selector.span.start, end: selector.span.end };

--- a/crates/oxc_css_parser/src/parser/at_rule/document.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/document.rs
@@ -1,14 +1,14 @@
 use super::Parser;
-use crate::{Parse, Spanned, ast::*, eat, error::PResult};
+use crate::{Parse, Spanned, arena_vec, ast::*, eat, error::PResult};
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/@document
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for DocumentPrelude<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for DocumentPrelude<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<DocumentPreludeMatcher>()?;
         let mut span = first.span().clone();
 
-        let mut matchers = vec![first];
-        let mut comma_spans = vec![];
+        let mut matchers = arena_vec!(input; first);
+        let mut comma_spans = arena_vec!(input);
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             matchers.push(input.parse()?);
@@ -22,8 +22,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for DocumentPrelude<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for DocumentPreludeMatcher<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for DocumentPreludeMatcher<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if let Ok(url) = input.try_parse(Url::parse) {
             Ok(DocumentPreludeMatcher::Url(url))
         } else {

--- a/crates/oxc_css_parser/src/parser/at_rule/font_feature_values.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/font_feature_values.rs
@@ -1,16 +1,16 @@
 use super::Parser;
-use crate::{Parse, Spanned, ast::*, error::PResult, peek, tokenizer::Token};
+use crate::{Parse, Spanned, arena_vec, ast::*, error::PResult, peek, tokenizer::Token};
 
 // https://drafts.csswg.org/css-fonts/Overview.bs
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for FontFamilyName<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for FontFamilyName<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &peek!(input).token {
             Token::Str(..) | Token::StrTemplate(..) => input.parse().map(FontFamilyName::Str),
             _ => {
                 let first = input.parse::<InterpolableIdent>()?;
                 let mut span = first.span().clone();
 
-                let mut idents = vec![first];
+                let mut idents = arena_vec!(input; first);
                 while let Token::Ident(..) | Token::HashLBrace(..) | Token::AtLBraceVar(..) =
                     &peek!(input).token
                 {

--- a/crates/oxc_css_parser/src/parser/at_rule/import.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/import.rs
@@ -1,6 +1,6 @@
 use super::Parser;
 use crate::{
-    Parse, Syntax,
+    Parse, Syntax, arena_vec,
     ast::*,
     bump,
     error::{Error, ErrorKind, PResult},
@@ -10,8 +10,8 @@ use crate::{
 };
 
 // https://www.w3.org/TR/css-cascade-5/#at-import
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ImportPrelude<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for ImportPrelude<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let href = match &peek!(input).token {
             Token::Str(..) | Token::StrTemplate(..) => input.parse().map(ImportPreludeHref::Str)?,
             _ => match input.try_parse(Url::parse) {
@@ -20,7 +20,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ImportPrelude<'s> {
                 // is not a parsable URL, e.g. `@import url($dir+"/path");`.
                 // Mirrors the fallback in `parse_component_value_atom`.
                 Err(error) if matches!(input.syntax, Syntax::Scss | Syntax::Sass) => {
-                    let function_name: Ident = expect!(input, Ident).into();
+                    let (function_name, function_name_span) = expect!(input, Ident);
+                    let function_name = input.ident(function_name, function_name_span);
                     if !function_name.name.eq_ignore_ascii_case("url") {
                         return Err(error);
                     }
@@ -42,7 +43,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ImportPrelude<'s> {
                         if span.start == ident.span.end =>
                     {
                         bump!(input);
-                        let args = vec![input.parse().map(ComponentValue::LayerName)?];
+                        let args = arena_vec!(input; input.parse().map(ComponentValue::LayerName)?);
                         let end = expect!(input, RParen).1.end;
                         let span = Span { start: ident.span.start, end };
                         ImportPreludeLayer::WithName(Function {

--- a/crates/oxc_css_parser/src/parser/at_rule/keyframes.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/keyframes.rs
@@ -1,6 +1,6 @@
 use super::Parser;
 use crate::{
-    Parse,
+    Parse, arena_vec,
     ast::*,
     eat,
     error::{Error, ErrorKind, PResult},
@@ -12,14 +12,14 @@ use crate::{
 };
 
 // https://drafts.csswg.org/css-animations/#keyframes
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for KeyframeBlock<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for KeyframeBlock<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first_selector = input.parse::<KeyframeSelector>()?;
         let start = first_selector.span().start;
 
-        let mut selectors = Vec::with_capacity(2);
+        let mut selectors = input.vec_with_capacity(2);
         selectors.push(first_selector);
-        let mut comma_spans = vec![];
+        let mut comma_spans = arena_vec!(input);
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             selectors.push(input.parse()?);
@@ -35,8 +35,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for KeyframeBlock<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for KeyframeSelector<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for KeyframeSelector<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &peek!(input).token {
             Token::Percentage(..) => Ok(KeyframeSelector::Percentage(input.parse()?)),
             _ => {
@@ -60,14 +60,14 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for KeyframeSelector<'s> {
 }
 
 // https://drafts.csswg.org/css-animations/#keyframes
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for KeyframesName<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for KeyframesName<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &peek!(input).token {
             Token::Ident(..) | Token::HashLBrace(..) | Token::AtLBraceVar(..) => {
                 let ident = input.parse()?;
                 match &ident {
                     InterpolableIdent::Literal(ident)
-                        if util::is_css_wide_keyword(&ident.name)
+                        if util::is_css_wide_keyword(ident.name)
                             || ident.name.eq_ignore_ascii_case("default") =>
                     {
                         input.recoverable_errors.push(Error {

--- a/crates/oxc_css_parser/src/parser/at_rule/layer.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/layer.rs
@@ -1,6 +1,6 @@
 use super::Parser;
 use crate::{
-    Parse,
+    Parse, arena_vec,
     ast::*,
     bump, eat,
     error::{Error, PResult},
@@ -11,13 +11,13 @@ use crate::{
 };
 
 // https://drafts.csswg.org/css-cascade-5/#layering
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LayerNames<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LayerNames<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<LayerName>()?;
         let mut span = first.span.clone();
 
-        let mut names = vec![first];
-        let mut comma_spans = vec![];
+        let mut names = arena_vec!(input; first);
+        let mut comma_spans = arena_vec!(input);
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             names.push(input.parse()?);
@@ -31,13 +31,13 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LayerNames<'s> {
 }
 
 // https://drafts.csswg.org/css-cascade-5/#layer-names
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LayerName<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LayerName<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<InterpolableIdent>()?;
         let start = first.span().start;
         let mut end = first.span().end;
 
-        let mut idents = vec![first];
+        let mut idents = arena_vec!(input; first);
         while let TokenWithSpan { token: Token::Dot(..), span } = peek!(input) {
             if span.start == end {
                 let span = bump!(input).span;
@@ -51,7 +51,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LayerName<'s> {
         }
 
         let invalid_ident = idents.iter().find(|ident| match &ident {
-            InterpolableIdent::Literal(ident) => util::is_css_wide_keyword(&ident.name),
+            InterpolableIdent::Literal(ident) => util::is_css_wide_keyword(ident.name),
             _ => false,
         });
         if let Some(invalid_ident) = invalid_ident {

--- a/crates/oxc_css_parser/src/parser/at_rule/media.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/media.rs
@@ -1,6 +1,6 @@
 use super::Parser;
 use crate::{
-    Parse, Syntax,
+    Parse, Syntax, arena_box, arena_vec,
     ast::*,
     bump, eat,
     error::{Error, ErrorKind, PResult},
@@ -9,8 +9,8 @@ use crate::{
     tokenizer::{Token, TokenWithSpan},
 };
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaAnd<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for MediaAnd<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let keyword = input.parse::<Ident>()?;
         if keyword.name.eq_ignore_ascii_case("and") {
             let media_in_parens = input.parse::<MediaInParens>()?;
@@ -22,13 +22,13 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaAnd<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaConditionAfterMediaType<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for MediaConditionAfterMediaType<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let and: Ident = match bump!(input) {
             TokenWithSpan { token: Token::Ident(ident), span }
                 if ident.name().eq_ignore_ascii_case("and") =>
             {
-                (ident, span).into()
+                input.ident(ident, span)
             }
             TokenWithSpan { span, .. } => {
                 return Err(Error { kind: ErrorKind::ExpectMediaAnd, span });
@@ -42,8 +42,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaConditionAfterMediaType<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaFeature<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for MediaFeature<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.parse_media_feature_value()? {
             ComponentValue::InterpolableIdent(ident) => match &peek!(input).token {
                 Token::Colon(..) => input.parse_media_feature_plain(ident).map(MediaFeature::Plain),
@@ -74,8 +74,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaFeature<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaFeatureComparison {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for MediaFeatureComparison {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match bump!(input) {
             TokenWithSpan { token: Token::LessThan(..), span } => {
                 Ok(MediaFeatureComparison { kind: MediaFeatureComparisonKind::LessThan, span })
@@ -103,8 +103,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaFeatureComparison {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaInParens<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for MediaInParens<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         // Sass allows an interpolation wherever `<media-in-parens>` is expected,
         // e.g. `@media screen and #{$query} {}`.
         if matches!(input.syntax, Syntax::Scss | Syntax::Sass)
@@ -125,8 +125,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaInParens<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaInParensKind<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for MediaInParensKind<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if let Ok(media_condition) = input.try_parse(|parser| {
             let media_condition = parser.parse_media_condition(/* allow_or */ true)?;
             // `(#{$x}-width: 1px)`: the interpolation parses as a
@@ -142,13 +142,14 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaInParensKind<'s> {
         }) {
             Ok(MediaInParensKind::MediaCondition(media_condition))
         } else {
-            input.parse().map(Box::new).map(MediaInParensKind::MediaFeature)
+            let media_feature = input.parse()?;
+            Ok(MediaInParensKind::MediaFeature(arena_box!(input, media_feature)))
         }
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaNot<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for MediaNot<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let keyword = input.parse::<Ident>()?;
         if keyword.name.eq_ignore_ascii_case("not") {
             let media_in_parens = input.parse::<MediaInParens>()?;
@@ -160,8 +161,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaNot<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaOr<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for MediaOr<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let keyword = input.parse::<Ident>()?;
         if keyword.name.eq_ignore_ascii_case("or") {
             let media_in_parens = input.parse::<MediaInParens>()?;
@@ -173,8 +174,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaOr<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaQuery<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for MediaQuery<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if let Ok(condition_only) =
             input.try_parse(|parser| parser.parse_media_condition(/* allow_or */ true))
         {
@@ -192,9 +193,10 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaQuery<'s> {
                         _ => unreachable!(),
                     })
                 }
-                Token::Dot(..) | Token::Hash(..) => input.parse().map(|less_namespace_value| {
-                    MediaQuery::LessNamespaceValue(Box::new(less_namespace_value))
-                }),
+                Token::Dot(..) | Token::Hash(..) => {
+                    let less_namespace_value = input.parse()?;
+                    Ok(MediaQuery::LessNamespaceValue(arena_box!(input, less_namespace_value)))
+                }
                 _ => input.parse_media_query_with_type_or_function(),
             }
         } else {
@@ -204,13 +206,13 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaQuery<'s> {
 }
 
 // https://www.w3.org/TR/mediaqueries-4/#mq-syntax
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaQueryList<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for MediaQueryList<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<MediaQuery>()?;
         let mut span = first.span().clone();
 
-        let mut queries = vec![first];
-        let mut comma_spans = vec![];
+        let mut queries = arena_vec!(input; first);
+        let mut comma_spans = arena_vec!(input);
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             queries.push(input.parse()?);
@@ -226,8 +228,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaQueryList<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaQueryWithType<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for MediaQueryWithType<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let modifier = if let Token::Ident(ident) = &peek!(input).token {
             let name = ident.name();
             if name.eq_ignore_ascii_case("not") || name.eq_ignore_ascii_case("only") {
@@ -269,18 +271,21 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for MediaQueryWithType<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
-    fn parse_media_condition(&mut self, allow_or: bool) -> PResult<MediaCondition<'s>> {
+impl<'a> Parser<'a> {
+    fn parse_media_condition(&mut self, allow_or: bool) -> PResult<MediaCondition<'a>> {
         match &peek!(self).token {
             Token::Ident(ident) if ident.name().eq_ignore_ascii_case("not") => {
                 let media_not = self.parse::<MediaNot>()?;
                 let span = media_not.span.clone();
-                Ok(MediaCondition { conditions: vec![MediaConditionKind::Not(media_not)], span })
+                Ok(MediaCondition {
+                    conditions: arena_vec!(self; MediaConditionKind::Not(media_not)),
+                    span,
+                })
             }
             _ => {
                 let first = self.parse::<MediaInParens>()?;
                 let mut span = first.span.clone();
-                let mut conditions = vec![MediaConditionKind::MediaInParens(first)];
+                let mut conditions = arena_vec!(self; MediaConditionKind::MediaInParens(first));
                 if let Token::Ident(ident) = &peek!(self).token {
                     let name = ident.name();
                     if name.eq_ignore_ascii_case("and") {
@@ -313,8 +318,8 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
 
     fn parse_media_feature_plain(
         &mut self,
-        ident: InterpolableIdent<'s>,
-    ) -> PResult<MediaFeaturePlain<'s>> {
+        ident: InterpolableIdent<'a>,
+    ) -> PResult<MediaFeaturePlain<'a>> {
         let (_, colon_span) = expect!(self, Colon);
         let value = self.parse_media_feature_value()?;
         let span = Span { start: ident.span().start, end: value.span().end };
@@ -323,8 +328,8 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
 
     fn parse_media_feature_range_or_range_interval(
         &mut self,
-        left: ComponentValue<'s>,
-    ) -> PResult<MediaFeature<'s>> {
+        left: ComponentValue<'a>,
+    ) -> PResult<MediaFeature<'a>> {
         let comparison = self.parse()?;
         let name_or_right = self.parse_media_feature_value()?;
         if let ComponentValue::InterpolableIdent(ident) = name_or_right {
@@ -375,7 +380,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         }
     }
 
-    fn parse_media_feature_value(&mut self) -> PResult<ComponentValue<'s>> {
+    fn parse_media_feature_value(&mut self) -> PResult<ComponentValue<'a>> {
         let value = match self.syntax {
             Syntax::Css => self.parse_component_value_atom()?,
             Syntax::Scss | Syntax::Sass => {
@@ -393,7 +398,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         }
     }
 
-    fn parse_media_query_with_type_or_function(&mut self) -> PResult<MediaQuery<'s>> {
+    fn parse_media_query_with_type_or_function(&mut self) -> PResult<MediaQuery<'a>> {
         let media_query_with_type = self.parse::<MediaQueryWithType>()?;
         match (media_query_with_type, peek!(self)) {
             (

--- a/crates/oxc_css_parser/src/parser/at_rule/mod.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/mod.rs
@@ -1,6 +1,6 @@
 use super::{Parser, state::ParserState};
 use crate::{
-    Parse, Syntax,
+    Parse, Syntax, arena_box,
     ast::*,
     bump,
     error::{Error, ErrorKind, PResult},
@@ -25,8 +25,8 @@ mod page;
 mod scope;
 mod supports;
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AtRule<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for AtRule<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (at_keyword, at_keyword_span) = expect!(input, AtKeyword);
 
         let at_rule_name = at_keyword.ident.name();
@@ -57,11 +57,11 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AtRule<'s> {
             let (end, prelude) = match input.syntax {
                 Syntax::Css => {
                     let prelude = input.parse::<ImportPrelude>()?;
-                    (prelude.span.end, AtRulePrelude::Import(Box::new(prelude)))
+                    (prelude.span.end, AtRulePrelude::Import(arena_box!(input, prelude)))
                 }
                 Syntax::Scss | Syntax::Sass => {
                     if let Ok(prelude) = input.try_parse(ImportPrelude::parse) {
-                        (prelude.span.end, AtRulePrelude::Import(Box::new(prelude)))
+                        (prelude.span.end, AtRulePrelude::Import(arena_box!(input, prelude)))
                     } else {
                         let prelude = input.parse::<SassImportPrelude>()?;
                         (prelude.span.end, AtRulePrelude::SassImport(prelude))
@@ -69,10 +69,10 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AtRule<'s> {
                 }
                 Syntax::Less => {
                     if let Ok(prelude) = input.try_parse(ImportPrelude::parse) {
-                        (prelude.span.end, AtRulePrelude::Import(Box::new(prelude)))
+                        (prelude.span.end, AtRulePrelude::Import(arena_box!(input, prelude)))
                     } else {
                         let prelude = input.parse::<LessImportPrelude>()?;
-                        (prelude.span.end, AtRulePrelude::LessImport(Box::new(prelude)))
+                        (prelude.span.end, AtRulePrelude::LessImport(arena_box!(input, prelude)))
                     }
                 }
             };
@@ -129,7 +129,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AtRule<'s> {
         } else if at_rule_name.eq_ignore_ascii_case("namespace") {
             let namespace = input.parse::<NamespacePrelude>()?;
             let end = namespace.span.end;
-            (Some(AtRulePrelude::Namespace(Box::new(namespace))), None, end)
+            (Some(AtRulePrelude::Namespace(arena_box!(input, namespace))), None, end)
         } else if at_rule_name.eq_ignore_ascii_case("color-profile") {
             let prelude = Some(AtRulePrelude::ColorProfile(input.parse()?));
             let block = input.parse::<SimpleBlock>()?;
@@ -154,11 +154,15 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AtRule<'s> {
         } else if at_rule_name.eq_ignore_ascii_case("custom-media") {
             let custom_media = input.parse::<CustomMedia>()?;
             let end = custom_media.span.end;
-            (Some(AtRulePrelude::CustomMedia(Box::new(custom_media))), None, end)
+            (Some(AtRulePrelude::CustomMedia(arena_box!(input, custom_media))), None, end)
         } else if at_rule_name.eq_ignore_ascii_case("custom-selector") {
             let custom_selector_prelude = input.parse::<CustomSelectorPrelude>()?;
             let end = custom_selector_prelude.span.end;
-            (Some(AtRulePrelude::CustomSelector(Box::new(custom_selector_prelude))), None, end)
+            (
+                Some(AtRulePrelude::CustomSelector(arena_box!(input, custom_selector_prelude))),
+                None,
+                end,
+            )
         } else if at_rule_name.eq_ignore_ascii_case("position-try") {
             // https://drafts.csswg.org/css-anchor-position-1/#fallback-rule
             let prelude = Some(AtRulePrelude::PositionTry(input.parse_dashed_ident()?));
@@ -179,7 +183,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AtRule<'s> {
             (prelude, Some(block), end)
         } else if at_rule_name.eq_ignore_ascii_case("scope") {
             let prelude = if let Token::LParen(..) | Token::Ident(..) = peek!(input).token {
-                Some(AtRulePrelude::Scope(Box::new(input.parse()?)))
+                Some(AtRulePrelude::Scope(arena_box!(input, input.parse()?)))
             } else {
                 None
             };
@@ -226,7 +230,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AtRule<'s> {
         } else if at_rule_name == "plugin" && input.syntax == Syntax::Less {
             let prelude = input.parse::<LessPlugin>()?;
             let end = prelude.span.end;
-            (Some(AtRulePrelude::LessPlugin(Box::new(prelude))), None, end)
+            (Some(AtRulePrelude::LessPlugin(arena_box!(input, prelude))), None, end)
         } else if matches!(input.syntax, Syntax::Scss | Syntax::Sass) {
             use super::state::{
                 SASS_CTX_ALLOW_DIV, SASS_CTX_ALLOW_KEYFRAME_BLOCK, SASS_CTX_IN_FUNCTION,
@@ -236,19 +240,19 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AtRule<'s> {
                     let prelude = input.parse()?;
                     let block = input.parse::<SimpleBlock>()?;
                     let end = block.span.end;
-                    (Some(AtRulePrelude::SassEach(Box::new(prelude))), Some(block), end)
+                    (Some(AtRulePrelude::SassEach(arena_box!(input, prelude))), Some(block), end)
                 }
                 "while" => {
                     let prelude = input.parse()?;
                     let block = input.parse::<SimpleBlock>()?;
                     let end = block.span.end;
-                    (Some(AtRulePrelude::SassExpr(Box::new(prelude))), Some(block), end)
+                    (Some(AtRulePrelude::SassExpr(arena_box!(input, prelude))), Some(block), end)
                 }
                 "for" => {
                     let prelude = input.parse()?;
                     let block = input.parse::<SimpleBlock>()?;
                     let end = block.span.end;
-                    (Some(AtRulePrelude::SassFor(Box::new(prelude))), Some(block), end)
+                    (Some(AtRulePrelude::SassFor(arena_box!(input, prelude))), Some(block), end)
                 }
                 "mixin" => {
                     let prelude = input.parse()?;
@@ -259,7 +263,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AtRule<'s> {
                         })
                         .parse::<SimpleBlock>()?;
                     let end = block.span.end;
-                    (Some(AtRulePrelude::SassMixin(Box::new(prelude))), Some(block), end)
+                    (Some(AtRulePrelude::SassMixin(arena_box!(input, prelude))), Some(block), end)
                 }
                 "include" => {
                     let prelude = input.parse::<SassInclude>()?;
@@ -279,7 +283,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AtRule<'s> {
                         };
                     let end =
                         block.as_ref().map(|block| block.span.end).unwrap_or(prelude.span.end);
-                    (Some(AtRulePrelude::SassInclude(Box::new(prelude))), block, end)
+                    (Some(AtRulePrelude::SassInclude(arena_box!(input, prelude))), block, end)
                 }
                 "content" => {
                     if matches!(peek!(input).token, Token::LParen(..)) {
@@ -293,7 +297,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AtRule<'s> {
                 "use" => {
                     let prelude = input.parse::<SassUse>()?;
                     let end = prelude.span.end;
-                    (Some(AtRulePrelude::SassUse(Box::new(prelude))), None, end)
+                    (Some(AtRulePrelude::SassUse(arena_box!(input, prelude))), None, end)
                 }
                 "function" => {
                     let prelude = input.parse::<SassFunction>()?;
@@ -304,7 +308,11 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AtRule<'s> {
                         })
                         .parse::<SimpleBlock>()?;
                     let end = block.span.end;
-                    (Some(AtRulePrelude::SassFunction(Box::new(prelude))), Some(block), end)
+                    (
+                        Some(AtRulePrelude::SassFunction(arena_box!(input, prelude))),
+                        Some(block),
+                        end,
+                    )
                 }
                 "return" => {
                     let expr = input
@@ -320,22 +328,22 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AtRule<'s> {
                             span: Span { start: at_keyword_span.start, end },
                         });
                     }
-                    (Some(AtRulePrelude::SassExpr(Box::new(expr))), None, end)
+                    (Some(AtRulePrelude::SassExpr(arena_box!(input, expr))), None, end)
                 }
                 "extend" => {
                     let prelude = input.parse::<SassExtend>()?;
                     let end = prelude.span.end;
-                    (Some(AtRulePrelude::SassExtend(Box::new(prelude))), None, end)
+                    (Some(AtRulePrelude::SassExtend(arena_box!(input, prelude))), None, end)
                 }
                 "warn" | "error" | "debug" => {
                     let expr = input.parse_maybe_sass_list(/* allow_comma */ true)?;
                     let end = expr.span().end;
-                    (Some(AtRulePrelude::SassExpr(Box::new(expr))), None, end)
+                    (Some(AtRulePrelude::SassExpr(arena_box!(input, expr))), None, end)
                 }
                 "forward" => {
                     let prelude = input.parse::<SassForward>()?;
                     let end = prelude.span.end;
-                    (Some(AtRulePrelude::SassForward(Box::new(prelude))), None, end)
+                    (Some(AtRulePrelude::SassForward(arena_box!(input, prelude))), None, end)
                 }
                 "at-root" => {
                     let prelude =
@@ -351,7 +359,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AtRule<'s> {
                 _ => {
                     let (prelude, block, end) = input.parse_unknown_at_rule()?;
                     (
-                        prelude.map(|prelude| AtRulePrelude::Unknown(Box::new(prelude))),
+                        prelude.map(|prelude| AtRulePrelude::Unknown(arena_box!(input, prelude))),
                         block,
                         end.unwrap_or(at_keyword_span.end),
                     )
@@ -360,7 +368,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AtRule<'s> {
         } else {
             let (prelude, block, end) = input.parse_unknown_at_rule()?;
             (
-                prelude.map(|prelude| AtRulePrelude::Unknown(Box::new(prelude))),
+                prelude.map(|prelude| AtRulePrelude::Unknown(arena_box!(input, prelude))),
                 block,
                 end.unwrap_or(at_keyword_span.end),
             )
@@ -368,13 +376,10 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AtRule<'s> {
 
         let span = Span { start: at_keyword_span.start, end };
         Ok(AtRule {
-            // We don't use `Ident::from_token` here because `at_rule_name` is already
-            // type of `Cow<str>`, avoiding creating it again.
-            name: Ident {
-                name: at_rule_name,
-                raw: at_keyword.ident.raw,
-                span: Span { start: at_keyword_span.start + 1, end: at_keyword_span.end },
-            },
+            name: input.ident(
+                at_keyword.ident,
+                Span { start: at_keyword_span.start + 1, end: at_keyword_span.end },
+            ),
             prelude,
             block,
             span,
@@ -382,10 +387,10 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AtRule<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
+impl<'a> Parser<'a> {
     pub(super) fn parse_unknown_at_rule(
         &mut self,
-    ) -> PResult<(Option<UnknownAtRulePrelude<'s>>, Option<SimpleBlock<'s>>, Option<usize>)> {
+    ) -> PResult<(Option<UnknownAtRulePrelude<'a>>, Option<SimpleBlock<'a>>, Option<usize>)> {
         let prelude = self.parse_unknown_at_rule_prelude()?;
         let block = match &peek!(self).token {
             Token::LBrace(..) | Token::Indent(..) => Some(self.parse::<SimpleBlock>()?),
@@ -398,9 +403,9 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         Ok((prelude, block, end))
     }
 
-    fn parse_unknown_at_rule_prelude(&mut self) -> PResult<Option<UnknownAtRulePrelude<'s>>> {
+    fn parse_unknown_at_rule_prelude(&mut self) -> PResult<Option<UnknownAtRulePrelude<'a>>> {
         if let Ok(prelude) = self.try_parse(|parser| {
-            let mut tokens = vec![];
+            let mut tokens = parser.vec();
             loop {
                 match &peek!(parser).token {
                     Token::LBrace(..)

--- a/crates/oxc_css_parser/src/parser/at_rule/namespace.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/namespace.rs
@@ -2,8 +2,8 @@ use super::Parser;
 use crate::{Parse, Spanned, ast::*, error::PResult, peek, tokenizer::Token};
 
 // https://www.w3.org/TR/css-namespaces-3/#syntax
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for NamespacePrelude<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for NamespacePrelude<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let prefix = match &peek!(input).token {
             Token::Ident(ident) => {
                 if ident.name().eq_ignore_ascii_case("url") {

--- a/crates/oxc_css_parser/src/parser/at_rule/page.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/page.rs
@@ -1,6 +1,6 @@
 use super::Parser;
 use crate::{
-    Parse,
+    Parse, arena_vec,
     ast::*,
     eat,
     error::PResult,
@@ -11,10 +11,10 @@ use crate::{
 };
 
 // https://www.w3.org/TR/css-page-3/#syntax-page-selector
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for PageSelector<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for PageSelector<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let mut name = None;
-        let mut pseudo = vec![];
+        let mut pseudo = arena_vec!(input);
         let start;
         let mut end;
 
@@ -46,13 +46,13 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for PageSelector<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for PageSelectorList<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for PageSelectorList<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<PageSelector>()?;
         let mut span = first.span.clone();
 
-        let mut selectors = vec![first];
-        let mut comma_spans = vec![];
+        let mut selectors = arena_vec!(input; first);
+        let mut comma_spans = arena_vec!(input);
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             selectors.push(input.parse()?);
@@ -65,8 +65,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for PageSelectorList<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for PseudoPage<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for PseudoPage<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, colon_span) = expect!(input, Colon);
         let name = input.parse::<InterpolableIdent>()?;
 

--- a/crates/oxc_css_parser/src/parser/at_rule/scope.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/scope.rs
@@ -9,8 +9,8 @@ use crate::{
     tokenizer::{Token, TokenWithSpan},
 };
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ScopeEnd<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for ScopeEnd<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let to_span = match bump!(input) {
             TokenWithSpan { token: Token::Ident(ident), span }
                 if ident.name().eq_ignore_ascii_case("to") =>
@@ -32,8 +32,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ScopeEnd<'s> {
 }
 
 // https://drafts.csswg.org/css-cascade-6/#scope-syntax
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ScopePrelude<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for ScopePrelude<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let start = if let Token::LParen(..) = peek!(input).token {
             Some(input.parse::<ScopeStart>()?)
         } else {
@@ -62,8 +62,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ScopePrelude<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ScopeStart<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for ScopeStart<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = expect!(input, LParen);
         let selector = input.parse()?;
         let (_, Span { end, .. }) = expect!(input, RParen);

--- a/crates/oxc_css_parser/src/parser/at_rule/supports.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/supports.rs
@@ -1,6 +1,6 @@
 use super::Parser;
 use crate::{
-    Parse,
+    Parse, arena_box, arena_vec,
     ast::*,
     error::{Error, ErrorKind, PResult},
     expect, peek,
@@ -9,26 +9,27 @@ use crate::{
 };
 
 // https://drafts.csswg.org/css-conditional-3/#at-supports
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SupportsCondition<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SupportsCondition<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &peek!(input).token {
             Token::Ident(token) if token.name().eq_ignore_ascii_case("not") => {
                 let keyword = input.parse::<Ident>()?;
                 let condition = input.parse::<SupportsInParens>()?;
                 let span = Span { start: keyword.span.start, end: condition.span().end };
                 Ok(SupportsCondition {
-                    conditions: vec![SupportsConditionKind::Not(SupportsNot {
+                    conditions: arena_vec!(input; SupportsConditionKind::Not(SupportsNot {
                         keyword,
                         condition,
                         span: span.clone(),
-                    })],
+                    })),
                     span,
                 })
             }
             _ => {
                 let first = input.parse::<SupportsInParens>()?;
                 let mut span = first.span().clone();
-                let mut conditions = vec![SupportsConditionKind::SupportsInParens(first)];
+                let mut conditions =
+                    arena_vec!(input; SupportsConditionKind::SupportsInParens(first));
                 while let Token::Ident(ident) = &peek!(input).token {
                     let name = ident.name();
                     if name.eq_ignore_ascii_case("and") {
@@ -62,15 +63,15 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SupportsCondition<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SupportsInParens<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SupportsInParens<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match peek!(input) {
             TokenWithSpan { token: Token::LParen(..), .. } => input
                 .try_parse(|parser| {
                     parser.parse::<SupportsDecl>().map(|supports_decl| {
                         let span = supports_decl.span.clone();
                         SupportsInParens {
-                            kind: SupportsInParensKind::Feature(Box::new(supports_decl)),
+                            kind: SupportsInParensKind::Feature(arena_box!(parser, supports_decl)),
                             span,
                         }
                     })
@@ -110,8 +111,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SupportsInParens<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SupportsDecl<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SupportsDecl<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let start = expect!(input, LParen).1.start;
         let decl = input.parse()?;
         let end = expect!(input, RParen).1.end;

--- a/crates/oxc_css_parser/src/parser/builder.rs
+++ b/crates/oxc_css_parser/src/parser/builder.rs
@@ -1,8 +1,6 @@
 use super::Parser;
-use crate::{
-    ParserOptions, Syntax,
-    tokenizer::{Tokenizer, token::Comment},
-};
+use crate::{ParserOptions, Syntax, tokenizer::Tokenizer};
+use oxc_allocator::Allocator;
 
 /// Parser builder is for building a parser while allowing us
 /// to control advanced behaviors.
@@ -10,18 +8,25 @@ use crate::{
 /// Unlike [`Parser`], syntax isn't required when creating a parser builder,
 /// and the default syntax will be CSS. If you need to parse with another syntax,
 /// use the [`syntax`](ParserBuilder::syntax) to modify it.
-pub struct ParserBuilder<'cmt, 's: 'cmt> {
-    source: &'s str,
+pub struct ParserBuilder<'a> {
+    allocator: &'a Allocator,
+    source: &'a str,
     syntax: Syntax,
     options: Option<ParserOptions>,
-    comments: Option<&'cmt mut Vec<Comment<'s>>>,
+    collect_comments: bool,
 }
 
-impl<'cmt, 's: 'cmt> ParserBuilder<'cmt, 's> {
+impl<'a> ParserBuilder<'a> {
     /// Create a parser builder from given source code.
-    pub fn new(source: &'s str) -> Self {
+    pub fn new(allocator: &'a Allocator, source: &'a str) -> Self {
         let source = source.strip_prefix('\u{feff}').unwrap_or(source);
-        ParserBuilder { source, options: None, syntax: Syntax::default(), comments: None }
+        ParserBuilder {
+            allocator,
+            source,
+            options: None,
+            syntax: Syntax::default(),
+            collect_comments: false,
+        }
     }
 
     /// Specify the syntax for parsing.
@@ -36,9 +41,9 @@ impl<'cmt, 's: 'cmt> ParserBuilder<'cmt, 's> {
         self
     }
 
-    /// Collect comments and put them into the given collection.
-    pub fn comments(mut self, comments: &'cmt mut Vec<Comment<'s>>) -> Self {
-        self.comments = Some(comments);
+    /// Collect comments.
+    pub fn comments(mut self) -> Self {
+        self.collect_comments = true;
         self
     }
 
@@ -47,12 +52,12 @@ impl<'cmt, 's: 'cmt> ParserBuilder<'cmt, 's> {
     /// Collecting comments is disabled by default,
     /// so you don't need to use this if you never call the [`comments`](ParserBuilder::comments) method.
     pub fn ignore_comments(mut self) -> Self {
-        self.comments = None;
+        self.collect_comments = false;
         self
     }
 
     /// Build a parser.
-    pub fn build(self) -> Parser<'cmt, 's> {
+    pub fn build(self) -> Parser<'a> {
         let options = self.options.unwrap_or_default();
         // Backtick is not valid CSS/SCSS/Sass; the placeholder lexer path only
         // makes sense for SCSS (in Less, backtick is the inline-JS delimiter).
@@ -61,14 +66,16 @@ impl<'cmt, 's: 'cmt> ParserBuilder<'cmt, 's> {
             "template_placeholder requires Syntax::Scss (backtick is Less's inline-JS delimiter)",
         );
         Parser {
+            allocator: self.allocator,
             source: self.source,
             syntax: self.syntax,
             options,
             tokenizer: Tokenizer::new(
+                self.allocator,
                 self.source,
                 self.syntax,
                 options.template_placeholder,
-                self.comments,
+                self.collect_comments,
             ),
             state: Default::default(),
             recoverable_errors: vec![],

--- a/crates/oxc_css_parser/src/parser/convert.rs
+++ b/crates/oxc_css_parser/src/parser/convert.rs
@@ -6,112 +6,113 @@ use crate::{
     },
     error::{Error, ErrorKind, PResult},
     tokenizer::token,
-    util,
 };
-use std::borrow::Cow;
 
-impl<'s> TryFrom<(token::Dimension<'s>, Span)> for Dimension<'s> {
+impl<'a> TryFrom<(token::Dimension<'a>, Span)> for Dimension<'a> {
     type Error = Error;
 
-    fn try_from((token, span): (token::Dimension<'s>, Span)) -> PResult<Self> {
+    fn try_from((token, span): (token::Dimension<'a>, Span)) -> PResult<Self> {
         let value_span = Span { start: span.start, end: span.start + token.value.raw.len() };
         let unit_span = Span { start: span.start + token.value.raw.len(), end: span.end };
 
         let value = (token.value, value_span).try_into()?;
         let unit = Ident::from((token.unit, unit_span));
-        let unit_name = &unit.name;
-        let kind = if unit_name.eq_ignore_ascii_case("px")
-            || unit_name.eq_ignore_ascii_case("em")
-            || unit_name.eq_ignore_ascii_case("rem")
-            || unit_name.eq_ignore_ascii_case("ex")
-            || unit_name.eq_ignore_ascii_case("rex")
-            || unit_name.eq_ignore_ascii_case("cap")
-            || unit_name.eq_ignore_ascii_case("rcap")
-            || unit_name.eq_ignore_ascii_case("ch")
-            || unit_name.eq_ignore_ascii_case("rch")
-            || unit_name.eq_ignore_ascii_case("ic")
-            || unit_name.eq_ignore_ascii_case("ric")
-            || unit_name.eq_ignore_ascii_case("lh")
-            || unit_name.eq_ignore_ascii_case("rlh")
-            || unit_name.eq_ignore_ascii_case("vw")
-            || unit_name.eq_ignore_ascii_case("vh")
-            || unit_name.eq_ignore_ascii_case("vi")
-            || unit_name.eq_ignore_ascii_case("vb")
-            || unit_name.eq_ignore_ascii_case("vmin")
-            || unit_name.eq_ignore_ascii_case("vmax")
-            || unit_name.eq_ignore_ascii_case("lvw")
-            || unit_name.eq_ignore_ascii_case("lvh")
-            || unit_name.eq_ignore_ascii_case("lvi")
-            || unit_name.eq_ignore_ascii_case("lvb")
-            || unit_name.eq_ignore_ascii_case("lvmin")
-            || unit_name.eq_ignore_ascii_case("lvmax")
-            || unit_name.eq_ignore_ascii_case("svw")
-            || unit_name.eq_ignore_ascii_case("svh")
-            || unit_name.eq_ignore_ascii_case("svi")
-            || unit_name.eq_ignore_ascii_case("svb")
-            || unit_name.eq_ignore_ascii_case("vmin")
-            || unit_name.eq_ignore_ascii_case("vmax")
-            || unit_name.eq_ignore_ascii_case("dvw")
-            || unit_name.eq_ignore_ascii_case("dvh")
-            || unit_name.eq_ignore_ascii_case("dvi")
-            || unit_name.eq_ignore_ascii_case("dvb")
-            || unit_name.eq_ignore_ascii_case("dvmin")
-            || unit_name.eq_ignore_ascii_case("dvmax")
-            || unit_name.eq_ignore_ascii_case("cm")
-            || unit_name.eq_ignore_ascii_case("mm")
-            || unit_name.eq_ignore_ascii_case("Q")
-            || unit_name.eq_ignore_ascii_case("in")
-            || unit_name.eq_ignore_ascii_case("pc")
-            || unit_name.eq_ignore_ascii_case("pt")
-        {
-            DimensionKind::Length
-        } else if unit_name.eq_ignore_ascii_case("deg")
-            || unit_name.eq_ignore_ascii_case("grad")
-            || unit_name.eq_ignore_ascii_case("rad")
-            || unit_name.eq_ignore_ascii_case("turn")
-        {
-            DimensionKind::Angle
-        } else if unit_name.eq_ignore_ascii_case("s") || unit_name.eq_ignore_ascii_case("ms") {
-            DimensionKind::Duration
-        } else if unit_name.eq_ignore_ascii_case("Hz") || unit_name.eq_ignore_ascii_case("kHz") {
-            DimensionKind::Frequency
-        } else if unit_name.eq_ignore_ascii_case("dpi")
-            || unit_name.eq_ignore_ascii_case("dpcm")
-            || unit_name.eq_ignore_ascii_case("dppx")
-        {
-            DimensionKind::Resolution
-        } else if unit_name.eq_ignore_ascii_case("fr") {
-            DimensionKind::Flex
-        } else {
-            DimensionKind::Unknown
-        };
+        let kind = dimension_kind(unit.name);
 
         Ok(Dimension { value, unit, kind, span })
     }
 }
 
-impl<'s> From<(token::Ident<'s>, Span)> for Ident<'s> {
-    fn from((token, span): (token::Ident<'s>, Span)) -> Self {
-        Ident { name: token.name(), raw: token.raw, span }
+pub(super) fn dimension_kind(unit_name: &str) -> DimensionKind {
+    if unit_name.eq_ignore_ascii_case("px")
+        || unit_name.eq_ignore_ascii_case("em")
+        || unit_name.eq_ignore_ascii_case("rem")
+        || unit_name.eq_ignore_ascii_case("ex")
+        || unit_name.eq_ignore_ascii_case("rex")
+        || unit_name.eq_ignore_ascii_case("cap")
+        || unit_name.eq_ignore_ascii_case("rcap")
+        || unit_name.eq_ignore_ascii_case("ch")
+        || unit_name.eq_ignore_ascii_case("rch")
+        || unit_name.eq_ignore_ascii_case("ic")
+        || unit_name.eq_ignore_ascii_case("ric")
+        || unit_name.eq_ignore_ascii_case("lh")
+        || unit_name.eq_ignore_ascii_case("rlh")
+        || unit_name.eq_ignore_ascii_case("vw")
+        || unit_name.eq_ignore_ascii_case("vh")
+        || unit_name.eq_ignore_ascii_case("vi")
+        || unit_name.eq_ignore_ascii_case("vb")
+        || unit_name.eq_ignore_ascii_case("vmin")
+        || unit_name.eq_ignore_ascii_case("vmax")
+        || unit_name.eq_ignore_ascii_case("lvw")
+        || unit_name.eq_ignore_ascii_case("lvh")
+        || unit_name.eq_ignore_ascii_case("lvi")
+        || unit_name.eq_ignore_ascii_case("lvb")
+        || unit_name.eq_ignore_ascii_case("lvmin")
+        || unit_name.eq_ignore_ascii_case("lvmax")
+        || unit_name.eq_ignore_ascii_case("svw")
+        || unit_name.eq_ignore_ascii_case("svh")
+        || unit_name.eq_ignore_ascii_case("svi")
+        || unit_name.eq_ignore_ascii_case("svb")
+        || unit_name.eq_ignore_ascii_case("vmin")
+        || unit_name.eq_ignore_ascii_case("vmax")
+        || unit_name.eq_ignore_ascii_case("dvw")
+        || unit_name.eq_ignore_ascii_case("dvh")
+        || unit_name.eq_ignore_ascii_case("dvi")
+        || unit_name.eq_ignore_ascii_case("dvb")
+        || unit_name.eq_ignore_ascii_case("dvmin")
+        || unit_name.eq_ignore_ascii_case("dvmax")
+        || unit_name.eq_ignore_ascii_case("cm")
+        || unit_name.eq_ignore_ascii_case("mm")
+        || unit_name.eq_ignore_ascii_case("Q")
+        || unit_name.eq_ignore_ascii_case("in")
+        || unit_name.eq_ignore_ascii_case("pc")
+        || unit_name.eq_ignore_ascii_case("pt")
+    {
+        DimensionKind::Length
+    } else if unit_name.eq_ignore_ascii_case("deg")
+        || unit_name.eq_ignore_ascii_case("grad")
+        || unit_name.eq_ignore_ascii_case("rad")
+        || unit_name.eq_ignore_ascii_case("turn")
+    {
+        DimensionKind::Angle
+    } else if unit_name.eq_ignore_ascii_case("s") || unit_name.eq_ignore_ascii_case("ms") {
+        DimensionKind::Duration
+    } else if unit_name.eq_ignore_ascii_case("Hz") || unit_name.eq_ignore_ascii_case("kHz") {
+        DimensionKind::Frequency
+    } else if unit_name.eq_ignore_ascii_case("dpi")
+        || unit_name.eq_ignore_ascii_case("dpcm")
+        || unit_name.eq_ignore_ascii_case("dppx")
+    {
+        DimensionKind::Resolution
+    } else if unit_name.eq_ignore_ascii_case("fr") {
+        DimensionKind::Flex
+    } else {
+        DimensionKind::Unknown
     }
 }
 
-impl<'s> From<(token::Placeholder<'s>, Span)> for Placeholder<'s> {
-    fn from((token, span): (token::Placeholder<'s>, Span)) -> Self {
+impl<'a> From<(token::Ident<'a>, Span)> for Ident<'a> {
+    fn from((token, span): (token::Ident<'a>, Span)) -> Self {
+        Ident { name: token.raw, raw: token.raw, span }
+    }
+}
+
+impl<'a> From<(token::Placeholder<'a>, Span)> for Placeholder<'a> {
+    fn from((token, span): (token::Placeholder<'a>, Span)) -> Self {
         Placeholder { index: token.index, suffix: token.suffix, span }
     }
 }
 
-impl<'s> From<(token::Ident<'s>, Span)> for InterpolableIdentStaticPart<'s> {
-    fn from((token, span): (token::Ident<'s>, Span)) -> Self {
-        InterpolableIdentStaticPart { value: token.name(), raw: token.raw, span }
+impl<'a> From<(token::Ident<'a>, Span)> for InterpolableIdentStaticPart<'a> {
+    fn from((token, span): (token::Ident<'a>, Span)) -> Self {
+        InterpolableIdentStaticPart { value: token.raw, raw: token.raw, span }
     }
 }
 
-impl<'s> TryFrom<(token::Number<'s>, Span)> for Number<'s> {
+impl<'a> TryFrom<(token::Number<'a>, Span)> for Number<'a> {
     type Error = Error;
 
-    fn try_from((token, span): (token::Number<'s>, Span)) -> PResult<Self> {
+    fn try_from((token, span): (token::Number<'a>, Span)) -> PResult<Self> {
         token
             .raw
             .parse()
@@ -120,8 +121,8 @@ impl<'s> TryFrom<(token::Number<'s>, Span)> for Number<'s> {
     }
 }
 
-impl<'s> From<(token::StrTemplate<'s>, Span)> for InterpolableStrStaticPart<'s> {
-    fn from((token, span): (token::StrTemplate<'s>, Span)) -> Self {
+impl<'a> From<(token::StrTemplate<'a>, Span)> for InterpolableStrStaticPart<'a> {
+    fn from((token, span): (token::StrTemplate<'a>, Span)) -> Self {
         let raw_without_quotes = if token.tail {
             unsafe { token.raw.get_unchecked(0..token.raw.len() - 1) }
         } else if token.head {
@@ -129,31 +130,22 @@ impl<'s> From<(token::StrTemplate<'s>, Span)> for InterpolableStrStaticPart<'s> 
         } else {
             token.raw
         };
-        let value = if token.escaped {
-            util::handle_escape(raw_without_quotes)
-        } else {
-            Cow::from(raw_without_quotes)
-        };
+        let value = raw_without_quotes;
         Self { value, raw: token.raw, span }
     }
 }
 
-impl<'s> From<(token::UrlTemplate<'s>, Span)> for InterpolableUrlStaticPart<'s> {
-    fn from((token, span): (token::UrlTemplate<'s>, Span)) -> Self {
-        let value =
-            if token.escaped { util::handle_escape(token.raw) } else { Cow::from(token.raw) };
+impl<'a> From<(token::UrlTemplate<'a>, Span)> for InterpolableUrlStaticPart<'a> {
+    fn from((token, span): (token::UrlTemplate<'a>, Span)) -> Self {
+        let value = token.raw;
         Self { value, raw: token.raw, span }
     }
 }
 
-impl<'s> From<(token::Str<'s>, Span)> for Str<'s> {
-    fn from((str, span): (token::Str<'s>, Span)) -> Self {
+impl<'a> From<(token::Str<'a>, Span)> for Str<'a> {
+    fn from((str, span): (token::Str<'a>, Span)) -> Self {
         let raw_without_quotes = unsafe { str.raw.get_unchecked(1..str.raw.len() - 1) };
-        let value = if str.escaped {
-            util::handle_escape(raw_without_quotes)
-        } else {
-            Cow::from(raw_without_quotes)
-        };
+        let value = raw_without_quotes;
         Self { value, raw: str.raw, span }
     }
 }

--- a/crates/oxc_css_parser/src/parser/less.rs
+++ b/crates/oxc_css_parser/src/parser/less.rs
@@ -3,7 +3,7 @@ use super::{
     state::{LESS_CTX_ALLOW_DIV, LESS_CTX_ALLOW_KEYFRAME_BLOCK, ParserState, QualifiedRuleContext},
 };
 use crate::{
-    Parse,
+    Parse, arena_box, arena_vec,
     ast::*,
     bump,
     config::Syntax,
@@ -14,7 +14,7 @@ use crate::{
     tokenizer::{Token, TokenWithSpan},
     util,
 };
-use std::{borrow::Cow, mem};
+use std::mem;
 
 const PRECEDENCE_AND: u8 = 2;
 const PRECEDENCE_OR: u8 = 1;
@@ -22,15 +22,15 @@ const PRECEDENCE_OR: u8 = 1;
 const PRECEDENCE_MULTIPLY: u8 = 2;
 const PRECEDENCE_PLUS: u8 = 1;
 
-impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
+impl<'a> Parser<'a> {
     pub(super) fn parse_less_condition(
         &mut self,
         needs_parens: bool,
-    ) -> PResult<LessCondition<'s>> {
+    ) -> PResult<LessCondition<'a>> {
         self.parse_less_condition_recursively(needs_parens, 0)
     }
 
-    fn parse_less_condition_atom(&mut self) -> PResult<LessCondition<'s>> {
+    fn parse_less_condition_atom(&mut self) -> PResult<LessCondition<'a>> {
         let left =
             self.parse_less_operation(/* allow_mixin_call */ false).map(LessCondition::Value)?;
 
@@ -84,9 +84,9 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
 
         let span = Span { start: left.span().start, end: right.span().end };
         Ok(LessCondition::Binary(LessBinaryCondition {
-            left: Box::new(left),
+            left: arena_box!(self, left),
             op,
-            right: Box::new(right),
+            right: arena_box!(self, right),
             span,
         }))
     }
@@ -94,7 +94,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
     fn parse_less_condition_inside_parens(
         &mut self,
         needs_parens: bool,
-    ) -> PResult<LessCondition<'s>> {
+    ) -> PResult<LessCondition<'a>> {
         self.try_parse(|parser| {
             let condition = parser.parse_less_condition(needs_parens);
             match &condition {
@@ -133,7 +133,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         &mut self,
         needs_parens: bool,
         precedence: u8,
-    ) -> PResult<LessCondition<'s>> {
+    ) -> PResult<LessCondition<'a>> {
         let mut left = if precedence >= PRECEDENCE_AND {
             match &peek!(self).token {
                 Token::LParen(..) => {
@@ -141,7 +141,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                     let condition = self.parse_less_condition_inside_parens(needs_parens)?;
                     let (_, Span { end, .. }) = expect!(self, RParen);
                     LessCondition::Parenthesized(LessParenthesizedCondition {
-                        condition: Box::new(condition),
+                        condition: arena_box!(self, condition),
                         span: Span { start, end },
                     })
                 }
@@ -151,7 +151,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                     let condition = self.parse_less_condition_inside_parens(needs_parens)?;
                     let (_, Span { end, .. }) = expect!(self, RParen);
                     LessCondition::Negated(LessNegatedCondition {
-                        condition: Box::new(condition),
+                        condition: arena_box!(self, condition),
                         span: Span { start, end },
                     })
                 }
@@ -194,9 +194,9 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
 
             let span = Span { start: left.span().start, end: right.span().end };
             left = LessCondition::Binary(LessBinaryCondition {
-                left: Box::new(left),
+                left: arena_box!(self, left),
                 op,
-                right: Box::new(right),
+                right: arena_box!(self, right),
                 span,
             });
         }
@@ -204,14 +204,16 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         Ok(left)
     }
 
-    pub(super) fn parse_less_interpolated_ident(&mut self) -> PResult<InterpolableIdent<'s>> {
+    pub(super) fn parse_less_interpolated_ident(&mut self) -> PResult<InterpolableIdent<'a>> {
         debug_assert_eq!(self.syntax, Syntax::Less);
 
         let (first, Span { start, mut end }) = match peek!(self) {
             TokenWithSpan { token: Token::Ident(..), .. } => {
                 let (ident, ident_span) = expect!(self, Ident);
                 (
-                    LessInterpolatedIdentElement::Static((ident, ident_span.clone()).into()),
+                    LessInterpolatedIdentElement::Static(
+                        self.interpolable_ident_static_part(ident, ident_span.clone()),
+                    ),
                     ident_span,
                 )
             }
@@ -266,12 +268,14 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
     pub(super) fn parse_less_interpolated_ident_rest(
         &mut self,
         end: &mut usize,
-    ) -> PResult<Vec<LessInterpolatedIdentElement<'s>>> {
-        let mut elements = vec![];
+    ) -> PResult<oxc_allocator::Vec<'a, LessInterpolatedIdentElement<'a>>> {
+        let mut elements = arena_vec!(self);
         loop {
             if let Some((token, span)) = self.tokenizer.scan_ident_template()? {
                 *end = span.end;
-                elements.push(LessInterpolatedIdentElement::Static((token, span).into()));
+                elements.push(LessInterpolatedIdentElement::Static(
+                    self.interpolable_ident_static_part(token, span),
+                ));
             } else {
                 match peek!(self) {
                     TokenWithSpan { token: Token::AtLBraceVar(..), span: at_lbrace_var_span }
@@ -301,16 +305,19 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
 
     pub(super) fn parse_less_maybe_mixin_call_or_with_lookups(
         &mut self,
-    ) -> PResult<ComponentValue<'s>> {
+    ) -> PResult<ComponentValue<'a>> {
         let mixin_call = self.parse::<LessMixinCall>()?;
         if matches!(peek!(self).token, Token::LBracket(..)) {
             let lookups = self.parse::<LessLookups>()?;
             let span = Span { start: mixin_call.span.start, end: lookups.span.end };
-            Ok(ComponentValue::LessNamespaceValue(Box::new(LessNamespaceValue {
-                callee: LessNamespaceValueCallee::LessMixinCall(mixin_call),
-                lookups,
-                span,
-            })))
+            Ok(ComponentValue::LessNamespaceValue(arena_box!(
+                self,
+                LessNamespaceValue {
+                    callee: LessNamespaceValueCallee::LessMixinCall(mixin_call),
+                    lookups,
+                    span,
+                }
+            )))
         } else {
             Ok(ComponentValue::LessMixinCall(mixin_call))
         }
@@ -318,7 +325,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
 
     pub(super) fn parse_less_maybe_variable_or_with_lookups(
         &mut self,
-    ) -> PResult<ComponentValue<'s>> {
+    ) -> PResult<ComponentValue<'a>> {
         let variable = self.parse::<LessVariable>()?;
         match peek!(self) {
             TokenWithSpan { token: Token::LBracket(..), span }
@@ -326,11 +333,14 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
             {
                 let lookups = self.parse::<LessLookups>()?;
                 let span = Span { start: variable.span.start, end: lookups.span.end };
-                Ok(ComponentValue::LessNamespaceValue(Box::new(LessNamespaceValue {
-                    callee: LessNamespaceValueCallee::LessVariable(variable),
-                    lookups,
-                    span,
-                })))
+                Ok(ComponentValue::LessNamespaceValue(arena_box!(
+                    self,
+                    LessNamespaceValue {
+                        callee: LessNamespaceValueCallee::LessVariable(variable),
+                        lookups,
+                        span,
+                    }
+                )))
             }
             _ => Ok(ComponentValue::LessVariable(variable)),
         }
@@ -339,7 +349,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
     pub(super) fn parse_less_operation(
         &mut self,
         allow_mixin_call: bool,
-    ) -> PResult<ComponentValue<'s>> {
+    ) -> PResult<ComponentValue<'a>> {
         self.parse_less_operation_recursively(allow_mixin_call, 0)
     }
 
@@ -347,7 +357,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         &mut self,
         allow_mixin_call: bool,
         precedence: u8,
-    ) -> PResult<ComponentValue<'s>> {
+    ) -> PResult<ComponentValue<'a>> {
         let mut left = if precedence >= PRECEDENCE_MULTIPLY {
             match peek!(self).token {
                 Token::LParen(..) => self
@@ -452,9 +462,9 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                             .map(|value| ComponentValue::Number(Number { value, raw, span }))?
                     };
                     left = ComponentValue::LessBinaryOperation(LessBinaryOperation {
-                        left: Box::new(left),
+                        left: arena_box!(self, left),
                         op,
-                        right: Box::new(right),
+                        right: arena_box!(self, right),
                         span,
                     });
                     continue;
@@ -476,7 +486,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                     };
                     let span = Span { start: left.span().start, end: dimension_span.end };
                     let right = {
-                        (
+                        self.dimension(
                             crate::token::Dimension {
                                 value: crate::token::Number {
                                     raw: unsafe {
@@ -490,13 +500,12 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                             },
                             Span { start: dimension_span.start + 1, end: dimension_span.end },
                         )
-                            .try_into()
-                            .map(ComponentValue::Dimension)?
+                        .map(ComponentValue::Dimension)?
                     };
                     left = ComponentValue::LessBinaryOperation(LessBinaryOperation {
-                        left: Box::new(left),
+                        left: arena_box!(self, left),
                         op,
-                        right: Box::new(right),
+                        right: arena_box!(self, right),
                         span,
                     });
                     continue;
@@ -507,9 +516,9 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
             let right = self.parse_less_operation_recursively(allow_mixin_call, precedence + 1)?;
             let span = Span { start: left.span().start, end: right.span().end };
             left = ComponentValue::LessBinaryOperation(LessBinaryOperation {
-                left: Box::new(left),
+                left: arena_box!(self, left),
                 op,
-                right: Box::new(right),
+                right: arena_box!(self, right),
                 span,
             });
         }
@@ -520,7 +529,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
     fn parse_less_parenthesized_operation(
         &mut self,
         allow_mixin_call: bool,
-    ) -> PResult<LessParenthesizedOperation<'s>> {
+    ) -> PResult<LessParenthesizedOperation<'a>> {
         let (_, Span { start, .. }) = expect!(self, LParen);
         let operation = self
             .with_state(ParserState {
@@ -529,10 +538,13 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
             })
             .parse_less_operation(allow_mixin_call)?;
         let (_, Span { end, .. }) = expect!(self, RParen);
-        Ok(LessParenthesizedOperation { operation: Box::new(operation), span: Span { start, end } })
+        Ok(LessParenthesizedOperation {
+            operation: arena_box!(self, operation),
+            span: Span { start, end },
+        })
     }
 
-    pub(super) fn parse_less_qualified_rule(&mut self) -> PResult<Statement<'s>> {
+    pub(super) fn parse_less_qualified_rule(&mut self) -> PResult<Statement<'a>> {
         debug_assert_eq!(self.syntax, Syntax::Less);
 
         let selector_list = self
@@ -570,7 +582,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
 
     pub(super) fn parse_maybe_hex_color_or_less_mixin_call(
         &mut self,
-    ) -> PResult<ComponentValue<'s>> {
+    ) -> PResult<ComponentValue<'a>> {
         debug_assert_eq!(self.syntax, Syntax::Less);
 
         let attempt = self.try_parse(|parser| {
@@ -599,7 +611,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
     pub(super) fn parse_maybe_less_list(
         &mut self,
         allow_comma: bool,
-    ) -> PResult<ComponentValue<'s>> {
+    ) -> PResult<ComponentValue<'a>> {
         use util::ListSeparatorKind;
 
         let single_value = if allow_comma {
@@ -610,8 +622,8 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
             self.parse_less_operation(/* allow_mixin_call */ true)?
         };
 
-        let mut elements = vec![];
-        let mut comma_spans: Option<Vec<_>> = None;
+        let mut elements = arena_vec!(self);
+        let mut comma_spans: Option<oxc_allocator::Vec<'a, Span>> = None;
         let mut separator = ListSeparatorKind::Unknown;
         let mut end = single_value.span().end;
         loop {
@@ -638,7 +650,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                         if let Some(spans) = &mut comma_spans {
                             spans.push(span);
                         } else {
-                            comma_spans = Some(vec![span]);
+                            comma_spans = Some(arena_vec!(self; span));
                         }
                     }
                 }
@@ -684,8 +696,8 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessConditions<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessConditions<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let when_span = match bump!(input) {
             TokenWithSpan { token: Token::Ident(ident), span } if ident.raw == "when" => span,
             TokenWithSpan { span, .. } => {
@@ -696,8 +708,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessConditions<'s> {
         let first = input.parse_less_condition(true)?;
         let mut span = first.span().clone();
 
-        let mut conditions = vec![first];
-        let mut comma_spans = vec![];
+        let mut conditions = arena_vec!(input; first);
+        let mut comma_spans = arena_vec!(input);
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             conditions.push(input.parse_less_condition(true)?);
@@ -711,25 +723,28 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessConditions<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessDetachedRuleset<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessDetachedRuleset<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let block = input.parse::<SimpleBlock>()?;
         let span = block.span.clone();
         Ok(LessDetachedRuleset { block, span })
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessEscapedStr<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessEscapedStr<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = expect!(input, Tilde);
-        let str: Str = input.tokenizer.scan_string_only()?.into();
+        let str = {
+            let (str, span) = input.tokenizer.scan_string_only()?;
+            input.str(str, span)
+        };
         let span = Span { start, end: str.span().end };
         Ok(LessEscapedStr { str, span })
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessExtend<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessExtend<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let mut selector = input.parse::<ComplexSelector>()?;
 
         let span = selector.span.clone();
@@ -755,24 +770,29 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessExtend<'s> {
                 })),
             ] = &children[..]
         {
-            all = Some(token_all.clone());
+            all = Some(Ident {
+                name: token_all.name,
+                raw: token_all.raw,
+                span: token_all.span.clone(),
+            });
             selector.span.end = complex_child.span().end;
-            selector.children.truncate(selector.children.len() - 2);
+            let len = selector.children.len();
+            selector.children.truncate(len - 2);
         }
 
         Ok(LessExtend { selector, all, span })
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessExtendList<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessExtendList<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert_eq!(input.syntax, Syntax::Less);
 
         let first = input.parse::<LessExtend>()?;
         let mut span = first.span.clone();
 
-        let mut elements = vec![first];
-        let mut comma_spans = vec![];
+        let mut elements = arena_vec!(input; first);
+        let mut comma_spans = arena_vec!(input);
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             elements.push(input.parse()?);
@@ -786,8 +806,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessExtendList<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessExtendRule<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessExtendRule<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let nesting_selector = input.parse::<NestingSelector>()?;
         if nesting_selector.suffix.is_some() {
             return Err(Error {
@@ -817,19 +837,19 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessExtendRule<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessFormatFunction {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessFormatFunction {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, span) = expect!(input, Percent);
         Ok(LessFormatFunction { span })
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessImportOptions<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessImportOptions<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = expect!(input, LParen);
 
-        let mut names = Vec::with_capacity(1);
-        let mut comma_spans = vec![];
+        let mut names = input.vec_with_capacity(1);
+        let mut comma_spans = arena_vec!(input);
         while let Token::Ident(crate::token::Ident {
             raw: "less" | "css" | "multiple" | "once" | "inline" | "reference" | "optional",
             ..
@@ -848,8 +868,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessImportOptions<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessImportPrelude<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessImportPrelude<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let options = input.parse::<LessImportOptions>()?;
         let start = options.span.start;
 
@@ -871,13 +891,18 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessImportPrelude<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessInterpolatedStr<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessInterpolatedStr<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (first, first_span) = expect!(input, StrTemplate);
         let quote = first.raw.chars().next().unwrap();
         debug_assert!(quote == '\'' || quote == '"');
         let mut span = first_span.clone();
-        let mut elements = vec![LessInterpolatedStrElement::Static((first, first_span).into())];
+        let mut elements = arena_vec!(
+            input;
+            LessInterpolatedStrElement::Static(
+                input.interpolable_str_static_part(first, first_span)
+            )
+        );
 
         let mut is_parsing_static_part = false;
         loop {
@@ -885,7 +910,9 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessInterpolatedStr<'s> {
                 let (token, str_tpl_span) = input.tokenizer.scan_string_template(quote)?;
                 let tail = token.tail;
                 let end = str_tpl_span.end;
-                elements.push(LessInterpolatedStrElement::Static((token, str_tpl_span).into()));
+                elements.push(LessInterpolatedStrElement::Static(
+                    input.interpolable_str_static_part(token, str_tpl_span),
+                ));
                 if tail {
                     span.end = end;
                     break;
@@ -898,11 +925,11 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessInterpolatedStr<'s> {
                 let end = expect!(input, RBrace).1.end;
                 elements.push(match input.source.as_bytes().get(start) {
                     Some(b'@') => LessInterpolatedStrElement::Variable(LessVariableInterpolation {
-                        name: (name, name_span).into(),
+                        name: input.ident(name, name_span),
                         span: Span { start, end },
                     }),
                     Some(b'$') => LessInterpolatedStrElement::Property(LessPropertyInterpolation {
-                        name: (name, name_span).into(),
+                        name: input.ident(name, name_span),
                         span: Span { start, end },
                     }),
                     _ => unreachable!(),
@@ -915,8 +942,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessInterpolatedStr<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessJavaScriptSnippet<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessJavaScriptSnippet<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let tilde = eat!(input, Tilde);
         let (token, span) = expect!(input, BacktickCode);
 
@@ -932,15 +959,15 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessJavaScriptSnippet<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessListFunction {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessListFunction {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, span) = expect!(input, Tilde);
         Ok(LessListFunction { span })
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessLookup<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessLookup<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert_eq!(input.syntax, Syntax::Less);
 
         let (_, Span { start, .. }) = expect!(input, LBracket);
@@ -951,8 +978,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessLookup<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessLookupName<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessLookupName<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert_eq!(input.syntax, Syntax::Less);
 
         match peek!(input).token {
@@ -964,14 +991,14 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessLookupName<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessLookups<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessLookups<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert_eq!(input.syntax, Syntax::Less);
 
         let first = input.parse::<LessLookup>()?;
         let mut span = first.span.clone();
 
-        let mut lookups = vec![first];
+        let mut lookups = arena_vec!(input; first);
         while let Token::LBracket(..) = peek!(input).token {
             lookups.push(input.parse()?);
         }
@@ -983,8 +1010,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessLookups<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessMixinCall<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessMixinCall<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert_eq!(input.syntax, Syntax::Less);
 
         let callee = input.parse::<LessMixinCallee>()?;
@@ -992,17 +1019,19 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessMixinCall<'s> {
         let mut end = callee.span.end;
         let args = if let Some((_, lparen_span)) = eat!(input, LParen) {
             let mut semicolon_comes_at = 0;
-            let mut args = vec![];
-            let mut comma_spans = vec![];
-            let mut semicolon_spans = vec![];
+            let mut args = arena_vec!(input);
+            let mut comma_spans = arena_vec!(input);
+            let mut semicolon_spans = arena_vec!(input);
             'args: loop {
                 match peek!(input).token {
                     Token::RParen(..) => {
                         let TokenWithSpan { span, .. } = bump!(input);
                         if semicolon_comes_at > 0 {
+                            let comma_spans = mem::replace(&mut comma_spans, arena_vec!(input));
                             wrap_less_mixin_args_into_less_list(
+                                input.allocator(),
                                 &mut args,
-                                mem::take(&mut comma_spans),
+                                comma_spans,
                                 semicolon_comes_at,
                             )
                             .map_err(|kind| Error {
@@ -1089,9 +1118,11 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessMixinCall<'s> {
                     }
                     Token::Semicolon(..) => {
                         let TokenWithSpan { span, .. } = bump!(input);
+                        let comma_spans = mem::replace(&mut comma_spans, arena_vec!(input));
                         wrap_less_mixin_args_into_less_list(
+                            input.allocator(),
                             &mut args,
-                            mem::take(&mut comma_spans),
+                            comma_spans,
                             semicolon_comes_at,
                         )
                         .map_err(|kind| Error { kind, span: span.clone() })?;
@@ -1140,13 +1171,15 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessMixinCall<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessMixinCallee<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessMixinCallee<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first_name = input.parse::<LessMixinName>()?;
         let mut span = first_name.span().clone();
 
-        let mut children =
-            vec![LessMixinCalleeChild { name: first_name, combinator: None, span: span.clone() }];
+        let mut children = arena_vec!(
+            input;
+            LessMixinCalleeChild { name: first_name, combinator: None, span: span.clone() }
+        );
         loop {
             let combinator = eat!(input, GreaterThan)
                 .map(|(_, span)| Combinator { kind: CombinatorKind::Child, span });
@@ -1173,8 +1206,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessMixinCallee<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessMixinDefinition<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessMixinDefinition<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert_eq!(input.syntax, Syntax::Less);
 
         let name = input.parse::<LessMixinName>()?;
@@ -1182,9 +1215,9 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessMixinDefinition<'s> {
         let (_, lparen_span) = expect!(input, LParen);
         let rparen_span;
         let mut semicolon_comes_at = 0;
-        let mut params = vec![];
-        let mut comma_spans = vec![];
-        let mut semicolon_spans = vec![];
+        let mut params = arena_vec!(input);
+        let mut comma_spans = arena_vec!(input);
+        let mut semicolon_spans = arena_vec!(input);
         'params: loop {
             match peek!(input).token {
                 Token::RParen(..) => {
@@ -1279,9 +1312,11 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessMixinDefinition<'s> {
             match bump!(input) {
                 TokenWithSpan { token: Token::RParen(..), span } => {
                     if semicolon_comes_at > 0 {
+                        let comma_spans = mem::replace(&mut comma_spans, arena_vec!(input));
                         wrap_less_mixin_params_into_less_list(
+                            input.allocator(),
                             &mut params,
-                            mem::take(&mut comma_spans),
+                            comma_spans,
                             semicolon_comes_at,
                         )
                         .map_err(|kind| Error {
@@ -1301,9 +1336,11 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessMixinDefinition<'s> {
                     comma_spans.push(span);
                 }
                 TokenWithSpan { token: Token::Semicolon(..), span } => {
+                    let comma_spans = mem::replace(&mut comma_spans, arena_vec!(input));
                     wrap_less_mixin_params_into_less_list(
+                        input.allocator(),
                         &mut params,
-                        mem::take(&mut comma_spans),
+                        comma_spans,
                         semicolon_comes_at,
                     )
                     .map_err(|kind| Error { kind, span: span.clone() })?;
@@ -1348,11 +1385,12 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessMixinDefinition<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessMixinName<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessMixinName<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match bump!(input) {
             TokenWithSpan { token: Token::Dot(..), span: dot_span } => {
-                let ident: Ident = expect_without_ws_or_comments!(input, Ident).into();
+                let (ident, ident_span) = expect_without_ws_or_comments!(input, Ident);
+                let ident = input.ident(ident, ident_span);
                 let span = Span { start: dot_span.start, end: ident.span.end };
                 Ok(LessMixinName::ClassSelector(ClassSelector {
                     name: InterpolableIdent::Literal(ident),
@@ -1368,7 +1406,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessMixinName<'s> {
                         .recoverable_errors
                         .push(Error { kind: ErrorKind::InvalidIdSelectorName, span: span.clone() });
                 }
-                let name = if hash.escaped { util::handle_escape(raw) } else { Cow::from(raw) };
+                let name =
+                    if hash.escaped { util::handle_escape_in(raw, input.allocator()) } else { raw };
                 let name_span = Span { start: span.start + 1, end: span.end };
                 Ok(LessMixinName::IdSelector(IdSelector {
                     name: InterpolableIdent::Literal(Ident { name, raw, span: name_span }),
@@ -1392,8 +1431,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessMixinName<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessMixinParameterName<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessMixinParameterName<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if matches!(peek!(input).token, Token::AtKeyword(..)) {
             input.parse().map(LessMixinParameterName::Variable)
         } else {
@@ -1402,8 +1441,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessMixinParameterName<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessNamespaceValue<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessNamespaceValue<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let callee = input.parse::<LessNamespaceValueCallee>()?;
         let callee_span = callee.span();
 
@@ -1415,8 +1454,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessNamespaceValue<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessNamespaceValueCallee<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessNamespaceValueCallee<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if matches!(peek!(input).token, Token::AtKeyword(..)) {
             input.parse().map(LessNamespaceValueCallee::LessVariable)
         } else {
@@ -1425,18 +1464,22 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessNamespaceValueCallee<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessNegativeValue<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessNegativeValue<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, minus_span) = expect!(input, Minus);
         let value = match peek!(input) {
             TokenWithSpan {
                 token: Token::AtKeyword(..) | Token::At(..) | Token::DollarVar(..),
                 span,
-            } if minus_span.end == span.start => Box::new(input.parse_component_value_atom()?),
+            } if minus_span.end == span.start => {
+                let value = input.parse_component_value_atom()?;
+                arena_box!(input, value)
+            }
             TokenWithSpan { token: Token::LParen(..), span } if minus_span.end == span.start => {
-                Box::new(ComponentValue::LessParenthesizedOperation(
+                let value = ComponentValue::LessParenthesizedOperation(
                     input.parse_less_parenthesized_operation(/* allow_mixin_call */ true)?,
-                ))
+                );
+                arena_box!(input, value)
             }
             TokenWithSpan { token, span } => {
                 use crate::{
@@ -1458,15 +1501,15 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessNegativeValue<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessPercentKeyword {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessPercentKeyword {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, span) = expect!(input, Percent);
         Ok(LessPercentKeyword { span })
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessPlugin<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessPlugin<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert_eq!(input.syntax, Syntax::Less);
 
         let mut start = None;
@@ -1488,8 +1531,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessPlugin<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessPluginPath<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessPluginPath<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if let Token::Str(..) = peek!(input).token {
             input.parse().map(LessPluginPath::Str)
         } else {
@@ -1498,19 +1541,19 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessPluginPath<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessPropertyInterpolation<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessPropertyInterpolation<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (dollar_lbrace_var, span) = expect!(input, DollarLBraceVar);
         Ok(LessPropertyInterpolation {
-            name: (dollar_lbrace_var.ident, Span { start: span.start + 2, end: span.end - 1 })
-                .into(),
+            name: input
+                .ident(dollar_lbrace_var.ident, Span { start: span.start + 2, end: span.end - 1 }),
             span,
         })
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Option<LessPropertyMerge> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for Option<LessPropertyMerge> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert_eq!(input.syntax, Syntax::Less);
 
         match &peek!(input).token {
@@ -1527,28 +1570,28 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Option<LessPropertyMerge> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessPropertyVariable<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessPropertyVariable<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (dollar_var, span) = expect!(input, DollarVar);
         Ok(LessPropertyVariable {
-            name: Ident::from((dollar_var.ident, Span { start: span.start + 1, end: span.end })),
+            name: input.ident(dollar_var.ident, Span { start: span.start + 1, end: span.end }),
             span,
         })
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessVariable<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessVariable<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (at_keyword, span) = expect!(input, AtKeyword);
         Ok(LessVariable {
-            name: (at_keyword.ident, Span { start: span.start + 1, end: span.end }).into(),
+            name: input.ident(at_keyword.ident, Span { start: span.start + 1, end: span.end }),
             span,
         })
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessVariableCall<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessVariableCall<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let variable = input.parse::<LessVariable>()?;
         expect_without_ws_or_comments!(input, LParen);
         let (_, Span { end, .. }) = expect!(input, RParen);
@@ -1558,8 +1601,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessVariableCall<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessVariableDeclaration<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessVariableDeclaration<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert_eq!(input.syntax, Syntax::Less);
 
         let name = input.parse::<LessVariable>()?;
@@ -1580,18 +1623,19 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessVariableDeclaration<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessVariableInterpolation<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessVariableInterpolation<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (at_lbrace_var, span) = expect!(input, AtLBraceVar);
         Ok(LessVariableInterpolation {
-            name: (at_lbrace_var.ident, Span { start: span.start + 2, end: span.end - 1 }).into(),
+            name: input
+                .ident(at_lbrace_var.ident, Span { start: span.start + 2, end: span.end - 1 }),
             span,
         })
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessVariableVariable<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LessVariableVariable<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, at_span) = expect!(input, At);
         let variable = input.parse::<LessVariable>()?;
         util::assert_no_ws_or_comment(&at_span, &variable.span)?;
@@ -1601,27 +1645,25 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LessVariableVariable<'s> {
     }
 }
 
-fn wrap_less_mixin_params_into_less_list(
-    params: &mut Vec<LessMixinParameter<'_>>,
-    comma_spans: Vec<Span>,
+fn wrap_less_mixin_params_into_less_list<'a>(
+    allocator: &'a oxc_allocator::Allocator,
+    params: &mut oxc_allocator::Vec<'a, LessMixinParameter<'a>>,
+    comma_spans: oxc_allocator::Vec<'a, Span>,
     index: usize,
 ) -> Result<(), ErrorKind> {
     if let [first, .., last] = &params[index..] {
         let span = Span { start: first.span().start, end: last.span().end };
-        let elements = params
-            .drain(index..)
-            .map(|param| {
-                if let LessMixinParameter::Unnamed(LessMixinUnnamedParameter { value, .. }) = param
-                {
-                    Ok(value)
-                } else {
-                    // reject code like this:
-                    // .mixin(@a: 5, @b: 6; @c: 7) {}
-                    // .mixin(@a: 5; @b: 6, @c: 7) {}
-                    Err(ErrorKind::MixedDelimiterKindInLessMixin)
-                }
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let mut elements = oxc_allocator::Vec::with_capacity_in(params.len() - index, allocator);
+        for param in params.drain(index..) {
+            if let LessMixinParameter::Unnamed(LessMixinUnnamedParameter { value, .. }) = param {
+                elements.push(value);
+            } else {
+                // reject code like this:
+                // .mixin(@a: 5, @b: 6; @c: 7) {}
+                // .mixin(@a: 5; @b: 6, @c: 7) {}
+                return Err(ErrorKind::MixedDelimiterKindInLessMixin);
+            }
+        }
         debug_assert!(elements.len() - comma_spans.len() <= 1);
         params.push(LessMixinParameter::Unnamed(LessMixinUnnamedParameter {
             value: ComponentValue::LessList(LessList {
@@ -1635,26 +1677,25 @@ fn wrap_less_mixin_params_into_less_list(
     Ok(())
 }
 
-fn wrap_less_mixin_args_into_less_list(
-    args: &mut Vec<LessMixinArgument<'_>>,
-    comma_spans: Vec<Span>,
+fn wrap_less_mixin_args_into_less_list<'a>(
+    allocator: &'a oxc_allocator::Allocator,
+    args: &mut oxc_allocator::Vec<'a, LessMixinArgument<'a>>,
+    comma_spans: oxc_allocator::Vec<'a, Span>,
     index: usize,
 ) -> Result<(), ErrorKind> {
     if let [first, .., last] = &args[index..] {
         let span = Span { start: first.span().start, end: last.span().end };
-        let elements = args
-            .drain(index..)
-            .map(|param| {
-                if let LessMixinArgument::Value(value) = param {
-                    Ok(value)
-                } else {
-                    // reject code like this:
-                    // .mixin(@a: 5, @b: 6; @c: 7) {}
-                    // .mixin(@a: 5; @b: 6, @c: 7) {}
-                    Err(ErrorKind::MixedDelimiterKindInLessMixin)
-                }
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let mut elements = oxc_allocator::Vec::with_capacity_in(args.len() - index, allocator);
+        for arg in args.drain(index..) {
+            if let LessMixinArgument::Value(value) = arg {
+                elements.push(value);
+            } else {
+                // reject code like this:
+                // .mixin(@a: 5, @b: 6; @c: 7) {}
+                // .mixin(@a: 5; @b: 6, @c: 7) {}
+                return Err(ErrorKind::MixedDelimiterKindInLessMixin);
+            }
+        }
         debug_assert!(elements.len() - comma_spans.len() <= 1);
         args.push(LessMixinArgument::Value(ComponentValue::LessList(LessList {
             elements,

--- a/crates/oxc_css_parser/src/parser/macros.rs
+++ b/crates/oxc_css_parser/src/parser/macros.rs
@@ -115,3 +115,28 @@ macro_rules! peek {
         }
     }};
 }
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! arena_box {
+    ($parser:expr, $value:expr) => {{ oxc_allocator::Box::new_in($value, $parser.allocator()) }};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! arena_vec {
+    ($parser:expr) => {{
+        oxc_allocator::Vec::new_in($parser.allocator())
+    }};
+    ($parser:expr; $($value:expr),+ $(,)?) => {{
+        let mut vec = oxc_allocator::Vec::with_capacity_in(
+            <[()]>::len(&[$($crate::arena_vec!(@unit $value)),+]),
+            $parser.allocator(),
+        );
+        $(vec.push($value);)+
+        vec
+    }};
+    (@unit $value:expr) => {
+        ()
+    };
+}

--- a/crates/oxc_css_parser/src/parser/mod.rs
+++ b/crates/oxc_css_parser/src/parser/mod.rs
@@ -1,11 +1,17 @@
 use self::state::ParserState;
 use crate::{
     ParserOptions,
+    ast::{
+        Dimension, Ident, InterpolableIdentStaticPart, InterpolableStrStaticPart,
+        InterpolableUrlStaticPart, Str,
+    },
     config::Syntax,
     error::{Error, PResult},
-    tokenizer::{Tokenizer, token::TokenWithSpan},
+    tokenizer::{TokenWithSpan, Tokenizer, token},
+    util,
 };
 pub use builder::ParserBuilder;
+use oxc_allocator::{Allocator, Vec as ArenaVec};
 
 mod at_rule;
 mod builder;
@@ -19,31 +25,33 @@ mod stmt;
 mod token_seq;
 mod value;
 
-pub trait Parse<'cmt, 's: 'cmt>: Sized {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self>;
+pub trait Parse<'a>: Sized {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self>;
 }
 
 /// Create a parser with some source code, then parse it.
-pub struct Parser<'cmt, 's: 'cmt> {
-    source: &'s str,
+pub struct Parser<'a> {
+    allocator: &'a Allocator,
+    source: &'a str,
     syntax: Syntax,
     options: ParserOptions,
-    tokenizer: Tokenizer<'cmt, 's>,
+    tokenizer: Tokenizer<'a>,
     state: ParserState,
     recoverable_errors: Vec<Error>,
-    cached_token: Option<TokenWithSpan<'s>>,
+    cached_token: Option<TokenWithSpan<'a>>,
 }
 
-impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
+impl<'a> Parser<'a> {
     /// Create a parser with the given source code and specified syntax.
     /// If you need to control more options, please use [`ParserBuilder`].
-    pub fn new(source: &'s str, syntax: Syntax) -> Self {
+    pub fn new(allocator: &'a Allocator, source: &'a str, syntax: Syntax) -> Self {
         let source = source.strip_prefix('\u{feff}').unwrap_or(source);
         Parser {
+            allocator,
             source,
             syntax,
             options: Default::default(),
-            tokenizer: Tokenizer::new(source, syntax, None, None),
+            tokenizer: Tokenizer::new(allocator, source, syntax, None, false),
             state: Default::default(),
             recoverable_errors: vec![],
             cached_token: None,
@@ -53,7 +61,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
     /// Start to parse.
     pub fn parse<T>(&mut self) -> PResult<T>
     where
-        T: Parse<'cmt, 's>,
+        T: Parse<'a>,
     {
         T::parse(self)
     }
@@ -64,18 +72,114 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         &self.recoverable_errors
     }
 
+    /// Retrieve collected comments.
+    #[inline]
+    pub fn comments(&self) -> &[crate::tokenizer::token::Comment<'a>] {
+        self.tokenizer.comments()
+    }
+
+    #[inline]
+    pub(crate) fn allocator(&self) -> &'a Allocator {
+        self.allocator
+    }
+
+    #[inline]
+    pub(crate) fn vec<T>(&self) -> ArenaVec<'a, T> {
+        ArenaVec::new_in(self.allocator)
+    }
+
+    #[inline]
+    pub(crate) fn vec_with_capacity<T>(&self, capacity: usize) -> ArenaVec<'a, T> {
+        ArenaVec::with_capacity_in(capacity, self.allocator)
+    }
+
+    #[inline]
+    pub(crate) fn ident(&self, token: token::Ident<'a>, span: crate::Span) -> Ident<'a> {
+        Ident { name: self.ident_name(&token), raw: token.raw, span }
+    }
+
+    pub(crate) fn dimension(
+        &self,
+        token: token::Dimension<'a>,
+        span: crate::Span,
+    ) -> PResult<Dimension<'a>> {
+        let value_span = crate::Span { start: span.start, end: span.start + token.value.raw.len() };
+        let unit_span = crate::Span { start: span.start + token.value.raw.len(), end: span.end };
+        let value = (token.value, value_span).try_into()?;
+        let unit = self.ident(token.unit, unit_span);
+        let kind = convert::dimension_kind(unit.name);
+        Ok(Dimension { value, unit, kind, span })
+    }
+
+    #[inline]
+    pub(crate) fn interpolable_ident_static_part(
+        &self,
+        token: token::Ident<'a>,
+        span: crate::Span,
+    ) -> InterpolableIdentStaticPart<'a> {
+        InterpolableIdentStaticPart { value: self.ident_name(&token), raw: token.raw, span }
+    }
+
+    #[inline]
+    pub(crate) fn str(&self, token: token::Str<'a>, span: crate::Span) -> Str<'a> {
+        let raw_without_quotes = unsafe { token.raw.get_unchecked(1..token.raw.len() - 1) };
+        let value = if token.escaped {
+            util::handle_escape_in(raw_without_quotes, self.allocator)
+        } else {
+            raw_without_quotes
+        };
+        Str { value, raw: token.raw, span }
+    }
+
+    #[inline]
+    pub(crate) fn interpolable_str_static_part(
+        &self,
+        token: token::StrTemplate<'a>,
+        span: crate::Span,
+    ) -> InterpolableStrStaticPart<'a> {
+        let raw_without_quotes = if token.tail {
+            unsafe { token.raw.get_unchecked(0..token.raw.len() - 1) }
+        } else if token.head {
+            unsafe { token.raw.get_unchecked(1..token.raw.len()) }
+        } else {
+            token.raw
+        };
+        let value = if token.escaped {
+            util::handle_escape_in(raw_without_quotes, self.allocator)
+        } else {
+            raw_without_quotes
+        };
+        InterpolableStrStaticPart { value, raw: token.raw, span }
+    }
+
+    #[inline]
+    pub(crate) fn interpolable_url_static_part(
+        &self,
+        token: token::UrlTemplate<'a>,
+        span: crate::Span,
+    ) -> InterpolableUrlStaticPart<'a> {
+        let value = if token.escaped {
+            util::handle_escape_in(token.raw, self.allocator)
+        } else {
+            token.raw
+        };
+        InterpolableUrlStaticPart { value, raw: token.raw, span }
+    }
+
+    #[inline]
+    fn ident_name(&self, token: &token::Ident<'a>) -> &'a str {
+        if token.escaped { util::handle_escape_in(token.raw, self.allocator) } else { token.raw }
+    }
+
     fn try_parse<R, F: FnOnce(&mut Self) -> PResult<R>>(&mut self, f: F) -> PResult<R> {
         let tokenizer_state = self.tokenizer.state.clone();
-        let comments_count =
-            if let Some(comments) = &self.tokenizer.comments { comments.len() } else { 0 };
+        let comments_count = self.tokenizer.comments_count();
         let recoverable_errors_count = self.recoverable_errors.len();
         let cached_token = self.cached_token.clone();
         let result = f(self);
         if result.is_err() {
             self.tokenizer.state = tokenizer_state;
-            if let Some(comments) = &mut self.tokenizer.comments {
-                comments.truncate(comments_count);
-            }
+            self.tokenizer.truncate_comments(comments_count);
             self.recoverable_errors.truncate(recoverable_errors_count);
             self.cached_token = cached_token;
         }

--- a/crates/oxc_css_parser/src/parser/sass.rs
+++ b/crates/oxc_css_parser/src/parser/sass.rs
@@ -3,7 +3,7 @@ use super::{
     state::{ParserState, SASS_CTX_ALLOW_DIV, SASS_CTX_IN_PARENS},
 };
 use crate::{
-    Parse,
+    Parse, arena_box, arena_vec,
     ast::*,
     bump,
     config::Syntax,
@@ -22,18 +22,18 @@ const PRECEDENCE_EQUALITY: u8 = 3;
 const PRECEDENCE_AND: u8 = 2;
 const PRECEDENCE_OR: u8 = 1;
 
-type SassParams<'s> = (
-    Vec<SassParameter<'s>>,
-    Option<SassArbitraryParameter<'s>>,
-    Vec<Span>, // comma spans
-    usize,     // end pos
+type SassParams<'a> = (
+    oxc_allocator::Vec<'a, SassParameter<'a>>,
+    Option<SassArbitraryParameter<'a>>,
+    oxc_allocator::Vec<'a, Span>, // comma spans
+    usize,                        // end pos
 );
 
-impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
+impl<'a> Parser<'a> {
     pub(super) fn parse_maybe_sass_list(
         &mut self,
         allow_comma: bool,
-    ) -> PResult<ComponentValue<'s>> {
+    ) -> PResult<ComponentValue<'a>> {
         use util::ListSeparatorKind;
 
         let single_value = if allow_comma {
@@ -44,8 +44,8 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
             self.parse_sass_bin_expr(/* allow_comparison */ true)?
         };
 
-        let mut elements = vec![];
-        let mut comma_spans: Option<Vec<_>> = None;
+        let mut elements = arena_vec!(self);
+        let mut comma_spans: Option<oxc_allocator::Vec<'a, Span>> = None;
         let mut separator = ListSeparatorKind::Unknown;
         let mut end = single_value.span().end;
         loop {
@@ -81,7 +81,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                         if let Some(spans) = &mut comma_spans {
                             spans.push(span);
                         } else {
-                            comma_spans = Some(vec![span]);
+                            comma_spans = Some(arena_vec!(self; span));
                         }
                     }
                 }
@@ -129,7 +129,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
     pub(super) fn parse_sass_bin_expr(
         &mut self,
         allow_comparison: bool,
-    ) -> PResult<ComponentValue<'s>> {
+    ) -> PResult<ComponentValue<'a>> {
         debug_assert!(matches!(self.syntax, Syntax::Scss | Syntax::Sass));
         self.parse_sass_bin_expr_recursively(0, allow_comparison)
     }
@@ -138,7 +138,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         &mut self,
         precedence: u8,
         allow_comparison: bool,
-    ) -> PResult<ComponentValue<'s>> {
+    ) -> PResult<ComponentValue<'a>> {
         let mut left = if precedence >= PRECEDENCE_MULTIPLY {
             self.parse_sass_unary_expression()?
         } else {
@@ -282,9 +282,9 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                             .map(|value| ComponentValue::Number(Number { value, raw, span }))?
                     };
                     left = ComponentValue::SassBinaryExpression(SassBinaryExpression {
-                        left: Box::new(left),
+                        left: arena_box!(self, left),
                         op,
-                        right: Box::new(right),
+                        right: arena_box!(self, right),
                         span,
                     });
                     continue;
@@ -306,7 +306,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                     };
                     let span = Span { start: left.span().start, end: dimension_span.end };
                     let right = {
-                        (
+                        self.dimension(
                             crate::token::Dimension {
                                 value: crate::token::Number {
                                     raw: unsafe {
@@ -320,13 +320,12 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                             },
                             Span { start: dimension_span.start + 1, end: dimension_span.end },
                         )
-                            .try_into()
-                            .map(ComponentValue::Dimension)?
+                        .map(ComponentValue::Dimension)?
                     };
                     left = ComponentValue::SassBinaryExpression(SassBinaryExpression {
-                        left: Box::new(left),
+                        left: arena_box!(self, left),
                         op,
-                        right: Box::new(right),
+                        right: arena_box!(self, right),
                         span,
                     });
                     continue;
@@ -342,9 +341,9 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
 
             let span = Span { start: left.span().start, end: right.span().end };
             left = ComponentValue::SassBinaryExpression(SassBinaryExpression {
-                left: Box::new(left),
+                left: arena_box!(self, left),
                 op: operator,
-                right: Box::new(right),
+                right: arena_box!(self, right),
                 span,
             });
         }
@@ -352,8 +351,10 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         Ok(left)
     }
 
-    fn parse_sass_flags(&mut self) -> PResult<(Vec<SassFlag<'s>>, Option<usize>)> {
-        let mut flags: Vec<SassFlag<'s>> = Vec::with_capacity(1);
+    fn parse_sass_flags(
+        &mut self,
+    ) -> PResult<(oxc_allocator::Vec<'a, SassFlag<'a>>, Option<usize>)> {
+        let mut flags: oxc_allocator::Vec<'a, SassFlag<'a>> = self.vec_with_capacity(1);
         let mut end = None;
         while let Some((_, exclamation_span)) = eat!(self, Exclamation) {
             let keyword = self.parse::<Ident>()?;
@@ -361,7 +362,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
             util::assert_no_ws_or_comment(&exclamation_span, &keyword_span)?;
             end = Some(keyword_span.end);
 
-            match &*keyword.name {
+            match keyword.name {
                 "default" => {
                     if flags.iter().any(|flag| flag.keyword.name == "default") {
                         self.recoverable_errors.push(Error {
@@ -393,14 +394,16 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         Ok((flags, end))
     }
 
-    pub(super) fn parse_sass_interpolated_ident(&mut self) -> PResult<InterpolableIdent<'s>> {
+    pub(super) fn parse_sass_interpolated_ident(&mut self) -> PResult<InterpolableIdent<'a>> {
         debug_assert!(matches!(self.syntax, Syntax::Scss | Syntax::Sass));
 
         let (first, Span { start, mut end }) = match peek!(self) {
             TokenWithSpan { token: Token::Ident(..), .. } => {
                 let (ident, ident_span) = expect!(self, Ident);
                 (
-                    SassInterpolatedIdentElement::Static((ident, ident_span.clone()).into()),
+                    SassInterpolatedIdentElement::Static(
+                        self.interpolable_ident_static_part(ident, ident_span.clone()),
+                    ),
                     ident_span,
                 )
             }
@@ -443,12 +446,14 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
     pub(super) fn parse_sass_interpolated_ident_rest(
         &mut self,
         end: &mut usize,
-    ) -> PResult<Vec<SassInterpolatedIdentElement<'s>>> {
-        let mut elements = vec![];
+    ) -> PResult<oxc_allocator::Vec<'a, SassInterpolatedIdentElement<'a>>> {
+        let mut elements = arena_vec!(self);
         loop {
             if let Some((token, span)) = self.tokenizer.scan_ident_template()? {
                 *end = span.end;
-                elements.push(SassInterpolatedIdentElement::Static((token, span).into()));
+                elements.push(SassInterpolatedIdentElement::Static(
+                    self.interpolable_ident_static_part(token, span),
+                ));
             } else if matches!(
                 peek!(self),
                 TokenWithSpan { token: Token::HashLBrace(..), span } if *end == span.start
@@ -464,7 +469,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
 
     fn parse_sass_interpolated_ident_expr(
         &mut self,
-    ) -> PResult<(SassInterpolatedIdentElement<'s>, Span)> {
+    ) -> PResult<(SassInterpolatedIdentElement<'a>, Span)> {
         debug_assert!(matches!(self.syntax, Syntax::Scss | Syntax::Sass));
 
         let start = expect!(self, HashLBrace).1.start;
@@ -473,11 +478,13 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         Ok((SassInterpolatedIdentElement::Expression(expr), Span { start, end }))
     }
 
-    fn parse_sass_invocation_args(&mut self) -> PResult<(Vec<ComponentValue<'s>>, Vec<Span>)> {
+    fn parse_sass_invocation_args(
+        &mut self,
+    ) -> PResult<(oxc_allocator::Vec<'a, ComponentValue<'a>>, oxc_allocator::Vec<'a, Span>)> {
         debug_assert!(matches!(self.syntax, Syntax::Scss | Syntax::Sass));
 
-        let mut values = Vec::with_capacity(4);
-        let mut comma_spans = vec![];
+        let mut values = self.vec_with_capacity(4);
+        let mut comma_spans = arena_vec!(self);
         while !matches!(peek!(self).token, Token::RParen(..) | Token::Eof(..)) {
             match peek!(self).token {
                 Token::Comma(..) => {
@@ -491,7 +498,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                     if let Some((_, span)) = eat!(self, DotDotDot) {
                         let span = Span { start: value.span().start, end: span.end };
                         values.push(ComponentValue::SassArbitraryArgument(SassArbitraryArgument {
-                            value: Box::new(value),
+                            value: arena_box!(self, value),
                             span,
                         }));
                     } else if let ComponentValue::SassVariable(sass_var) = value {
@@ -501,7 +508,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                             values.push(ComponentValue::SassKeywordArgument(SassKeywordArgument {
                                 name: sass_var,
                                 colon_span,
-                                value: Box::new(value),
+                                value: arena_box!(self, value),
                                 span,
                             }));
                         } else {
@@ -523,7 +530,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
     fn parse_sass_module_config(
         &mut self,
         allow_overridable: bool,
-    ) -> PResult<Option<SassModuleConfig<'s>>> {
+    ) -> PResult<Option<SassModuleConfig<'a>>> {
         match &peek!(self).token {
             Token::Ident(ident) if ident.name().eq_ignore_ascii_case("with") => {
                 let TokenWithSpan { span: with_span, .. } = bump!(self);
@@ -531,8 +538,9 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                 let end;
                 let (_, lparen_span) = expect!(self, LParen);
 
-                let mut items = vec![self.parse_sass_module_config_item(allow_overridable)?];
-                let mut comma_spans = vec![];
+                let mut items =
+                    arena_vec!(self; self.parse_sass_module_config_item(allow_overridable)?);
+                let mut comma_spans = arena_vec!(self);
                 if let Some((_, span)) = eat!(self, RParen) {
                     end = span.end;
                 } else {
@@ -569,7 +577,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
     fn parse_sass_module_config_item(
         &mut self,
         allow_overridable: bool,
-    ) -> PResult<SassModuleConfigItem<'s>> {
+    ) -> PResult<SassModuleConfigItem<'a>> {
         let variable = self.parse::<SassVariable>()?;
         let (_, colon_span) = expect!(self, Colon);
         let value = self.parse_maybe_sass_list(/* allow_comma */ false)?;
@@ -578,7 +586,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
             self.parse_sass_flags()
                 .map(|(flags, end)| (flags, end.unwrap_or_else(|| value.span().end)))?
         } else {
-            (vec![], value.span().end)
+            (arena_vec!(self), value.span().end)
         };
 
         let span = Span { start: variable.span.start, end };
@@ -586,10 +594,10 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
     }
 
     /// This method will consume `)` token.
-    fn parse_sass_params(&mut self) -> PResult<SassParams<'s>> {
-        let mut parameters = vec![];
+    fn parse_sass_params(&mut self) -> PResult<SassParams<'a>> {
+        let mut parameters = arena_vec!(self);
         let mut arbitrary_parameter = None;
-        let mut comma_spans = vec![];
+        let mut comma_spans = arena_vec!(self);
         let end;
         loop {
             if let Some((_, span)) = eat!(self, RParen) {
@@ -659,8 +667,8 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
 
     pub(super) fn parse_sass_qualified_name(
         &mut self,
-        module: Ident<'s>,
-    ) -> PResult<SassQualifiedName<'s>> {
+        module: Ident<'a>,
+    ) -> PResult<SassQualifiedName<'a>> {
         debug_assert!(matches!(self.syntax, Syntax::Scss | Syntax::Sass));
 
         let (_, dot_span) = expect!(self, Dot);
@@ -677,7 +685,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         Ok(SassQualifiedName { module, member, span })
     }
 
-    fn parse_sass_unary_expression(&mut self) -> PResult<ComponentValue<'s>> {
+    fn parse_sass_unary_expression(&mut self) -> PResult<ComponentValue<'a>> {
         let op = match &peek!(self).token {
             Token::Plus(..) => {
                 SassUnaryOperator { kind: SassUnaryOperatorKind::Plus, span: bump!(self).span }
@@ -694,15 +702,15 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         let expr = self.parse_sass_unary_expression()?;
         let span = Span { start: op.span.start, end: expr.span().end };
         Ok(ComponentValue::SassUnaryExpression(SassUnaryExpression {
-            expr: Box::new(expr),
+            expr: arena_box!(self, expr),
             op,
             span,
         }))
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassAtRoot<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassAtRoot<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let kind = if matches!(peek!(input).token, Token::LParen(..)) {
             SassAtRootKind::Query(input.parse()?)
         } else {
@@ -714,8 +722,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassAtRoot<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassAtRootQuery<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassAtRootQuery<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let start = expect!(input, LParen).1.start;
 
         let modifier = {
@@ -731,7 +739,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassAtRootQuery<'s> {
         };
         let colon_span = expect!(input, Colon).1;
 
-        let mut rules = Vec::with_capacity(1);
+        let mut rules = input.vec_with_capacity(1);
         loop {
             match &peek!(input).token {
                 Token::Ident(..) | Token::HashLBrace(..) => {
@@ -749,8 +757,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassAtRootQuery<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassConditionalClause<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassConditionalClause<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let condition = input.parse::<ComponentValue>()?;
         let block = input.parse::<SimpleBlock>()?;
         let span = Span { start: condition.span().start, end: block.span.end };
@@ -758,8 +766,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassConditionalClause<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassContent<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassContent<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = expect!(input, LParen);
         let (args, comma_spans) = input.parse_sass_invocation_args()?;
         let (_, Span { end, .. }) = expect!(input, RParen);
@@ -767,15 +775,15 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassContent<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassEach<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassEach<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
 
         let first_binding = input.parse::<SassVariable>()?;
         let start = first_binding.span().start;
 
-        let mut bindings = vec![first_binding];
-        let mut comma_spans = vec![];
+        let mut bindings = arena_vec!(input; first_binding);
+        let mut comma_spans = arena_vec!(input);
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             bindings.push(input.parse()?);
@@ -793,8 +801,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassEach<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassExtend<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassExtend<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let selectors = input.parse::<CompoundSelectorList>()?;
         let start = selectors.span.start;
         let mut end = selectors.span.end;
@@ -804,7 +812,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassExtend<'s> {
             if keyword.name().eq_ignore_ascii_case("optional") {
                 end = keyword_span.end;
                 let span = Span { start: exclamation_span.start, end: keyword_span.end };
-                Some(SassFlag { keyword: (keyword, keyword_span).into(), span })
+                Some(SassFlag { keyword: input.ident(keyword, keyword_span), span })
             } else {
                 input.recoverable_errors.push(Error {
                     kind: ErrorKind::ExpectSassKeyword("optional"),
@@ -820,8 +828,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassExtend<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassFor<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassFor<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
 
         let binding = input.parse::<SassVariable>()?;
@@ -843,8 +851,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassFor<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassForBoundary {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassForBoundary {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (keyword, span) = expect!(input, Ident);
         match &*keyword.name() {
             "to" => Ok(SassForBoundary { kind: SassForBoundaryKind::Exclusive, span }),
@@ -854,8 +862,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassForBoundary {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassForward<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassForward<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
 
         let path = input.parse::<InterpolableStr>()?;
@@ -879,8 +887,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassForward<'s> {
             let name = keyword.name();
             if name.eq_ignore_ascii_case("hide") {
                 let keyword_span = bump!(input).span;
-                let mut members = vec![];
-                let mut comma_spans = vec![];
+                let mut members = arena_vec!(input);
+                let mut comma_spans = arena_vec!(input);
                 loop {
                     match &peek!(input).token {
                         Token::Ident(..) => {
@@ -905,8 +913,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassForward<'s> {
                 })
             } else if name.eq_ignore_ascii_case("show") {
                 let keyword_span = bump!(input).span;
-                let mut members = vec![];
-                let mut comma_spans = vec![];
+                let mut members = arena_vec!(input);
+                let mut comma_spans = arena_vec!(input);
                 loop {
                     match &peek!(input).token {
                         Token::Ident(..) => {
@@ -945,8 +953,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassForward<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassFunction<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassFunction<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
 
         let name = input.parse::<Ident>()?;
@@ -959,16 +967,16 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassFunction<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassIfAtRule<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassIfAtRule<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
 
         let start = expect!(input, AtKeyword).1.start;
 
         let if_clause = input.parse::<SassConditionalClause>()?;
-        let mut else_if_clauses = Vec::<SassConditionalClause>::new();
+        let mut else_if_clauses: oxc_allocator::Vec<'a, SassConditionalClause<'a>> = input.vec();
         let mut else_clause: Option<SimpleBlock> = None;
-        let mut else_spans = vec![];
+        let mut else_spans = arena_vec!(input);
 
         while let Token::AtKeyword(at_keyword) = &peek!(input).token {
             match &*at_keyword.ident.name() {
@@ -1007,13 +1015,13 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassIfAtRule<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassImportPrelude<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassImportPrelude<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<Str>()?;
         let mut span = first.span.clone();
 
-        let mut paths = vec![first];
-        let mut comma_spans = vec![];
+        let mut paths = arena_vec!(input; first);
+        let mut comma_spans = arena_vec!(input);
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             paths.push(input.parse()?);
@@ -1027,8 +1035,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassImportPrelude<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassInclude<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassInclude<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
 
         let name = input.parse::<FunctionName>()?;
@@ -1055,8 +1063,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassInclude<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassIncludeArgs<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassIncludeArgs<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = expect!(input, LParen);
         let (args, comma_spans) = input.parse_sass_invocation_args()?;
         let (_, Span { end, .. }) = expect!(input, RParen);
@@ -1064,8 +1072,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassIncludeArgs<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassIncludeContentBlockParams<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassIncludeContentBlockParams<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match bump!(input) {
             TokenWithSpan { token: Token::Ident(ident), span: using_span }
                 if ident.name().eq_ignore_ascii_case("using") =>
@@ -1081,13 +1089,14 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassIncludeContentBlockParams<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassInterpolatedStr<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassInterpolatedStr<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (first, first_span) = expect!(input, StrTemplate);
         let quote = first.raw.chars().next().unwrap();
         debug_assert!(quote == '\'' || quote == '"');
         let mut span = first_span.clone();
-        let mut elements = vec![SassInterpolatedStrElement::Static((first, first_span).into())];
+        let first = input.interpolable_str_static_part(first, first_span);
+        let mut elements = arena_vec!(input; SassInterpolatedStrElement::Static(first));
 
         let mut is_parsing_static_part = false;
         loop {
@@ -1095,7 +1104,9 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassInterpolatedStr<'s> {
                 let (token, str_tpl_span) = input.tokenizer.scan_string_template(quote)?;
                 let tail = token.tail;
                 let end = str_tpl_span.end;
-                elements.push(SassInterpolatedStrElement::Static((token, str_tpl_span).into()));
+                elements.push(SassInterpolatedStrElement::Static(
+                    input.interpolable_str_static_part(token, str_tpl_span),
+                ));
                 if tail {
                     span.end = end;
                     break;
@@ -1115,8 +1126,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassInterpolatedStr<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassInterpolatedUrl<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassInterpolatedUrl<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
 
         let (first, first_span) = match input.tokenizer.scan_url_raw_or_template()? {
@@ -1129,7 +1140,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassInterpolatedUrl<'s> {
             }
         };
         let mut span = first_span.clone();
-        let mut elements = vec![SassInterpolatedUrlElement::Static((first, first_span).into())];
+        let first = input.interpolable_url_static_part(first, first_span);
+        let mut elements = arena_vec!(input; SassInterpolatedUrlElement::Static(first));
 
         let mut is_parsing_static_part = false;
         loop {
@@ -1137,7 +1149,9 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassInterpolatedUrl<'s> {
                 let (token, url_tpl_span @ Span { end, .. }) =
                     input.tokenizer.scan_url_template()?;
                 let tail = token.tail;
-                elements.push(SassInterpolatedUrlElement::Static((token, url_tpl_span).into()));
+                elements.push(SassInterpolatedUrlElement::Static(
+                    input.interpolable_url_static_part(token, url_tpl_span),
+                ));
                 if tail {
                     span.end = end;
                     break;
@@ -1157,8 +1171,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassInterpolatedUrl<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassList<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassList<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if let ComponentValue::SassList(list) =
             input.parse_maybe_sass_list(/* allow_comma */ true)?
         {
@@ -1171,12 +1185,12 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassList<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassMap<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassMap<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let start = expect!(input, LParen).1.start;
 
-        let mut items = vec![];
-        let mut comma_spans = vec![];
+        let mut items = arena_vec!(input);
+        let mut comma_spans = arena_vec!(input);
         loop {
             match peek!(input).token {
                 Token::RParen(..) => break,
@@ -1204,8 +1218,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassMap<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassMapItem<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassMapItem<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let key = input.parse_maybe_sass_list(/* allow_comma */ false)?;
         let (_, colon_span) = expect!(input, Colon);
         let value = input.parse_maybe_sass_list(/* allow_comma */ false)?;
@@ -1214,8 +1228,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassMapItem<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassMixin<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassMixin<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
 
         let name = input.parse::<Ident>()?;
@@ -1234,16 +1248,16 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassMixin<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassParameters<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassParameters<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = expect!(input, LParen);
         let (params, arbitrary_param, comma_spans, end) = input.parse_sass_params()?;
         Ok(SassParameters { params, arbitrary_param, comma_spans, span: Span { start, end } })
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassNestingDeclaration<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassNestingDeclaration<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let block = input.parse::<SimpleBlock>()?;
         let span = block.span.clone();
 
@@ -1251,25 +1265,24 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassNestingDeclaration<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassParenthesizedExpression<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassParenthesizedExpression<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let start = expect!(input, LParen).1.start;
         eat!(input, Indent);
-        let expr = Box::new(
-            input
-                .with_state(ParserState {
-                    sass_ctx: input.state.sass_ctx | SASS_CTX_ALLOW_DIV | SASS_CTX_IN_PARENS,
-                    ..input.state.clone()
-                })
-                .parse_maybe_sass_list(/* allow_comma */ true)?,
-        );
+        let expr = input
+            .with_state(ParserState {
+                sass_ctx: input.state.sass_ctx | SASS_CTX_ALLOW_DIV | SASS_CTX_IN_PARENS,
+                ..input.state.clone()
+            })
+            .parse_maybe_sass_list(/* allow_comma */ true)?;
+        let expr = arena_box!(input, expr);
         let end = expect!(input, RParen).1.end;
         Ok(SassParenthesizedExpression { expr, span: Span { start, end } })
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassPlaceholderSelector<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassPlaceholderSelector<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, percent_span) = expect!(input, Percent);
         let name = input.parse::<InterpolableIdent>()?;
         let name_span = name.span();
@@ -1279,8 +1292,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassPlaceholderSelector<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassUse<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassUse<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let path = input.parse::<InterpolableStr>()?;
         let mut span = path.span().clone();
 
@@ -1302,8 +1315,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassUse<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassUseNamespace<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassUseNamespace<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let as_span = match peek!(input) {
             TokenWithSpan { token: Token::Ident(ident), .. }
                 if ident.name().eq_ignore_ascii_case("as") =>
@@ -1329,7 +1342,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassUseNamespace<'s> {
                 let span = Span { start: as_span.start, end: ident_span.end };
                 Ok(SassUseNamespace {
                     as_span,
-                    kind: SassUseNamespaceKind::Named((ident, ident_span).into()),
+                    kind: SassUseNamespaceKind::Named(input.ident(ident, ident_span)),
                     span,
                 })
             }
@@ -1340,20 +1353,20 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassUseNamespace<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassVariable<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassVariable<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
 
         let (dollar_var, span) = expect!(input, DollarVar);
         Ok(SassVariable {
-            name: (dollar_var.ident, Span { start: span.start + 1, end: span.end }).into(),
+            name: input.ident(dollar_var.ident, Span { start: span.start + 1, end: span.end }),
             span,
         })
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassVariableDeclaration<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SassVariableDeclaration<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
 
         let namespace = if let Some((ident_token, span)) = eat!(input, Ident) {
@@ -1361,7 +1374,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassVariableDeclaration<'s> {
             util::assert_no_ws_or_comment(&span, &dot_span)?;
             let TokenWithSpan { span: next_span, .. } = peek!(input);
             util::assert_no_ws_or_comment(&dot_span, next_span)?;
-            Some(Ident::from((ident_token, span)))
+            Some(input.ident(ident_token, span))
         } else {
             None
         };
@@ -1395,8 +1408,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SassVariableDeclaration<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for UnknownSassAtRule<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for UnknownSassAtRule<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
 
         let (_, at_span) = expect!(input, At);

--- a/crates/oxc_css_parser/src/parser/selector.rs
+++ b/crates/oxc_css_parser/src/parser/selector.rs
@@ -1,6 +1,6 @@
 use super::Parser;
 use crate::{
-    Parse, Syntax,
+    Parse, Syntax, arena_vec,
     ast::*,
     bump, eat,
     error::{Error, ErrorKind, PResult},
@@ -9,12 +9,10 @@ use crate::{
     tokenizer::{Token, TokenWithSpan, token},
     util,
 };
-use smallvec::SmallVec;
-use std::borrow::Cow;
 
 // https://www.w3.org/TR/css-syntax-3/#the-anb-type
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AnPlusB {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for AnPlusB {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match peek!(input) {
             TokenWithSpan { token: Token::Dimension(..), .. } => {
                 let (token::Dimension { value, unit }, span) = expect!(input, Dimension);
@@ -313,8 +311,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AnPlusB {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AttributeSelector<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for AttributeSelector<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let start = expect!(input, LBracket).1.start;
 
         let name = match peek!(input) {
@@ -474,8 +472,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for AttributeSelector<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ClassSelector<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for ClassSelector<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, dot_span) = expect!(input, Dot);
         let start = dot_span.start;
         let end;
@@ -498,7 +496,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ClassSelector<'s> {
         } else if input.syntax == Syntax::Css {
             let (ident, ident_span) = expect_without_ws_or_comments!(input, Ident);
             end = ident_span.end;
-            InterpolableIdent::Literal((ident, ident_span).into())
+            InterpolableIdent::Literal(input.ident(ident, ident_span))
         } else {
             let ident = input.parse::<InterpolableIdent>()?;
             let ident_span = ident.span();
@@ -511,9 +509,9 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ClassSelector<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ComplexSelector<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
-        let mut children = SmallVec::with_capacity(3);
+impl<'a> Parse<'a> for ComplexSelector<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
+        let mut children = input.vec_with_capacity(3);
 
         let (span, first, mut is_previous_combinator) = if let Token::GreaterThan(..)
         | Token::Plus(..)
@@ -567,14 +565,14 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ComplexSelector<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for CompoundSelector<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for CompoundSelector<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<SimpleSelector>()?;
         let first_span = first.span();
         let start = first_span.start;
         let mut end = first_span.end;
 
-        let mut children = Vec::with_capacity(2);
+        let mut children = input.vec_with_capacity(2);
         children.push(first);
         loop {
             use token::*;
@@ -622,13 +620,13 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for CompoundSelector<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for CompoundSelectorList<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for CompoundSelectorList<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<CompoundSelector>()?;
         let mut span = first.span.clone();
 
-        let mut selectors = vec![first];
-        let mut comma_spans = vec![];
+        let mut selectors = arena_vec!(input; first);
+        let mut comma_spans = arena_vec!(input);
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             selectors.push(input.parse()?);
@@ -643,8 +641,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for CompoundSelectorList<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for IdSelector<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for IdSelector<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match bump!(input) {
             TokenWithSpan { token: Token::Hash(token), span } => {
                 let first_span = Span { start: span.start + 1, end: span.end };
@@ -656,7 +654,11 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for IdSelector<'s> {
                         .recoverable_errors
                         .push(Error { kind: ErrorKind::InvalidIdSelectorName, span: span.clone() });
                 }
-                let value = if token.escaped { util::handle_escape(raw) } else { Cow::from(raw) };
+                let value = if token.escaped {
+                    util::handle_escape_in(raw, input.allocator())
+                } else {
+                    raw
+                };
                 let first = Ident { name: value, raw: token.raw, span: first_span };
                 let name = match peek!(input) {
                     TokenWithSpan { token: Token::HashLBrace(..), span }
@@ -695,8 +697,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for IdSelector<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LanguageRange<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LanguageRange<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &peek!(input).token {
             Token::Str(..) | Token::StrTemplate(..) => input.parse().map(LanguageRange::Str),
             _ => input.parse().map(LanguageRange::Ident),
@@ -704,13 +706,13 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LanguageRange<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LanguageRangeList<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for LanguageRangeList<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<LanguageRange>()?;
         let mut span = first.span().clone();
 
-        let mut ranges = vec![first];
-        let mut comma_spans = vec![];
+        let mut ranges = arena_vec!(input; first);
+        let mut comma_spans = arena_vec!(input);
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             ranges.push(input.parse()?);
@@ -724,14 +726,18 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for LanguageRangeList<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for NestingSelector<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for NestingSelector<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, mut span) = expect!(input, Ampersand);
         let suffix = match input.syntax {
-            Syntax::Css => input.tokenizer.scan_ident_template()?.map(|token| {
-                span.end = token.1.end;
-                InterpolableIdent::Literal(token.into())
-            }),
+            Syntax::Css => {
+                if let Some((ident, ident_span)) = input.tokenizer.scan_ident_template()? {
+                    span.end = ident_span.end;
+                    Some(InterpolableIdent::Literal(input.ident(ident, ident_span)))
+                } else {
+                    None
+                }
+            }
             Syntax::Scss | Syntax::Sass => {
                 let start = span.end;
                 let elements = input.parse_sass_interpolated_ident_rest(&mut span.end)?;
@@ -762,8 +768,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for NestingSelector<'s> {
 }
 
 // https://drafts.csswg.org/selectors-4/#the-nth-child-pseudo
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Nth<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for Nth<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let index = input.parse::<NthIndex>()?;
         let mut span = index.span().clone();
         let matcher = match &peek!(input).token {
@@ -779,8 +785,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Nth<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for NthIndex<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for NthIndex<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &peek!(input).token {
             Token::Ident(ident) => {
                 let name = ident.name();
@@ -805,8 +811,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for NthIndex<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for NthMatcher<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for NthMatcher<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (ident, mut span) = expect!(input, Ident);
         if !ident.name().eq_ignore_ascii_case("of") {
             return Err(Error { kind: ErrorKind::ExpectNthOf, span });
@@ -824,8 +830,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for NthMatcher<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for PseudoClassSelector<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for PseudoClassSelector<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, colon_span) = expect!(input, Colon);
         let name = input.parse::<InterpolableIdent>()?;
         let name_span = name.span();
@@ -915,7 +921,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for PseudoClassSelector<'s> {
                         input.parse().map(PseudoClassSelectorArgKind::CompoundSelector)?
                     }
                     InterpolableIdent::Literal(Ident { name, .. })
-                        if input.syntax == Syntax::Less && name == "extend" =>
+                        if input.syntax == Syntax::Less && *name == "extend" =>
                     {
                         input.parse().map(PseudoClassSelectorArgKind::LessExtendList)?
                     }
@@ -937,15 +943,15 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for PseudoClassSelector<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for PseudoElementSelector<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for PseudoElementSelector<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, colon_colon_span) = expect!(input, ColonColon);
         let mut end;
         let name = if input.syntax == Syntax::Css {
             let (ident, ident_span) = expect!(input, Ident);
             end = ident_span.end;
             util::assert_no_ws(input.source, &colon_colon_span, &ident_span)?;
-            InterpolableIdent::Literal((ident, ident_span).into())
+            InterpolableIdent::Literal(input.ident(ident, ident_span))
         } else {
             let name = input.parse::<InterpolableIdent>()?;
             let name_span = name.span();
@@ -989,8 +995,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for PseudoElementSelector<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for RelativeSelector<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for RelativeSelector<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let pos = input.tokenizer.current_offset();
         let combinator = match input.parse_combinator(pos)? {
             Some(Combinator { kind: CombinatorKind::Descendant, .. }) => None,
@@ -1005,13 +1011,13 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for RelativeSelector<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for RelativeSelectorList<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for RelativeSelectorList<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<RelativeSelector>()?;
         let mut span = first.span.clone();
 
-        let mut selectors = vec![first];
-        let mut comma_spans = vec![];
+        let mut selectors = arena_vec!(input; first);
+        let mut comma_spans = arena_vec!(input);
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             selectors.push(input.parse()?);
@@ -1026,14 +1032,14 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for RelativeSelectorList<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SelectorList<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SelectorList<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<ComplexSelector>()?;
         let mut span = first.span.clone();
 
-        let mut selectors = Vec::with_capacity(2);
+        let mut selectors = input.vec_with_capacity(2);
         selectors.push(first);
-        let mut comma_spans = vec![];
+        let mut comma_spans = arena_vec!(input);
 
         let is_css = input.syntax == Syntax::Css;
         while let Some((_, comma_span)) = eat!(input, Comma) {
@@ -1064,8 +1070,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SelectorList<'s> {
 }
 
 // https://www.w3.org/TR/selectors-4/#ref-for-typedef-simple-selector
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SimpleSelector<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SimpleSelector<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match peek!(input) {
             TokenWithSpan { token: Token::Dot(..), .. } => input.parse().map(SimpleSelector::Class),
             TokenWithSpan { token: Token::Hash(..) | Token::NumberSign(..), .. } => {
@@ -1113,10 +1119,10 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SimpleSelector<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for TypeSelector<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
-        enum IdentOrAsterisk<'s> {
-            Ident(InterpolableIdent<'s>),
+impl<'a> Parse<'a> for TypeSelector<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
+        enum IdentOrAsterisk<'a> {
+            Ident(InterpolableIdent<'a>),
             Asterisk(Span),
         }
 
@@ -1207,7 +1213,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for TypeSelector<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
+impl<'a> Parser<'a> {
     fn parse_combinator(&mut self, pos: usize) -> PResult<Option<Combinator>> {
         match peek!(self) {
             TokenWithSpan {
@@ -1266,9 +1272,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
     }
 }
 
-fn expect_unsigned_int<'cmt, 's: 'cmt>(
-    input: &mut Parser<'cmt, 's>,
-) -> PResult<(token::Number<'s>, Span)> {
+fn expect_unsigned_int<'a>(input: &mut Parser<'a>) -> PResult<(token::Number<'a>, Span)> {
     let (number, span) = expect!(input, Number);
     if number.raw.chars().any(|c| !c.is_ascii_digit()) {
         Err(Error { kind: ErrorKind::ExpectUnsignedInteger, span })

--- a/crates/oxc_css_parser/src/parser/state.rs
+++ b/crates/oxc_css_parser/src/parser/state.rs
@@ -27,33 +27,33 @@ pub(super) const SASS_CTX_IN_PARENS: u8 = 8;
 pub(super) const LESS_CTX_ALLOW_DIV: u8 = 1;
 pub(super) const LESS_CTX_ALLOW_KEYFRAME_BLOCK: u8 = 2;
 
-impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
-    pub(super) fn with_state(&mut self, state: ParserState) -> WithState<'cmt, 's, '_> {
+impl<'a> Parser<'a> {
+    pub(super) fn with_state(&mut self, state: ParserState) -> WithState<'a, '_> {
         let original_state = mem::replace(&mut self.state, state);
         WithState { parser: self, original_state }
     }
 }
 
-pub(super) struct WithState<'cmt, 's: 'cmt, 'p> {
-    parser: &'p mut Parser<'cmt, 's>,
+pub(super) struct WithState<'a, 'p> {
+    parser: &'p mut Parser<'a>,
     original_state: ParserState,
 }
 
-impl<'cmt, 's: 'cmt, 'p> Deref for WithState<'cmt, 's, 'p> {
-    type Target = Parser<'cmt, 's>;
+impl<'a, 'p> Deref for WithState<'a, 'p> {
+    type Target = Parser<'a>;
 
     fn deref(&self) -> &Self::Target {
         self.parser
     }
 }
 
-impl<'cmt, 's: 'cmt, 'p> DerefMut for WithState<'cmt, 's, 'p> {
+impl<'a, 'p> DerefMut for WithState<'a, 'p> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.parser
     }
 }
 
-impl<'cmt, 's: 'cmt, 'p> Drop for WithState<'cmt, 's, 'p> {
+impl<'a, 'p> Drop for WithState<'a, 'p> {
     fn drop(&mut self) {
         mem::swap(&mut self.parser.state, &mut self.original_state);
     }

--- a/crates/oxc_css_parser/src/parser/stmt.rs
+++ b/crates/oxc_css_parser/src/parser/stmt.rs
@@ -3,7 +3,7 @@ use super::{
     state::{ParserState, QualifiedRuleContext},
 };
 use crate::{
-    Parse, Syntax,
+    Parse, Syntax, arena_box, arena_vec,
     ast::*,
     bump, eat,
     error::{Error, ErrorKind, PResult},
@@ -13,8 +13,8 @@ use crate::{
     util::PairedToken,
 };
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Declaration<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for Declaration<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         // A css-in-js `${}` placeholder may stand in for the property name
         // (`${foo}: ${bar}`); it is not a real ident, so accept it directly.
         let name = if let Token::Placeholder(..) = peek!(input).token {
@@ -64,7 +64,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Declaration<'s> {
                         break 'value values;
                     }
 
-                    let mut values = Vec::with_capacity(3);
+                    let mut values = parser.vec_with_capacity(3);
                     let mut pairs = Vec::with_capacity(1);
                     loop {
                         match &peek!(parser).token {
@@ -146,8 +146,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Declaration<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ImportantAnnotation<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for ImportantAnnotation<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, span) = expect!(input, Exclamation);
         let ident: Ident = input.parse::<Ident>()?;
         let span = Span { start: span.start, end: ident.span.end };
@@ -159,8 +159,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ImportantAnnotation<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for QualifiedRule<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for QualifiedRule<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let selector_list = input
             .with_state(ParserState {
                 qualified_rule_ctx: Some(QualifiedRuleContext::Selector),
@@ -173,8 +173,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for QualifiedRule<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SimpleBlock<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for SimpleBlock<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let is_sass = input.syntax == Syntax::Sass;
         let start = if is_sass {
             if let Some((_, span)) = eat!(input, Indent) {
@@ -182,7 +182,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SimpleBlock<'s> {
             } else {
                 let offset = peek!(input).span.start;
                 return Ok(SimpleBlock {
-                    statements: vec![],
+                    statements: arena_vec!(input),
                     span: Span { start: offset, end: offset },
                 });
             }
@@ -209,17 +209,17 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for SimpleBlock<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Stylesheet<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for Stylesheet<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let statements = input.parse_statements(/* is_top_level */ true)?;
         expect!(input, Eof);
         Ok(Stylesheet { statements, span: Span { start: 0, end: input.source.len() } })
     }
 }
 
-impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
-    fn parse_declaration_value(&mut self) -> PResult<Vec<ComponentValue<'s>>> {
-        let mut values = Vec::with_capacity(3);
+impl<'a> Parser<'a> {
+    fn parse_declaration_value(&mut self) -> PResult<oxc_allocator::Vec<'a, ComponentValue<'a>>> {
+        let mut values = self.vec_with_capacity(3);
         loop {
             match &peek!(self).token {
                 Token::RBrace(..)
@@ -246,8 +246,11 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         Ok(values)
     }
 
-    fn parse_statements(&mut self, is_top_level: bool) -> PResult<Vec<Statement<'s>>> {
-        let mut statements = Vec::with_capacity(1);
+    fn parse_statements(
+        &mut self,
+        is_top_level: bool,
+    ) -> PResult<oxc_allocator::Vec<'a, Statement<'a>>> {
+        let mut statements = self.vec_with_capacity(1);
         loop {
             // Set true for braced blocks AND `${}` placeholder statements: both
             // make the trailing terminator optional. A placeholder substitutes a
@@ -497,7 +500,8 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                 Token::At(..) if matches!(self.syntax, Syntax::Scss | Syntax::Sass) => {
                     let unknown_sass_at_rule = self.parse::<UnknownSassAtRule>()?;
                     is_block_element = unknown_sass_at_rule.block.is_some();
-                    statements.push(Statement::UnknownSassAtRule(Box::new(unknown_sass_at_rule)));
+                    statements
+                        .push(Statement::UnknownSassAtRule(arena_box!(self, unknown_sass_at_rule)));
                 }
                 Token::Percentage(..)
                     if self.state.in_keyframes_at_rule

--- a/crates/oxc_css_parser/src/parser/token_seq.rs
+++ b/crates/oxc_css_parser/src/parser/token_seq.rs
@@ -1,10 +1,10 @@
 use super::Parser;
 use crate::{ast::*, bump, error::PResult, peek, pos::Span, tokenizer::Token, util::PairedToken};
 
-impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
-    pub(super) fn parse_tokens_in_parens(&mut self) -> PResult<TokenSeq<'s>> {
+impl<'a> Parser<'a> {
+    pub(super) fn parse_tokens_in_parens(&mut self) -> PResult<TokenSeq<'a>> {
         let start = self.tokenizer.current_offset();
-        let mut tokens = Vec::with_capacity(1);
+        let mut tokens = self.vec_with_capacity(1);
         let mut pairs = Vec::with_capacity(1);
         loop {
             match &peek!(self).token {

--- a/crates/oxc_css_parser/src/parser/value.rs
+++ b/crates/oxc_css_parser/src/parser/value.rs
@@ -1,6 +1,6 @@
 use super::{Parser, state::QualifiedRuleContext};
 use crate::{
-    Parse, Syntax,
+    Parse, Syntax, arena_box, arena_vec,
     ast::*,
     bump, eat,
     error::{Error, ErrorKind, PResult},
@@ -9,17 +9,16 @@ use crate::{
     tokenizer::{Token, TokenWithSpan},
     util,
 };
-use std::borrow::Cow;
 
 const PRECEDENCE_MULTIPLY: u8 = 2;
 const PRECEDENCE_PLUS: u8 = 1;
 
-impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
-    pub(in crate::parser) fn parse_calc_expr(&mut self) -> PResult<ComponentValue<'s>> {
+impl<'a> Parser<'a> {
+    pub(in crate::parser) fn parse_calc_expr(&mut self) -> PResult<ComponentValue<'a>> {
         self.parse_calc_expr_recursively(0)
     }
 
-    fn parse_calc_expr_recursively(&mut self, precedence: u8) -> PResult<ComponentValue<'s>> {
+    fn parse_calc_expr_recursively(&mut self, precedence: u8) -> PResult<ComponentValue<'a>> {
         let mut left = if precedence >= PRECEDENCE_MULTIPLY {
             if eat!(self, LParen).is_some() {
                 let expr = self.parse_calc_expr()?;
@@ -58,9 +57,9 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
             let right = self.parse_calc_expr_recursively(precedence + 1)?;
             let span = Span { start: left.span().start, end: right.span().end };
             left = ComponentValue::Calc(Calc {
-                left: Box::new(left),
+                left: arena_box!(self, left),
                 op: operator,
-                right: Box::new(right),
+                right: arena_box!(self, right),
                 span,
             });
         }
@@ -68,7 +67,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         Ok(left)
     }
 
-    pub(super) fn parse_component_value_atom(&mut self) -> PResult<ComponentValue<'s>> {
+    pub(super) fn parse_component_value_atom(&mut self) -> PResult<ComponentValue<'a>> {
         let token_with_span = peek!(self);
         match &token_with_span.token {
             Token::Ident(token) => {
@@ -78,7 +77,8 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                         Err(Error { kind: ErrorKind::TryParseError, .. }) => {}
                         Err(error) => {
                             return if matches!(self.syntax, Syntax::Scss | Syntax::Sass) {
-                                let function_name = expect!(self, Ident).into();
+                                let (function_name, function_name_span) = expect!(self, Ident);
+                                let function_name = self.ident(function_name, function_name_span);
                                 self.parse_function(InterpolableIdent::Literal(function_name))
                                     .map(ComponentValue::Function)
                                     .map_err(|_| error)
@@ -118,7 +118,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                                 let (_, Span { end, .. }) = expect!(self, RParen);
                                 let span = Span { start: name.span.start, end };
                                 Ok(ComponentValue::Function(Function {
-                                    name: FunctionName::SassQualifiedName(Box::new(name)),
+                                    name: FunctionName::SassQualifiedName(arena_box!(self, name)),
                                     args,
                                     span,
                                 }))
@@ -258,7 +258,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         }
     }
 
-    pub(super) fn parse_dashed_ident(&mut self) -> PResult<InterpolableIdent<'s>> {
+    pub(super) fn parse_dashed_ident(&mut self) -> PResult<InterpolableIdent<'a>> {
         let ident = self.parse()?;
         match &ident {
             InterpolableIdent::Literal(ident) if !ident.name.starts_with("--") => {
@@ -270,10 +270,10 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         Ok(ident)
     }
 
-    pub(super) fn parse_function(&mut self, name: InterpolableIdent<'s>) -> PResult<Function<'s>> {
+    pub(super) fn parse_function(&mut self, name: InterpolableIdent<'a>) -> PResult<Function<'a>> {
         expect!(self, LParen);
         let args = if let Token::RParen(..) = &peek!(self).token {
-            vec![]
+            arena_vec!(self)
         } else {
             match &name {
                 InterpolableIdent::Literal(ident)
@@ -301,7 +301,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                         || ident.name.eq_ignore_ascii_case("pow")
                         || ident.name.eq_ignore_ascii_case("log") =>
                 {
-                    let mut values = Vec::with_capacity(1);
+                    let mut values = self.vec_with_capacity(1);
                     loop {
                         match peek!(self) {
                             TokenWithSpan { token: Token::RParen(..), .. } => break,
@@ -316,7 +316,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                                 let value = values.remove(0);
                                 let span = Span { start: value.span().start, end };
                                 values.push(ComponentValue::SassArbitraryArgument(
-                                    SassArbitraryArgument { value: Box::new(value), span },
+                                    SassArbitraryArgument { value: arena_box!(self, value), span },
                                 ));
                                 break;
                             }
@@ -326,13 +326,15 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                     values
                 }
                 InterpolableIdent::Literal(ident) if ident.name.eq_ignore_ascii_case("element") => {
-                    vec![self.parse().map(ComponentValue::IdSelector)?]
+                    arena_vec!(self; self.parse().map(ComponentValue::IdSelector)?)
                 }
                 InterpolableIdent::Literal(Ident { raw: "boolean" | "if", .. })
                     if self.syntax == Syntax::Less =>
                 {
-                    let condition =
-                        ComponentValue::LessCondition(Box::new(self.parse_less_condition(false)?));
+                    let condition = ComponentValue::LessCondition(arena_box!(
+                        self,
+                        self.parse_less_condition(false)?
+                    ));
                     let mut args = self.parse_function_args()?;
                     args.insert(0, condition);
                     args
@@ -345,8 +347,10 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         Ok(Function { name: FunctionName::Ident(name), args, span })
     }
 
-    pub(super) fn parse_function_args(&mut self) -> PResult<Vec<ComponentValue<'s>>> {
-        let mut values = Vec::with_capacity(4);
+    pub(super) fn parse_function_args(
+        &mut self,
+    ) -> PResult<oxc_allocator::Vec<'a, ComponentValue<'a>>> {
+        let mut values = self.vec_with_capacity(4);
         loop {
             match &peek!(self).token {
                 Token::RParen(..) | Token::Eof(..) => break,
@@ -374,7 +378,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                         if let Some((_, mut span)) = eat!(self, DotDotDot) {
                             span.start = value.span().start;
                             values.push(ComponentValue::SassArbitraryArgument(
-                                SassArbitraryArgument { value: Box::new(value), span },
+                                SassArbitraryArgument { value: arena_box!(self, value), span },
                             ));
                         } else if let ComponentValue::SassVariable(sass_var) = value {
                             if let Some((_, colon_span)) = eat!(self, Colon) {
@@ -385,7 +389,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                                     SassKeywordArgument {
                                         name: sass_var,
                                         colon_span,
-                                        value: Box::new(value),
+                                        value: arena_box!(self, value),
                                         span,
                                     },
                                 ));
@@ -404,7 +408,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         Ok(values)
     }
 
-    pub(super) fn parse_ratio(&mut self, numerator: Number<'s>) -> PResult<Ratio<'s>> {
+    pub(super) fn parse_ratio(&mut self, numerator: Number<'a>) -> PResult<Ratio<'a>> {
         let (_, solidus_span) = expect!(self, Solidus);
         let denominator = self.parse::<Number>()?;
         if denominator.value <= 0.0 {
@@ -418,7 +422,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         Ok(Ratio { numerator, solidus_span, denominator, span })
     }
 
-    fn parse_src_url(&mut self, name: Ident<'s>) -> PResult<Url<'s>> {
+    fn parse_src_url(&mut self, name: Ident<'a>) -> PResult<Url<'a>> {
         // caller of `parse_src_url` should make sure there're no whitespaces before paren
         expect!(self, LParen);
         let value = match &peek!(self).token {
@@ -429,7 +433,7 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
         };
         let modifiers = match &peek!(self).token {
             Token::Ident(..) | Token::HashLBrace(..) | Token::AtLBraceVar(..) => {
-                let mut modifiers = Vec::with_capacity(1);
+                let mut modifiers = self.vec_with_capacity(1);
                 loop {
                     modifiers.push(self.parse()?);
                     if let Token::RParen(..) = &peek!(self).token {
@@ -438,14 +442,14 @@ impl<'cmt, 's: 'cmt> Parser<'cmt, 's> {
                 }
                 modifiers
             }
-            _ => vec![],
+            _ => arena_vec!(self),
         };
         let end = expect!(self, RParen).1.end;
         let span = Span { start: name.span.start, end };
         Ok(Url { name, value, modifiers, span })
     }
 
-    fn parse_unicode_range(&mut self, prefix_ident: Ident<'s>) -> PResult<UnicodeRange<'s>> {
+    fn parse_unicode_range(&mut self, prefix_ident: Ident<'a>) -> PResult<UnicodeRange<'a>> {
         let prefix = prefix_ident.raw.chars().next().unwrap();
         let (span_start, span_end) = match bump!(self) {
             TokenWithSpan { token: Token::Plus(..), span: plus_token_span } => {
@@ -564,10 +568,10 @@ fn replace_unicode_range_wildcards(source: &str, replacement: char) -> String {
     source.chars().map(|c| if c == '?' { replacement } else { c }).collect()
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for BracketBlock<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for BracketBlock<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let start = expect!(input, LBracket).1.start;
-        let mut value = Vec::with_capacity(3);
+        let mut value = input.vec_with_capacity(3);
         loop {
             match &peek!(input).token {
                 Token::RBracket(..) => break,
@@ -579,8 +583,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for BracketBlock<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ComponentValue<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for ComponentValue<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.syntax {
             Syntax::Css => input.parse_component_value_atom(),
             Syntax::Scss | Syntax::Sass => {
@@ -591,13 +595,13 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ComponentValue<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ComponentValues<'s> {
+impl<'a> Parse<'a> for ComponentValues<'a> {
     /// This is for public-use only. For internal code of oxc-css-parser, **DO NOT** use.
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<ComponentValue>()?;
         let mut span = first.span().clone();
 
-        let mut values = Vec::with_capacity(4);
+        let mut values = input.vec_with_capacity(4);
         values.push(first);
         loop {
             match &peek!(input).token {
@@ -616,8 +620,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for ComponentValues<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Delimiter {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for Delimiter {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         use crate::tokenizer::token::*;
         match bump!(input) {
             TokenWithSpan { token: Token::Solidus(..), span } => {
@@ -634,14 +638,15 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Delimiter {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Dimension<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
-        expect!(input, Dimension).try_into()
+impl<'a> Parse<'a> for Dimension<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
+        let (dimension, span) = expect!(input, Dimension);
+        input.dimension(dimension, span)
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Function<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for Function<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let name = input.parse::<FunctionName>()?;
         match peek!(input) {
             TokenWithSpan { token: Token::LParen(..), span } => {
@@ -668,8 +673,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Function<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for FunctionName<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for FunctionName<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match peek!(input).token {
             Token::Ident(..) => {
                 let ident = input.parse::<Ident>()?;
@@ -678,11 +683,14 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for FunctionName<'s> {
                         bump!(input);
                         let member = input.parse::<Ident>()?;
                         let span = Span { start: ident.span.start, end: member.span.end };
-                        Ok(FunctionName::SassQualifiedName(Box::new(SassQualifiedName {
-                            module: ident,
-                            member: SassModuleMemberName::Ident(member),
-                            span,
-                        })))
+                        Ok(FunctionName::SassQualifiedName(arena_box!(
+                            input,
+                            SassQualifiedName {
+                                module: ident,
+                                member: SassModuleMemberName::Ident(member),
+                                span,
+                            }
+                        )))
                     }
                     _ => Ok(FunctionName::Ident(InterpolableIdent::Literal(ident))),
                 }
@@ -702,23 +710,25 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for FunctionName<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for HexColor<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for HexColor<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (token, span) = expect!(input, Hash);
         let raw = token.raw;
-        let value = if token.escaped { util::handle_escape(raw) } else { Cow::from(raw) };
+        let value =
+            if token.escaped { util::handle_escape_in(raw, input.allocator()) } else { raw };
         Ok(HexColor { value, raw, span })
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Ident<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
-        Ok(expect!(input, Ident).into())
+impl<'a> Parse<'a> for Ident<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
+        let (ident, span) = expect!(input, Ident);
+        Ok(input.ident(ident, span))
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for InterpolableIdent<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for InterpolableIdent<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         // A css-in-js placeholder stands in for an interpolated ident anywhere one
         // is expected (id selector `#${x}`, attribute value `[a=${x}]`, ...).
         if let Token::Placeholder(..) = peek!(input).token {
@@ -743,8 +753,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for InterpolableIdent<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for InterpolableStr<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for InterpolableStr<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match peek!(input) {
             TokenWithSpan { token: Token::Str(..), .. } => {
                 input.parse().map(InterpolableStr::Literal)
@@ -763,8 +773,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for InterpolableStr<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Number<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for Number<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (number, span) = expect!(input, Number);
         number
             .raw
@@ -774,8 +784,8 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Number<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Percentage<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for Percentage<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (token, span) = expect!(input, Percentage);
         Ok(Percentage {
             value: (token.value, Span { start: span.start, end: span.end - 1 }).try_into()?,
@@ -784,18 +794,21 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Percentage<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Str<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
-        Ok(expect!(input, Str).into())
+impl<'a> Parse<'a> for Str<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
+        let (str, span) = expect!(input, Str);
+        Ok(input.str(str, span))
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Url<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for Url<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (prefix, prefix_span) = expect!(input, Ident);
         if !prefix.name().eq_ignore_ascii_case("url") {
             return Err(Error { kind: ErrorKind::ExpectUrl, span: prefix_span });
         }
+        let prefix_start = prefix_span.start;
+        let name = input.ident(prefix, prefix_span.clone());
 
         match peek!(input) {
             TokenWithSpan { token: Token::LParen(..), span } if prefix_span.end == span.start => {
@@ -810,7 +823,7 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Url<'s> {
             let value = input.parse()?;
             let modifiers = match &peek!(input).token {
                 Token::Ident(..) | Token::HashLBrace(..) | Token::AtLBraceVar(..) => {
-                    let mut modifiers = Vec::with_capacity(1);
+                    let mut modifiers = input.vec_with_capacity(1);
                     loop {
                         modifiers.push(input.parse()?);
                         if let Token::RParen(..) = &peek!(input).token {
@@ -819,61 +832,46 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for Url<'s> {
                     }
                     modifiers
                 }
-                _ => vec![],
+                _ => arena_vec!(input),
             };
             let end = expect!(input, RParen).1.end;
-            let span = Span { start: prefix_span.start, end };
-            Ok(Url {
-                name: (prefix, prefix_span).into(),
-                value: Some(UrlValue::Str(value)),
-                modifiers,
-                span,
-            })
+            let span = Span { start: prefix_start, end };
+            Ok(Url { name, value: Some(UrlValue::Str(value)), modifiers, span })
         } else if let Ok(value) = input.try_parse(UrlRaw::parse) {
             let span = Span {
-                start: prefix_span.start,
+                start: prefix_start,
                 end: value.span.end + 1, // `)` is consumed, but span excludes it
             };
-            Ok(Url {
-                name: (prefix, prefix_span).into(),
-                value: Some(UrlValue::Raw(value)),
-                modifiers: vec![],
-                span,
-            })
+            Ok(Url { name, value: Some(UrlValue::Raw(value)), modifiers: arena_vec!(input), span })
         } else {
             match input.syntax {
                 Syntax::Css => Err(Error { kind: ErrorKind::InvalidUrl, span: bump!(input).span }),
                 Syntax::Scss | Syntax::Sass => {
                     let value = input.parse::<SassInterpolatedUrl>()?;
                     let span = Span {
-                        start: prefix_span.start,
+                        start: prefix_start,
                         end: value.span.end + 1, // `)` is consumed, but span excludes it
                     };
                     Ok(Url {
-                        name: (prefix, prefix_span).into(),
+                        name,
                         value: Some(UrlValue::SassInterpolated(value)),
-                        modifiers: vec![],
+                        modifiers: arena_vec!(input),
                         span,
                     })
                 }
                 Syntax::Less => {
                     let value = UrlValue::LessEscapedStr(input.parse()?);
                     let (_, Span { end, .. }) = expect!(input, RParen);
-                    let span = Span { start: prefix_span.start, end };
-                    Ok(Url {
-                        name: (prefix, prefix_span).into(),
-                        value: Some(value),
-                        modifiers: vec![],
-                        span,
-                    })
+                    let span = Span { start: prefix_start, end };
+                    Ok(Url { name, value: Some(value), modifiers: arena_vec!(input), span })
                 }
             }
         }
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for UrlModifier<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for UrlModifier<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let ident = input.parse::<InterpolableIdent>()?;
         match peek!(input) {
             TokenWithSpan { token: Token::LParen(..), span } if ident.span().end == span.start => {
@@ -884,12 +882,15 @@ impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for UrlModifier<'s> {
     }
 }
 
-impl<'cmt, 's: 'cmt> Parse<'cmt, 's> for UrlRaw<'s> {
-    fn parse(input: &mut Parser<'cmt, 's>) -> PResult<Self> {
+impl<'a> Parse<'a> for UrlRaw<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.tokenizer.scan_url_raw_or_template()? {
             TokenWithSpan { token: Token::UrlRaw(url), span } => {
-                let value =
-                    if url.escaped { util::handle_escape(url.raw) } else { Cow::from(url.raw) };
+                let value = if url.escaped {
+                    util::handle_escape_in(url.raw, input.allocator())
+                } else {
+                    url.raw
+                };
                 Ok(UrlRaw { value, raw: url.raw, span })
             }
             TokenWithSpan { token, span } => {

--- a/crates/oxc_css_parser/src/span_ignored_eq.rs
+++ b/crates/oxc_css_parser/src/span_ignored_eq.rs
@@ -1,5 +1,4 @@
 use crate::Span;
-use smallvec::SmallVec;
 use std::borrow::Cow;
 
 /// Compare equality of two AST nodes without respecting their spans.
@@ -93,7 +92,7 @@ where
     }
 }
 
-impl<T, const N: usize> SpanIgnoredEq for SmallVec<[T; N]>
+impl<'a, T> SpanIgnoredEq for oxc_allocator::Vec<'a, T>
 where
     T: SpanIgnoredEq,
 {
@@ -118,7 +117,7 @@ where
     }
 }
 
-impl<T> SpanIgnoredEq for Box<T>
+impl<'a, T> SpanIgnoredEq for oxc_allocator::Box<'a, T>
 where
     T: SpanIgnoredEq,
 {

--- a/crates/oxc_css_parser/src/tokenizer/mod.rs
+++ b/crates/oxc_css_parser/src/tokenizer/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     error::{Error, ErrorKind, PResult},
     pos::Span,
 };
+use oxc_allocator::{Allocator, Vec as ArenaVec};
 use std::{cmp::Ordering, iter::Peekable, str::CharIndices};
 pub(crate) use symbol::TokenSymbol;
 use token::*;
@@ -14,26 +15,27 @@ mod symbol;
 pub mod token;
 
 #[derive(Clone)]
-pub(crate) struct TokenizerState<'s> {
-    chars: Peekable<CharIndices<'s>>,
+pub(crate) struct TokenizerState<'a> {
+    chars: Peekable<CharIndices<'a>>,
     current_indent: u16,
     indents: Vec<u16>,
 }
 
-pub struct Tokenizer<'cmt, 's: 'cmt> {
-    source: &'s str,
+pub struct Tokenizer<'a> {
+    source: &'a str,
     syntax: Syntax,
     template_placeholder: Option<TemplatePlaceholder>,
-    pub(crate) comments: Option<&'cmt mut Vec<Comment<'s>>>,
-    pub(crate) state: TokenizerState<'s>,
+    comments: Option<ArenaVec<'a, Comment<'a>>>,
+    pub(crate) state: TokenizerState<'a>,
 }
 
-impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
+impl<'a> Tokenizer<'a> {
     pub fn new(
-        source: &'s str,
+        allocator: &'a Allocator,
+        source: &'a str,
         syntax: Syntax,
         template_placeholder: Option<TemplatePlaceholder>,
-        comments: Option<&'cmt mut Vec<Comment<'s>>>,
+        collect_comments: bool,
     ) -> Self {
         let mut chars = source.char_indices().peekable();
         if syntax == Syntax::Sass {
@@ -43,7 +45,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
             source,
             syntax,
             template_placeholder,
-            comments,
+            comments: collect_comments.then(|| ArenaVec::new_in(allocator)),
             state: TokenizerState {
                 chars,
                 current_indent: 0,
@@ -53,12 +55,32 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
     }
 
     #[inline]
-    pub fn bump(&mut self) -> PResult<TokenWithSpan<'s>> {
+    pub fn comments(&self) -> &[Comment<'a>] {
+        match &self.comments {
+            Some(comments) => comments,
+            None => &[],
+        }
+    }
+
+    #[inline]
+    pub(crate) fn comments_count(&self) -> usize {
+        self.comments.as_ref().map_or(0, |comments| comments.len())
+    }
+
+    #[inline]
+    pub(crate) fn truncate_comments(&mut self, len: usize) {
+        if let Some(comments) = &mut self.comments {
+            comments.truncate(len);
+        }
+    }
+
+    #[inline]
+    pub fn bump(&mut self) -> PResult<TokenWithSpan<'a>> {
         if let Some(indent) = self.skip_ws_or_comment() { Ok(indent) } else { self.next() }
     }
 
     #[inline]
-    pub fn bump_without_ws_or_comments(&mut self) -> PResult<TokenWithSpan<'s>> {
+    pub fn bump_without_ws_or_comments(&mut self) -> PResult<TokenWithSpan<'a>> {
         self.next()
     }
 
@@ -78,7 +100,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         Error { kind: ErrorKind::UnexpectedEof, span: Span { start: offset, end: offset } }
     }
 
-    fn next(&mut self) -> PResult<TokenWithSpan<'s>> {
+    fn next(&mut self) -> PResult<TokenWithSpan<'a>> {
         // detect frequent tokens here, but DO NOT add too many and don't forget to do profiling
         match self.state.chars.peek() {
             Some((_, c)) if is_start_of_ident(*c) && c != &'-' => return self.scan_ident(),
@@ -154,7 +176,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         }
     }
 
-    fn skip_ws_or_comment(&mut self) -> Option<TokenWithSpan<'s>> {
+    fn skip_ws_or_comment(&mut self) -> Option<TokenWithSpan<'a>> {
         // Sass can dedent more than one level at a time,
         // so we need to produce a dedent token for each level.
         if self.syntax == Syntax::Sass
@@ -202,7 +224,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         }
     }
 
-    fn scan_indent(&mut self) -> Option<TokenWithSpan<'s>> {
+    fn scan_indent(&mut self) -> Option<TokenWithSpan<'a>> {
         debug_assert_eq!(self.syntax, Syntax::Sass);
         let mut start = None;
         while let Some((i, c)) = self.state.chars.peek() {
@@ -311,7 +333,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         }
     }
 
-    pub(crate) fn scan_ident_sequence(&mut self) -> PResult<(Ident<'s>, Span)> {
+    pub(crate) fn scan_ident_sequence(&mut self) -> PResult<(Ident<'a>, Span)> {
         let start;
         let end;
         let mut escaped = false;
@@ -395,7 +417,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         }
     }
 
-    fn scan_number(&mut self) -> PResult<(Number<'s>, Span)> {
+    fn scan_number(&mut self) -> PResult<(Number<'a>, Span)> {
         let start;
         let mut end;
 
@@ -494,9 +516,9 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
 
     fn scan_dimension_or_percentage(
         &mut self,
-        number: Number<'s>,
+        number: Number<'a>,
         span: Span,
-    ) -> PResult<TokenWithSpan<'s>> {
+    ) -> PResult<TokenWithSpan<'a>> {
         let mut chars = self.state.chars.clone();
         match (chars.next(), chars.next()) {
             (Some((_, '-')), Some((_, c))) if is_start_of_ident(c) => {
@@ -512,9 +534,9 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
 
     fn scan_dimension(
         &mut self,
-        value: Number<'s>,
+        value: Number<'a>,
         value_span: Span,
-    ) -> PResult<TokenWithSpan<'s>> {
+    ) -> PResult<TokenWithSpan<'a>> {
         let (unit, unit_span) = self.scan_ident_sequence()?;
         Ok(TokenWithSpan {
             token: Token::Dimension(Dimension { value, unit }),
@@ -522,7 +544,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         })
     }
 
-    fn scan_percentage(&mut self, value: Number<'s>, span: Span) -> PResult<TokenWithSpan<'s>> {
+    fn scan_percentage(&mut self, value: Number<'a>, span: Span) -> PResult<TokenWithSpan<'a>> {
         self.state.chars.next();
         Ok(TokenWithSpan {
             token: Token::Percentage(Percentage { value }),
@@ -530,7 +552,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         })
     }
 
-    pub(crate) fn scan_string_only(&mut self) -> PResult<(Str<'s>, Span)> {
+    pub(crate) fn scan_string_only(&mut self) -> PResult<(Str<'a>, Span)> {
         let (start, quote) = match self.state.chars.next() {
             Some((index, c @ '\'' | c @ '"')) => (index, c),
             Some((index, _)) => {
@@ -575,7 +597,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         Ok((Str { raw, escaped }, Span { start, end }))
     }
 
-    fn scan_string_or_template(&mut self) -> PResult<TokenWithSpan<'s>> {
+    fn scan_string_or_template(&mut self) -> PResult<TokenWithSpan<'a>> {
         // '\'' or '"' is checked (but not consumed) before
         let (start, quote) = self.state.chars.next().unwrap();
 
@@ -627,7 +649,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         Ok(TokenWithSpan { token: Token::Str(Str { raw, escaped }), span: Span { start, end } })
     }
 
-    pub(crate) fn scan_string_template(&mut self, quote: char) -> PResult<(StrTemplate<'s>, Span)> {
+    pub(crate) fn scan_string_template(&mut self, quote: char) -> PResult<(StrTemplate<'a>, Span)> {
         let start = self.current_offset();
         let end;
         let mut escaped = false;
@@ -677,12 +699,12 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         }
     }
 
-    fn scan_ident(&mut self) -> PResult<TokenWithSpan<'s>> {
+    fn scan_ident(&mut self) -> PResult<TokenWithSpan<'a>> {
         self.scan_ident_sequence()
             .map(|(ident, span)| TokenWithSpan { token: Token::Ident(ident), span })
     }
 
-    pub(crate) fn scan_ident_template(&mut self) -> PResult<Option<(Ident<'s>, Span)>> {
+    pub(crate) fn scan_ident_template(&mut self) -> PResult<Option<(Ident<'a>, Span)>> {
         let start = self.current_offset();
         let mut escaped = false;
 
@@ -716,7 +738,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         }
     }
 
-    fn scan_sass_single_hyphen_as_ident(&mut self) -> PResult<TokenWithSpan<'s>> {
+    fn scan_sass_single_hyphen_as_ident(&mut self) -> PResult<TokenWithSpan<'a>> {
         debug_assert!(matches!(self.syntax, Syntax::Scss | Syntax::Sass));
         match self.state.chars.next() {
             Some((start, c)) => {
@@ -730,7 +752,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         }
     }
 
-    pub(crate) fn scan_url_raw_or_template(&mut self) -> PResult<TokenWithSpan<'s>> {
+    pub(crate) fn scan_url_raw_or_template(&mut self) -> PResult<TokenWithSpan<'a>> {
         self.skip_ws();
         let start = self.current_offset();
         let end;
@@ -786,7 +808,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         Ok(TokenWithSpan { token: Token::UrlRaw(UrlRaw { raw, escaped }), span })
     }
 
-    pub(crate) fn scan_url_template(&mut self) -> PResult<(UrlTemplate<'s>, Span)> {
+    pub(crate) fn scan_url_template(&mut self) -> PResult<(UrlTemplate<'a>, Span)> {
         let start = self.current_offset();
         let mut escaped = false;
         loop {
@@ -848,7 +870,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         }
     }
 
-    fn scan_hash(&mut self) -> PResult<TokenWithSpan<'s>> {
+    fn scan_hash(&mut self) -> PResult<TokenWithSpan<'a>> {
         let (start, c) = self.state.chars.next().unwrap();
         debug_assert_eq!(c, '#');
 
@@ -897,7 +919,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         Ok(TokenWithSpan { token: Token::Hash(Hash { escaped, raw }), span: Span { start, end } })
     }
 
-    fn scan_dollar_var(&mut self) -> PResult<TokenWithSpan<'s>> {
+    fn scan_dollar_var(&mut self) -> PResult<TokenWithSpan<'a>> {
         let (start, c) = self.state.chars.next().expect("expect char `$`");
         debug_assert_eq!(c, '$');
         let (ident, span) = self.scan_ident_sequence()?;
@@ -907,7 +929,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         })
     }
 
-    fn scan_less_lbrace_var(&mut self) -> PResult<TokenWithSpan<'s>> {
+    fn scan_less_lbrace_var(&mut self) -> PResult<TokenWithSpan<'a>> {
         let (start, first_char) = self.state.chars.next().expect("expect char `@` or `$`");
         debug_assert!(matches!(first_char, '@' | '$'));
         let (_, c) = self.state.chars.next().expect("expect char `{`");
@@ -934,7 +956,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         }
     }
 
-    fn scan_at_keyword(&mut self) -> PResult<TokenWithSpan<'s>> {
+    fn scan_at_keyword(&mut self) -> PResult<TokenWithSpan<'a>> {
         let (start, c) = self.state.chars.next().expect("expect char `@`");
         debug_assert_eq!(c, '@');
 
@@ -949,7 +971,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
     /// opening backtick is at the current position. Emits a [`Token::Placeholder`].
     /// A backtick that doesn't form a valid placeholder is invalid (backtick is
     /// not valid SCSS) and errors like any unknown token.
-    fn scan_template_placeholder(&mut self) -> PResult<TokenWithSpan<'s>> {
+    fn scan_template_placeholder(&mut self) -> PResult<TokenWithSpan<'a>> {
         let start = self.current_offset();
         if let Some((placeholder, end)) = self.match_placeholder(start) {
             // Affixes and digits are ASCII, so `end` lands on a char boundary.
@@ -968,11 +990,11 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
     /// the closing backtick and any glued suffix), or `None` when the option is
     /// unset or the shape doesn't match. An index that overflows `u32` doesn't
     /// match (so the caller errors) instead of panicking. Does not advance.
-    fn match_placeholder(&self, at: usize) -> Option<(Placeholder<'s>, usize)> {
-        // Bind `source` as `&'s str` so the suffix slice has lifetime `'s`
+    fn match_placeholder(&self, at: usize) -> Option<(Placeholder<'a>, usize)> {
+        // Bind `source` as `&'a str` so the suffix slice has lifetime `'a`
         // (independent of `&self`), letting callers mutate the tokenizer while
         // holding the returned token.
-        let source: &'s str = self.source;
+        let source: &'a str = self.source;
         let ph = self.template_placeholder?;
         // `at` is the opening backtick.
         let after_open = source[at + 1..].strip_prefix(ph.prefix)?;
@@ -1001,7 +1023,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
     /// return `None`. Used where a placeholder must be detected without first
     /// skipping whitespace (e.g. a class selector name), so callers can't rely
     /// on the main dispatch having already emitted the token.
-    pub(crate) fn scan_placeholder(&mut self) -> Option<TokenWithSpan<'s>> {
+    pub(crate) fn scan_placeholder(&mut self) -> Option<TokenWithSpan<'a>> {
         let start = self.current_offset();
         if !self.source[start..].starts_with('`') {
             return None;
@@ -1013,7 +1035,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         Some(TokenWithSpan { token: Token::Placeholder(placeholder), span: Span { start, end } })
     }
 
-    fn scan_backtick_code(&mut self) -> PResult<TokenWithSpan<'s>> {
+    fn scan_backtick_code(&mut self) -> PResult<TokenWithSpan<'a>> {
         debug_assert!(self.syntax == Syntax::Less);
 
         // '`' is checked (but not consumed) before
@@ -1041,7 +1063,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
         })
     }
 
-    fn scan_punc(&mut self) -> PResult<TokenWithSpan<'s>> {
+    fn scan_punc(&mut self) -> PResult<TokenWithSpan<'a>> {
         match self.state.chars.next() {
             Some((start, '.')) => {
                 if self.syntax != Syntax::Css
@@ -1319,7 +1341,7 @@ impl<'cmt, 's: 'cmt> Tokenizer<'cmt, 's> {
     }
 
     #[cold]
-    fn scan_cdc(&mut self, start: usize) -> PResult<TokenWithSpan<'s>> {
+    fn scan_cdc(&mut self, start: usize) -> PResult<TokenWithSpan<'a>> {
         self.state.chars.next();
         self.state.chars.next();
         self.state.chars.next();

--- a/crates/oxc_css_parser/src/util.rs
+++ b/crates/oxc_css_parser/src/util.rs
@@ -2,6 +2,7 @@ use crate::{
     Span,
     error::{Error, ErrorKind, PResult},
 };
+use oxc_allocator::Allocator;
 use std::borrow::Cow;
 
 pub fn is_css_wide_keyword(s: &str) -> bool {
@@ -61,6 +62,14 @@ pub fn handle_escape(s: &str) -> Cow<'_, str> {
         }
     }
     Cow::from(escaped)
+}
+
+pub fn handle_escape_in<'a>(s: &'a str, allocator: &'a Allocator) -> &'a str {
+    let escaped = handle_escape(s);
+    match escaped {
+        Cow::Borrowed(value) => value,
+        Cow::Owned(value) => allocator.alloc_str(&value),
+    }
 }
 
 pub(crate) fn assert_no_ws_or_comment(left: &Span, right: &Span) -> PResult<()> {

--- a/crates/oxc_css_parser/tests/ast.rs
+++ b/crates/oxc_css_parser/tests/ast.rs
@@ -4,7 +4,7 @@ use codespan_reporting::{
     term,
 };
 use insta::{Settings, assert_ron_snapshot, glob};
-use oxc_css_parser::{Parser, Syntax, ast::Stylesheet};
+use oxc_css_parser::{Allocator, Parser, Syntax, ast::Stylesheet};
 use std::fs;
 
 #[test]
@@ -18,7 +18,8 @@ fn ast_snapshot() {
             "less" => Syntax::Less,
             _ => unreachable!("unknown file extension"),
         };
-        let mut parser = Parser::new(&code, syntax);
+        let allocator = Allocator::default();
+        let mut parser = Parser::new(&allocator, &code, syntax);
         let ast = match parser.parse::<Stylesheet>() {
             Ok(ast) => {
                 let recoverable_errors = parser.recoverable_errors();

--- a/crates/oxc_css_parser/tests/error.rs
+++ b/crates/oxc_css_parser/tests/error.rs
@@ -4,7 +4,7 @@ use codespan_reporting::{
     term,
 };
 use insta::{Settings, assert_snapshot, glob};
-use oxc_css_parser::{Parser, Syntax, ast::Stylesheet};
+use oxc_css_parser::{Allocator, Parser, Syntax, ast::Stylesheet};
 use std::fs;
 
 #[test]
@@ -20,7 +20,8 @@ fn error_snapshot() {
             "less" => Syntax::Less,
             _ => unreachable!("unknown file extension"),
         };
-        let mut parser = Parser::new(&code, syntax);
+        let allocator = Allocator::default();
+        let mut parser = Parser::new(&allocator, &code, syntax);
         let error = match parser.parse::<Stylesheet>() {
             Ok(..) => panic!(
                 "\"{}\" should contain unrecoverable syntax error, but actually parsed successfully.",

--- a/crates/oxc_css_parser/tests/placeholder.rs
+++ b/crates/oxc_css_parser/tests/placeholder.rs
@@ -1,4 +1,6 @@
-use oxc_css_parser::{ParserBuilder, ParserOptions, Syntax, TemplatePlaceholder, ast::*};
+use oxc_css_parser::{
+    Allocator, ParserBuilder, ParserOptions, Syntax, TemplatePlaceholder, ast::*,
+};
 
 fn opts() -> ParserOptions {
     ParserOptions {
@@ -7,11 +9,12 @@ fn opts() -> ParserOptions {
     }
 }
 
-fn parse(code: &str, options: Option<ParserOptions>) -> Stylesheet<'_> {
+fn parse(code: &'static str, options: Option<ParserOptions>) -> Stylesheet<'static> {
     // Backtick placeholders require SCSS (the builder asserts this); without the
     // option, parse as plain CSS so the backtick stays an ordinary error.
+    let allocator = Box::leak(Box::new(Allocator::default()));
     let syntax = if options.is_some() { Syntax::Scss } else { Syntax::Css };
-    let mut builder = ParserBuilder::new(code).syntax(syntax);
+    let mut builder = ParserBuilder::new(allocator, code).syntax(syntax);
     if let Some(options) = options {
         builder = builder.options(options);
     }
@@ -22,7 +25,8 @@ fn parse(code: &str, options: Option<ParserOptions>) -> Stylesheet<'_> {
 fn default_options_do_not_parse_placeholders() {
     // Without the option set, a backtick is not special (it's an ordinary syntax
     // error outside Less); the tokenizer never emits `Token::Placeholder`.
-    let builder = ParserBuilder::new("`PLACEHOLDER-0`;").syntax(Syntax::Css);
+    let allocator = Allocator::default();
+    let builder = ParserBuilder::new(&allocator, "`PLACEHOLDER-0`;").syntax(Syntax::Css);
     assert!(builder.build().parse::<Stylesheet>().is_err());
 }
 
@@ -256,7 +260,8 @@ fn media_feature_value_placeholder_glued_to_unit() {
 fn huge_index_does_not_panic() {
     // Regression: an index that overflows u32 must not panic; it fails to match
     // the placeholder shape, so the stray backtick is a value error (not a crash).
-    let builder = ParserBuilder::new("a{width:`PLACEHOLDER-9999999999`}")
+    let allocator = Allocator::default();
+    let builder = ParserBuilder::new(&allocator, "a{width:`PLACEHOLDER-9999999999`}")
         .syntax(Syntax::Scss)
         .options(opts());
     assert!(builder.build().parse::<Stylesheet>().is_err());

--- a/crates/oxc_css_parser/tests/recoverable.rs
+++ b/crates/oxc_css_parser/tests/recoverable.rs
@@ -4,7 +4,7 @@ use codespan_reporting::{
     term,
 };
 use insta::{Settings, assert_ron_snapshot, assert_snapshot, glob};
-use oxc_css_parser::{Parser, Syntax, ast::Stylesheet};
+use oxc_css_parser::{Allocator, Parser, Syntax, ast::Stylesheet};
 use std::fs;
 
 #[test]
@@ -20,7 +20,8 @@ fn recoverable_errors_snapshot() {
             "less" => Syntax::Less,
             _ => unreachable!("unknown file extension"),
         };
-        let mut parser = Parser::new(&code, syntax);
+        let allocator = Allocator::default();
+        let mut parser = Parser::new(&allocator, &code, syntax);
 
         let file = SimpleFile::new(file_name, &code);
         let config = term::Config::default();

--- a/examples/comments.rs
+++ b/examples/comments.rs
@@ -1,8 +1,9 @@
-use oxc_css_parser::{ParserBuilder, ast::Stylesheet};
+use oxc_css_parser::{Allocator, ParserBuilder, ast::Stylesheet};
 
 fn main() {
-    let mut comments = vec![];
+    let allocator = Allocator::default();
     let mut parser = ParserBuilder::new(
+        &allocator,
         "
 a {
     /* comment */
@@ -10,8 +11,8 @@ a {
 }
     ",
     )
-    .comments(&mut comments)
+    .comments()
     .build();
     let _ = parser.parse::<Stylesheet>().unwrap();
-    println!("{:#?}", comments);
+    println!("{:#?}", parser.comments());
 }

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,4 +1,4 @@
-use oxc_css_parser::{Parser, Syntax, ast::Stylesheet};
+use oxc_css_parser::{Allocator, Parser, Syntax, ast::Stylesheet};
 use std::{env, fs, path::Path};
 
 fn main() {
@@ -12,7 +12,9 @@ fn main() {
         Some("less") => Syntax::Less,
         _ => Syntax::Css,
     };
-    let ast = Parser::new(&file, syntax).parse::<Stylesheet>().unwrap();
+    let allocator = Allocator::default();
+    let mut parser = Parser::new(&allocator, &file, syntax);
+    let ast = parser.parse::<Stylesheet>().unwrap();
     let json = serde_json::to_string_pretty(&ast).unwrap();
     println!("{}", json);
 }

--- a/examples/print_ast.rs
+++ b/examples/print_ast.rs
@@ -6,7 +6,7 @@ use codespan_reporting::{
         termcolor::{ColorChoice, StandardStream},
     },
 };
-use oxc_css_parser::{Parser, Syntax, ast::Stylesheet, error::Error};
+use oxc_css_parser::{Allocator, Parser, Syntax, ast::Stylesheet, error::Error};
 use std::{env, fs, path::Path};
 
 fn main() {
@@ -21,7 +21,8 @@ fn main() {
         _ => Syntax::Css,
     };
 
-    let mut parser = Parser::new(&code, syntax);
+    let allocator = Allocator::default();
+    let mut parser = Parser::new(&allocator, &code, syntax);
     let result = parser.parse::<Stylesheet>();
     match result {
         Ok(ast) => {

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,11 +1,12 @@
-use oxc_css_parser::{Parser, ast::Stylesheet};
+use oxc_css_parser::{Allocator, Parser, ast::Stylesheet};
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(js_name = parseStylesheet)]
 pub fn parse_stylesheet(source: String, syntax: JsValue) -> Result<JsValue, JsValue> {
     let syntax = serde_wasm_bindgen::from_value(syntax)?;
-    let mut parser = Parser::new(&source, syntax);
+    let allocator = Allocator::default();
+    let mut parser = Parser::new(&allocator, &source, syntax);
     match parser.parse::<Stylesheet>() {
         Ok(ast) => {
             let serializer = serde_wasm_bindgen::Serializer::new().serialize_missing_as_null(true);


### PR DESCRIPTION
Allocates CSS AST containers and comments through `oxc_allocator`, updating parser APIs and callers to pass an arena.