### PR TITLE
perf: box oversized ComponentValue variants

### DIFF
--- a/crates/oxc_css_parser/src/ast.rs
+++ b/crates/oxc_css_parser/src/ast.rs
@@ -231,7 +231,7 @@ pub enum ComponentValue<'a> {
     LessEscapedStr(LessEscapedStr<'a>),
     LessJavaScriptSnippet(LessJavaScriptSnippet<'a>),
     LessList(LessList<'a>),
-    LessMixinCall(LessMixinCall<'a>),
+    LessMixinCall(Box<'a, LessMixinCall<'a>>),
     LessNamespaceValue(Box<'a, LessNamespaceValue<'a>>),
     LessNegativeValue(LessNegativeValue<'a>),
     LessParenthesizedOperation(LessParenthesizedOperation<'a>),
@@ -248,7 +248,7 @@ pub enum ComponentValue<'a> {
     SassKeywordArgument(SassKeywordArgument<'a>),
     SassList(SassList<'a>),
     SassMap(SassMap<'a>),
-    SassQualifiedName(SassQualifiedName<'a>),
+    SassQualifiedName(Box<'a, SassQualifiedName<'a>>),
     SassNestingDeclaration(SassNestingDeclaration<'a>),
     SassParenthesizedExpression(SassParenthesizedExpression<'a>),
     SassParentSelector(NestingSelector<'a>),
@@ -256,7 +256,7 @@ pub enum ComponentValue<'a> {
     SassVariable(SassVariable<'a>),
     TokenWithSpan(TokenWithSpan<'a>),
     UnicodeRange(UnicodeRange<'a>),
-    Url(Url<'a>),
+    Url(Box<'a, Url<'a>>),
 }
 
 #[derive(Debug)]

--- a/crates/oxc_css_parser/src/parser/less.rs
+++ b/crates/oxc_css_parser/src/parser/less.rs
@@ -319,7 +319,7 @@ impl<'a> Parser<'a> {
                 }
             )))
         } else {
-            Ok(ComponentValue::LessMixinCall(mixin_call))
+            Ok(ComponentValue::LessMixinCall(arena_box!(self, mixin_call)))
         }
     }
 

--- a/crates/oxc_css_parser/src/parser/value.rs
+++ b/crates/oxc_css_parser/src/parser/value.rs
@@ -73,7 +73,7 @@ impl<'a> Parser<'a> {
             Token::Ident(token) => {
                 if token.name().eq_ignore_ascii_case("url") {
                     match self.try_parse(Url::parse) {
-                        Ok(url) => return Ok(ComponentValue::Url(url)),
+                        Ok(url) => return Ok(ComponentValue::Url(arena_box!(self, url))),
                         Err(Error { kind: ErrorKind::TryParseError, .. }) => {}
                         Err(error) => {
                             return if matches!(self.syntax, Syntax::Scss | Syntax::Sass) {
@@ -96,7 +96,8 @@ impl<'a> Parser<'a> {
                             InterpolableIdent::Literal(ident)
                                 if ident.name.eq_ignore_ascii_case("src") =>
                             {
-                                self.parse_src_url(ident).map(ComponentValue::Url)
+                                self.parse_src_url(ident)
+                                    .map(|url| ComponentValue::Url(arena_box!(self, url)))
                             }
                             ident => self.parse_function(ident).map(ComponentValue::Function),
                         };
@@ -123,7 +124,7 @@ impl<'a> Parser<'a> {
                                     span,
                                 }))
                             } else {
-                                Ok(ComponentValue::SassQualifiedName(name))
+                                Ok(ComponentValue::SassQualifiedName(arena_box!(self, name)))
                             };
                         }
                     }


### PR DESCRIPTION
## Summary

`ComponentValue` — the value type the parser moves and returns by value throughout value parsing — was **192 bytes**, so every move / return / `Vec` push copied 192 bytes.

Its width was pinned by three rare, oversized variants, all above the 128-byte `memcpy` threshold:

| variant | size | scope |
|---|---|---|
| `LessMixinCall` | 192 B | Less only |
| `Url` | 160 B | — |
| `SassQualifiedName` | 128 B | Sass only |

Boxing them into the arena (`Box`, exactly like the existing `LessCondition` / `LessNamespaceValue` variants) shrinks `ComponentValue` from **192 → 120 bytes**, without penalising the hot, small variants (`Dimension` stays inline at 112 B).

## Results

Parsing ~1.5 MB fixtures (criterion, reproduced over two runs):

| syntax | change |
|---|---|
| css  | −11.4 … −12.1% |
| less |  −9.3 …  −9.4% |
| sass | −13.3% |
| scss | −11.5 … −12.2% |

## Correctness

- `cargo test --all-features` passes — all snapshots byte-identical.
- The serialized AST is **byte-identical to `main`** across all four syntaxes on the 1.5 MB corpus (14.5M+ lines of serialized AST), since boxing is a pure memory-layout change.

## Note

The `variant_helpers` accessors (`as_url()`, `as_less_mixin_call()`, `as_sass_qualified_name()`) now hand back `&Box<…>` rather than `&…`, consistent with the already-boxed `LessCondition` / `LessNamespaceValue`. `Box` derefs transparently.
