### PR TITLE
bench: make parser benchmark self-contained

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,16 @@ For detailed API documentation, see [docs.rs](https://docs.rs/oxc-css-parser).
 
 The benchmark suite compares parser performance against other CSS parsers.
 
-Install `cargo-criterion`, then add CSS files to a local `bench_data` directory:
+Install `cargo-criterion`, then run the checked-in fixture benchmark:
 
 ```sh
 cargo install cargo-criterion
 cargo criterion
 ```
+
+To benchmark custom inputs, add CSS, SCSS, Sass, or Less files to a local `bench_data`
+directory. When `bench_data` contains supported files, it is used instead of the
+checked-in fixtures.
 
 ## Credits
 

--- a/benches/self.rs
+++ b/benches/self.rs
@@ -1,43 +1,83 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use oxc_css_parser::{Allocator, Parser, Syntax, ast::Stylesheet};
-use std::{fs, hint::black_box, path::Path, time::Duration};
+use std::{
+    fs,
+    hint::black_box,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+struct BenchInput {
+    name: String,
+    path: PathBuf,
+    syntax: Syntax,
+}
 
 fn bench_parser(c: &mut Criterion) {
     let mut group = c.benchmark_group("self");
     group.measurement_time(Duration::from_secs(12));
 
-    let bench_data_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..").join("bench_data");
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let bench_data_dir = workspace_root.join("bench_data");
+    let fixture_dir = workspace_root.join("benchmark/fixtures");
+    let mut inputs = collect_bench_inputs(&bench_data_dir);
+    if inputs.is_empty() {
+        inputs = collect_bench_inputs(&fixture_dir);
+    }
+    assert!(
+        !inputs.is_empty(),
+        "no benchmark inputs found in {} or {}",
+        bench_data_dir.display(),
+        fixture_dir.display(),
+    );
 
-    fs::read_dir(&bench_data_dir)
-        .unwrap_or_else(|error| {
-            panic!("failed to read benchmark data directory {}: {error}", bench_data_dir.display())
-        })
-        .filter_map(|entry| entry.ok())
-        .filter_map(|entry| {
-            entry.path().extension().and_then(|ext| ext.to_str()).and_then(|ext| match ext {
-                "css" => Some((entry, Syntax::Css)),
-                "scss" => Some((entry, Syntax::Scss)),
-                "sass" => Some((entry, Syntax::Sass)),
-                "less" => Some((entry, Syntax::Less)),
-                _ => None,
-            })
-        })
-        .filter(|(entry, ..)| entry.file_type().is_ok_and(|file_type| file_type.is_file()))
-        .for_each(|(entry, syntax)| {
-            let path = &entry.path();
-            let name = entry.file_name();
-            let name = &name.to_string_lossy();
-            let code = black_box(fs::read_to_string(path).unwrap());
+    for input in inputs {
+        let code = black_box(fs::read_to_string(&input.path).unwrap_or_else(|error| {
+            panic!("failed to read benchmark input {}: {error}", input.path.display())
+        }));
+        let syntax = input.syntax;
 
-            group.bench_with_input(BenchmarkId::from_parameter(name), &code, |b, code| {
-                b.iter(|| {
-                    let allocator = Allocator::default();
-                    let mut parser = Parser::new(&allocator, code, syntax);
-                    black_box(parser.parse::<Stylesheet>().unwrap());
-                });
+        group.bench_with_input(BenchmarkId::from_parameter(input.name), &code, |b, code| {
+            b.iter(|| {
+                let allocator = Allocator::default();
+                let mut parser = Parser::new(&allocator, code, syntax);
+                black_box(parser.parse::<Stylesheet>().unwrap());
             });
         });
+    }
     group.finish();
+}
+
+fn collect_bench_inputs(dir: &Path) -> Vec<BenchInput> {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Vec::new();
+    };
+
+    let mut inputs = entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            if !entry.file_type().is_ok_and(|file_type| file_type.is_file()) {
+                return None;
+            }
+
+            let path = entry.path();
+            let syntax = syntax_from_path(&path)?;
+            let name = entry.file_name().to_string_lossy().into_owned();
+            Some(BenchInput { name, path, syntax })
+        })
+        .collect::<Vec<_>>();
+    inputs.sort_unstable_by(|a, b| a.name.cmp(&b.name));
+    inputs
+}
+
+fn syntax_from_path(path: &Path) -> Option<Syntax> {
+    match path.extension()?.to_str()? {
+        "css" => Some(Syntax::Css),
+        "scss" => Some(Syntax::Scss),
+        "sass" => Some(Syntax::Sass),
+        "less" => Some(Syntax::Less),
+        _ => None,
+    }
 }
 
 criterion_group!(benches, bench_parser);

--- a/benchmark/fixtures/css-media.css
+++ b/benchmark/fixtures/css-media.css
@@ -1,0 +1,197 @@
+@media screen, (orientation) {}
+@media screen, not (orientation) {}
+@media ((orientation)), not all and ((orientation)) {}
+@media (not (orientation)), not all and (not (orientation)) {}
+@media screen, all and (orientation) {}
+@media screen, not all and (orientation) {}
+@media screen, only all and (orientation) {}
+@media screen, (orientation) and (orientation) {}
+@media screen, (orientation) or (orientation) {}
+@media screen, (orientation) or ((orientation) and ((orientation) or (orientation) or (not (orientation)))) {}
+@media ((orientation) and (orientation)), not all and ((orientation) and (orientation)) {}
+@media ((orientation) or (orientation)), not all and ((orientation) or (orientation)) {}
+@media ((orientation) or ((orientation) and ((orientation) or (orientation) or (not (orientation))))), not all and ((orientation) or ((orientation) and ((orientation) or (orientation) or (not (orientation))))) {}
+@media screen, all and (orientation) and (orientation) {}
+
+@media (width : 0), not all and (width : 0) {}
+@media (width : 0px), not all and (width : 0px) {}
+@media (width : -0), not all and (width : -0) {}
+@media (width : -0cm), not all and (width : -0cm) {}
+@media (width : 1px), not all and (width : 1px) {}
+@media (width : 0.001mm), not all and (width : 0.001mm) {}
+@media screen, (width : -1px) {}
+
+@media (width > 0), not all and (width > 0) {}
+@media (width > 0px), not all and (width > 0px) {}
+@media (width > -0), not all and (width > -0) {}
+@media (width > -0cm), not all and (width > -0cm) {}
+@media (width > 1px), not all and (width > 1px) {}
+@media (width > 0.001mm), not all and (width > 0.001mm) {}
+@media screen, (width > -1px) {}
+@media (width > -1px), not all and (width > -1px) {}
+@media (0px > width > 0px), not all and (0px > width > 0px) {}
+@media (0px > width >= 0px), not all and (0px > width >= 0px) {}
+@media screen, (0px > width = 0px) {}
+@media (0px > width = 0px), not all and (0px > width = 0px) {}
+@media screen, (0px > width <= 0px) {}
+@media (0px > width <= 0px), not all and (0px > width <= 0px) {}
+@media screen, (0px > width < 0px) {}
+@media (0px > width < 0px), not all and (0px > width < 0px) {}
+@media (width >= 0), not all and (width >= 0) {}
+@media (width >= 0px), not all and (width >= 0px) {}
+@media (width >= -0), not all and (width >= -0) {}
+@media (width >= -0cm), not all and (width >= -0cm) {}
+@media (width >= 1px), not all and (width >= 1px) {}
+@media (width >= 0.001mm), not all and (width >= 0.001mm) {}
+@media screen, (min-width >= -0) {}
+@media screen, (width >= -1px) {}
+@media (width >= -1px), not all and (width >= -1px) {}
+@media screen, (width >= -0.00001mm) {}
+@media (width >= -0.00001mm), not all and (width >= -0.00001mm) {}
+@media screen, (width >= -100000em) {}
+@media (width >= -100000em), not all and (width >= -100000em) {}
+@media (0px >= width > 0px), not all and (0px >= width > 0px) {}
+@media (0px >= width >= 0px), not all and (0px >= width >= 0px) {}
+@media screen, (0px >= width = 0px) {}
+@media (0px >= width = 0px), not all and (0px >= width = 0px) {}
+@media screen, (0px >= width <= 0px) {}
+@media (0px >= width <= 0px), not all and (0px >= width <= 0px) {}
+@media screen, (0px >= width < 0px) {}
+@media (0px >= width < 0px), not all and (0px >= width < 0px) {}
+@media (width = 0), not all and (width = 0) {}
+@media (width = 0px), not all and (width = 0px) {}
+@media (width = -0), not all and (width = -0) {}
+@media (width = -0cm), not all and (width = -0cm) {}
+@media (width = 0.001mm), not all and (width = 0.001mm) {}
+@media screen, (0px = width = 100000px) {}
+@media (0px = width = 100000px), not all and (0px = width = 100000px) {}
+@media screen, (width = -1px) {}
+@media (width = -1px), not all and (width = -1px) {}
+@media screen, (width = -0.00001mm) {}
+@media (width = -0.00001mm), not all and (width = -0.00001mm) {}
+@media screen, (0px = width > 0px) {}
+@media (0px = width > 0px), not all and (0px = width > 0px) {}
+@media screen, (0px = width >= 0px) {}
+@media (0px = width >= 0px), not all and (0px = width >= 0px) {}
+@media screen, (0px = width = 0px) {}
+@media (0px = width = 0px), not all and (0px = width = 0px) {}
+@media screen, (0px = width <= 0px) {}
+@media (0px = width <= 0px), not all and (0px = width <= 0px) {}
+@media screen, (0px = width < 0px) {}
+@media (0px = width < 0px), not all and (0px = width < 0px) {}
+@media (width <= 0), not all and (width <= 0) {}
+@media (width <= 0px), not all and (width <= 0px) {}
+@media (width <= -0), not all and (width <= -0) {}
+@media (width <= -0cm), not all and (width <= -0cm) {}
+@media (width <= 0.001mm), not all and (width <= 0.001mm) {}
+@media (0px <= width <= 100000px), not all and (0px <= width <= 100000px) {}
+@media screen, (width <= -1px) {}
+@media (width <= -1px), not all and (width <= -1px) {}
+@media screen, (width <= -0.00001mm) {}
+@media (width <= -0.00001mm), not all and (width <= -0.00001mm) {}
+@media screen, (0px <= width > 0px) {}
+@media (0px <= width > 0px), not all and (0px <= width > 0px) {}
+@media screen, (0px <= width >= 0px) {}
+@media (0px <= width >= 0px), not all and (0px <= width >= 0px) {}
+@media screen, (0px <= width = 0px) {}
+@media (0px <= width = 0px), not all and (0px <= width = 0px) {}
+@media (0px <= width <= 0px), not all and (0px <= width <= 0px) {}
+@media (0px <= width < 0px), not all and (0px <= width < 0px) {}
+@media (width < 0), not all and (width < 0) {}
+@media (width < 0px), not all and (width < 0px) {}
+@media (width < -0), not all and (width < -0) {}
+@media (width < -0cm), not all and (width < -0cm) {}
+@media (width < 0.001mm), not all and (width < 0.001mm) {}
+@media screen, (width < -1px) {}
+@media (width < -1px), not all and (width < -1px) {}
+@media screen, (0px < width > 0px) {}
+@media (0px < width > 0px), not all and (0px < width > 0px) {}
+@media screen, (0px < width >= 0px) {}
+@media (0px < width >= 0px), not all and (0px < width >= 0px) {}
+@media screen, (0px < width = 0px) {}
+@media (0px < width = 0px), not all and (0px < width = 0px) {}
+@media (0px < width <= 0px), not all and (0px < width <= 0px) {}
+@media (0px < width < 0px), not all and (0px < width < 0px) {}
+
+@media all and (width: 117px) {}
+@media all and (width = 117px) {}
+@media (width < 117px) {}
+@media (width > 117px) {}
+@media (width <= 118px) {}
+@media (width >= 118px) {}
+@media (116px < width) {}
+@media (116px <= width) {}
+@media (116px > width) {}
+@media (116px >= width) {}
+@media (116px < width < 118px) {}
+@media (116px < width <= 117px) {}
+@media (117px <= width < 118px) {}
+@media (118px > width > 116px) {}
+@media (118px > width >= 117px) {}
+@media (117px >= width > 116px) {}
+
+@media (orientation) {}
+@media (orientation: landscape) {}
+@media (orientation), not all and (orientation) {}
+@media (orientation: portrait), not all and (orientation: portrait) {}
+
+@media (max-aspect-ratio: 1/1), not all and (max-aspect-ratio: 1/1) {}
+@media (max-aspect-ratio: 1  /1), not all and (max-aspect-ratio: 1  /1) {}
+@media (max-aspect-ratio: 1  /
+1), not all and (max-aspect-ratio: 1  /
+1) {}
+@media (max-aspect-ratio: 1/
+1), not all and (max-aspect-ratio: 1/
+1) {}
+@media (max-aspect-ratio: 1.0/1), not all and (max-aspect-ratio: 1.0/1) {}
+@media (max-aspect-ratio: 0/1), not all and (max-aspect-ratio: 0/1) {}
+@media (resolution: 3dpi), not all and (resolution: 3dpi) {}
+@media (resolution:3dpi), not all and (resolution:3dpi) {}
+@media (resolution: 3.0dpi), not all and (resolution: 3.0dpi) {}
+@media (resolution	: 120dpcm), not all and (resolution	: 120dpcm) {}
+@media (resolution: 1dppx), not all and (resolution: 1dppx) {}
+@media (resolution: 1x), not all and (resolution: 1x) {}
+
+@media all,badmedium {}
+@media badmedium,all {}
+@media all,(badexpression) {}
+@media (badexpression),all {}
+@media (badexpression),badmedium {}
+@media badmedium,(badexpression) {}
+
+@media not all and (bogus) {}
+@media only all and (bogus) {}
+@media (hover), not all and (hover) {}
+@media (hover: hover), not all and (hover: hover) {}
+@media (hover: none), not all and (hover: none) {}
+@media (any-hover), not all and (any-hover) {}
+@media (any-hover: hover), not all and (any-hover: hover) {}
+@media (any-hover: none), not all and (any-hover: none) {}
+
+@media (height) or (height) {}
+@media (width) or (height) {}
+@media (height) or (width) {}
+@media (height) or (width) or (height) {}
+
+@media ((height)) {}
+@media ((width)) {}
+@media (((((width))))) {}
+
+@media not (width) {}
+@media not (height) {}
+@media not ((width) and (height)) {}
+@media not ((width) or (height)) {}
+@media not ((width) and (not (height))) {}
+
+@MeDIa aLL and (Height) AnD (mIN-Width:0cM) aND (orienTAtion:LandScape) {}
+@MeDIa nOT All and (heiGHt) and (Min-widtH:0MM) and (Orientation:porTrait) {}
+
+@media (--FOO: bar) {}
+
+@media (min-width: calc(1px - 1px)) {}
+@media (min-width: calc(1em)) {}
+@media (min-width: calc(1px * 2 + 1rem)) {}
+@media (min-width: calc(1 * (2px + 1rem))) {}
+
+/* non-standard syntax, but for Tailwind CSS */
+@media screen(md) {}

--- a/benchmark/fixtures/less-mixin-definition.less
+++ b/benchmark/fixtures/less-mixin-definition.less
@@ -1,0 +1,91 @@
+.mixin_def(@url, @position) {
+  background-image: @url;
+  background-position: @position;
+}
+
+.clearfix() {
+  // ...
+}
+
+.light (@a) when (lightness(@a) > 50%) {
+  color: inherit;
+}
+.light (@a) when (lightness(@a) < 50%) {
+  color: black;
+}
+
+.max (@a, @b) when (@a > @b) {
+  width: @a;
+}
+.max (@a, @b) when (@a < @b) {
+  width: @b;
+}
+
+.ops (@a) when (@a = 0) {}
+.ops (@a) when (@a >= 0) {}
+.ops (@a) when (@a => 0) {}
+.ops (@a) when (@a <= 0) {}
+.ops (@a) when (@a =< 0) {}
+.ops (@a) when not(@a = 0) {}
+
+.default (@a: inherit) when (@a = inherit) {}
+
+.bool () when (true) and (false)                             {}
+.bool () when (true) and (true)                              {}
+.bool () when (true)                                         {}
+.bool () when (false) and (false)                            {}
+.bool () when (false), (true)                                {}
+.bool () when (false) and (true) and (true),  (true)         {}
+.bool () when (true)  and (true) and (false), (false)        {}
+.bool () when (false), (true) and (true)                     {}
+.bool () when (false), (false), (true)                       {}
+.bool () when (false), (false) and (true), (false)           {}
+.bool () when (false), (true) and (true) and (true), (false) {}
+.bool () when not (false)                                    {}
+.bool () when not (true) and not (false)                     {}
+.bool () when not (true) and not (true)                      {}
+.bool () when not (false) and (false), not (false)           {}
+
+.parenthesisNot(@value) when ((((@value)))) {}
+.parenthesisNot(@value) when (((not(@value)))) {}
+.parenthesisNot(@value) when not((((@value)))) {}
+.parenthesisNot(@value) when ((not((@value)))) {}
+.parenthesisNot(@value) when not(((not(@value)))) {}
+.parenthesisNot(@value) when (not((not(@value)))) {}
+.parenthesisNot(@value) when ((not(not(@value)))) {}
+.parenthesisNot (...) when (default()) {}
+
+.orderOfEvaluation(@a1, @a2, @a3) when ((@a1) and (@a2) or (@a3)) {}
+.orderOfEvaluation(@a1, @a2, @a3) when ((@a3) or (@a1) and (@a2)) {}
+.orderOfEvaluation(@a1, @a2, @a3) when ((@a1) and ((@a2) or (@a3))) {}
+.orderOfEvaluation(@a1, @a2, @a3) when (@a3), (@a1) and (@a2) {}
+.orderOfEvaluation(@a1, @a2, @a3) when (((@a3) or (@a1)) and (@a2)) {}
+.orderOfEvaluation(@a1, @a2, @a3) when ((@a1) and (@a2) or not (@a3)) {}
+.orderOfEvaluation(@a1, @a2, @a3) when (not (@a3) or (@a1) and (@a2)) {}
+.orderOfEvaluation(@a1, @a2, @a3) when not (@a3), (@a1) and (@a2) {}
+.orderOfEvaluation(@a1, @a2, @a3) when (not (@a1) and (@a2) or (@a3)) {}
+.orderOfEvaluation(@a1, @a2, @a3) when ((((@a1) and (@a2) or (@a3)))) {}
+.orderOfEvaluation(@a1, @a2, @a3) when (((@a1) and (@a2)) or (@a3)) {}
+.orderOfEvaluation(...) when (default()) {}
+
+.mixin (@a: 1px, @b: 50%) {}
+.mixin (@a: 1px, @b: 50%) when (@b > 75%) {}
+
+.mixin (...) {}
+.mixin (@a...) {}
+.mixin ('left') {}
+.mxin ('right') {}
+.border-side (left, @w) {}
+.border-radius (@r, left) {}
+
+.mixin ($a) {}
+.mixin ($a: 1px) {}
+.mixin ($a...) {}
+
+.mixin-arguments (@width: 0px, ...) {}
+
+.border-radius(@r: 2px/5px) {}
+
+.mixin(@list: 1 2) {}
+
+.conditions-parser-1 when ((8+6) < 13) {}

--- a/benchmark/fixtures/sass-map.sass
+++ b/benchmark/fixtures/sass-map.sass
@@ -1,0 +1,15 @@
+$theme-light: (
+  col-primary-bg: #F8FAFC
+)
+$theme-light: (
+  col-primary-bg: #F8FAFC,
+  col-secondary-bg: #E2E8F0
+)
+$theme-light: (
+  col-primary-bg: #F8FAFC
+, col-secondary-bg: #E2E8F0
+)
+$theme-light: (
+  col-primary-bg: #F8FAFC,
+  col-secondary-bg: #E2E8F0,
+)

--- a/benchmark/fixtures/scss-interpolation.scss
+++ b/benchmark/fixtures/scss-interpolation.scss
@@ -1,0 +1,283 @@
+foo[val="bar #{"foo" + " bar"} baz"] {a: b}
+
+@foo #{"directive"} {
+  .#{"foo"} { #{"foo-prop"}: #{"foo-val"}; }
+}
+
+a /*#{"}*/ {
+  margin: 2px;
+}
+
+a /*#{#{*/ {
+  margin: 2px;
+}
+
+div {
+  blah: "hello #{2+2} world #{unit(23px)} #{'bloo\n'} blah";
+}
+
+a { --#{"foo"}-bar: b; }
+
+[#{$zzz}=foo] { a: b; }
+.#{$zzz} { a: b; }
+##{$zzz} { a: b; }
+:#{$zzz}::#{$zzz} { a: b; }
+
+.js:root #{if(&, '&', '')} {}
+
+.col#{$infix}-#{$i} {}
+
+tr:nth-child(#{$table-striped-order}) {}
+tr:nth-of-type(#{$table-striped-order}) {}
+
+@#{$ar-name} #{meta.call($converter, $ar-str, $this-util)} {}
+@#{$name} #{"#{$blocks}"} {}
+
+.after-hyphen {
+  // We want to treat interpolation as though it's a valid identifier character,
+  // which means that if it comes after a hyphen or double-hyphen it should be
+  // treated as part of an interpolated identifier that includes that hyphen.
+  standalone-single: -#{foo};
+  standalone-double: --#{foo};
+
+  // It also means that we shouldn't treat the hyphen as a subtraction
+  // operation.
+  adjacent-single: #{foo} -#{bar};
+  adjacent-double: #{foo} --#{bar};
+}
+
+.trailing-non-name-start {
+  // We want to treat interpolation as though it's a valid identifier character,
+  // which means that if it's followed by a [name character][] that's not a
+  // [name start character][] it should still treat that as part of the
+  // identifier.
+  //
+  // [name character]: https://drafts.csswg.org/css-syntax-3/#name-code-point
+  // [name start character]: https://drafts.csswg.org/css-syntax-3/#name-start-code-point
+  digit: foo#{bar}12;
+  hyphen: foo#{bar}-12;
+  double-hyphen: foo#{bar}--12;
+}
+
+.double-interpolation {
+  output: #{#{literal}};
+  output: #{"[#{literal}]"};
+  output: #{"#{literal}"};
+  output: #{'#{literal}'};
+  output: #{"['#{literal}']"};
+}
+
+.escape {
+  output: "[\#{literal}]";
+  output: "\#{literal}";
+  output: '\#{literal}';
+  output: "['\#{literal}']";
+}
+
+.double-quoted {
+  output: #{"dquoted"};
+  output: "[#{"dquoted"}]";
+  output: "#{"dquoted"}";
+  output: '#{"dquoted"}';
+  output: "['#{"dquoted"}']";
+}
+
+.singled-quoted {
+  output: #{'squoted'};
+  output: "[#{'squoted'}]";
+  output: "#{'squoted'}";
+  output: '#{'squoted'}';
+  output: "['#{'squoted'}']";
+}
+
+.space-list-quoted {
+  output: #{"alpha" 'beta'};
+  output: "[#{"alpha" 'beta'}]";
+  output: "#{"alpha" 'beta'}";
+  output: '#{"alpha" 'beta'}';
+  output: "['#{"alpha" 'beta'}']";
+}
+
+.comma-list-quoted {
+  output: #{"alpha", 'beta'};
+  output: "[#{"alpha", 'beta'}]";
+  output: "#{"alpha", 'beta'}";
+  output: '#{"alpha", 'beta'}';
+  output: "['#{"alpha", 'beta'}']";
+}
+
+.space-list-complex {
+  output: #{gamme "'"delta"'"};
+  output: "[#{gamme "'"delta"'"}]";
+  output: "#{gamme "'"delta"'"}";
+  output: '#{gamme "'"delta"'"}';
+  output: "['#{gamme "'"delta"'"}']";
+}
+
+.comma-list-complex {
+  output: #{gamma, "'"delta"'"};
+  output: "[#{gamma, "'"delta"'"}]";
+  output: "#{gamma, "'"delta"'"}";
+  output: '#{gamma, "'"delta"'"}';
+  output: "['#{gamma, "'"delta"'"}']";
+}
+
+.escaped-backslash {
+  output: #{\\};
+  output: "[#{\\}]";
+  output: "#{\\}";
+  output: '#{\\}';
+  output: "['#{\\}']";
+}
+
+.escaped-literal {
+  output: #{l\\ite\ral};
+  output: "[#{l\\ite\ral}]";
+  output: "#{l\\ite\ral}";
+  output: '#{l\\ite\ral}';
+  output: "['#{l\\ite\ral}']";
+}
+
+.escaped-double-quoted {
+  output: #{"l\\ite\ral"};
+  output: "[#{"l\\ite\ral"}]";
+  output: "#{"l\\ite\ral"}";
+  output: '#{"l\\ite\ral"}';
+  output: "['#{"l\\ite\ral"}']";
+}
+
+.escaped-single-quoted {
+  output: #{'l\\ite\ral'};
+  output: "[#{'l\\ite\ral'}]";
+  output: "#{'l\\ite\ral'}";
+  output: '#{'l\\ite\ral'}';
+  output: "['#{'l\\ite\ral'}']";
+}
+
+.escapes-literal-numbers {
+  output: #{\1\2\3\4\5\6\7\8\9};
+  output: "[#{\1\2\3\4\5\6\7\8\9}]";
+  output: "#{\1\2\3\4\5\6\7\8\9}";
+  output: '#{\1\2\3\4\5\6\7\8\9}';
+  output: "['#{\1\2\3\4\5\6\7\8\9}']";
+}
+
+.escapes-double-quoted-numbers {
+  output: #{"\1\2\3\4\5\6\7\8\9"};
+  output: "[#{"\1\2\3\4\5\6\7\8\9"}]";
+  output: "#{"\1\2\3\4\5\6\7\8\9"}";
+  output: '#{"\1\2\3\4\5\6\7\8\9"}';
+  output: "['#{"\1\2\3\4\5\6\7\8\9"}']";
+}
+
+.escapes-single-qouted-numbers {
+  output: #{'\1\2\3\4\5\6\7\8\9'};
+  output: "[#{'\1\2\3\4\5\6\7\8\9'}]";
+  output: "#{'\1\2\3\4\5\6\7\8\9'}";
+  output: '#{'\1\2\3\4\5\6\7\8\9'}';
+  output: "['#{'\1\2\3\4\5\6\7\8\9'}']";
+}
+
+.escapes-literal-lowercase {
+  output: #{\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z};
+  output: "[#{\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z}]";
+  output: "#{\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z}";
+  output: '#{\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z}';
+  output: "['#{\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z}']";
+}
+
+.escapes-double-quoted-lowercase {
+  output: #{"\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z"};
+  output: "[#{"\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z"}]";
+  output: "#{"\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z"}";
+  output: '#{"\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z"}';
+  output: "['#{"\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z"}']";
+}
+
+.escapes-single-quoted-lowercase {
+  output: #{'\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z'};
+  output: "[#{'\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z'}]";
+  output: "#{'\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z'}";
+  output: '#{'\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z'}';
+  output: "['#{'\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z'}']";
+}
+
+.escapes-literal-uppercase {
+  output: #{\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z};
+  output: "[#{\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z}]";
+  output: "#{\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z}";
+  output: '#{\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z}';
+  output: "['#{\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z}']";
+}
+
+.escapes-double-quoted-uppercase {
+  output: #{"\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z"};
+  output: "[#{"\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z"}]";
+  output: "#{"\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z"}";
+  output: '#{"\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z"}';
+  output: "['#{"\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z"}']";
+}
+
+.escapes-single-qouted-uppercase {
+  output: #{'\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z'};
+  output: "[#{'\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z'}]";
+  output: "#{'\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z'}";
+  output: '#{'\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z'}';
+  output: "['#{'\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z'}']";
+}
+
+.escapes-literal-specials {
+  output: #{\0_\a_\A};
+  output: "[#{\0_\a_\A}]";
+  output: "#{\0_\a_\A}";
+  output: '#{\0_\a_\A}';
+  output: "['#{\0_\a_\A}']";
+}
+
+.escapes-double-quoted-specials {
+  output: #{"\0_\a_\A"};
+  output: "[#{"\0_\a_\A"}]";
+  output: "#{"\0_\a_\A"}";
+  output: '#{"\0_\a_\A"}';
+  output: "['#{"\0_\a_\A"}']";
+}
+
+.escaped-single-quoted-specials {
+  output: #{'\0_\a_\A'};
+  output: "[#{'\0_\a_\A'}]";
+  output: "#{'\0_\a_\A'}";
+  output: '#{'\0_\a_\A'}';
+  output: "['#{'\0_\a_\A'}']";
+}
+
+.escaped-literal-qoutes {
+  output: #{\"\'};
+  output: "[#{\"\'}]";
+  output: "#{\"\'}";
+  output: '#{\"\'}';
+  output: "['#{\"\'}']";
+}
+
+.escaped-double-quotes {
+  output: #{"\""};
+  output: "[#{"\""}]";
+  output: "#{"\""}";
+  output: '#{"\""}';
+  output: "['#{"\""}']";
+}
+
+.escaped-single-quotes {
+  output: #{'\''};
+  output: "[#{'\''}]";
+  output: "#{'\''}";
+  output: '#{'\''}';
+  output: "['#{'\''}']";
+}
+
+.weird-space-separated-list {
+  output: #{"["'foo'"]"};
+  output: "[#{"["'foo'"]"}]";
+  output: "#{"["'foo'"]"}";
+  output: '#{"["'foo'"]"}';
+  output: "['#{"["'foo'"]"}']";
+}


### PR DESCRIPTION
Adds checked-in CSS, SCSS, Sass, and Less benchmark fixtures and falls back to them when local `bench_data` is absent. Custom `bench_data` inputs still take precedence.

Validated locally with fmt, tests, Clippy, and `cargo bench -p oxc-css-parser --bench self`.