### PR TITLE
perf: box oversized Sass/Less variants of Statement

### DIFF
--- a/crates/oxc_css_parser/src/ast.rs
+++ b/crates/oxc_css_parser/src/ast.rs
@@ -2267,13 +2267,13 @@ pub enum Statement<'a> {
     LessExtendRule(LessExtendRule<'a>),
     LessFunctionCall(Function<'a>),
     LessMixinCall(LessMixinCall<'a>),
-    LessMixinDefinition(LessMixinDefinition<'a>),
+    LessMixinDefinition(Box<'a, LessMixinDefinition<'a>>),
     LessVariableCall(LessVariableCall<'a>),
-    LessVariableDeclaration(LessVariableDeclaration<'a>),
+    LessVariableDeclaration(Box<'a, LessVariableDeclaration<'a>>),
     Placeholder(Placeholder<'a>),
     QualifiedRule(QualifiedRule<'a>),
-    SassIfAtRule(SassIfAtRule<'a>),
-    SassVariableDeclaration(SassVariableDeclaration<'a>),
+    SassIfAtRule(Box<'a, SassIfAtRule<'a>>),
+    SassVariableDeclaration(Box<'a, SassVariableDeclaration<'a>>),
     UnknownSassAtRule(Box<'a, UnknownSassAtRule<'a>>),
 }
 

--- a/crates/oxc_css_parser/src/parser/stmt.rs
+++ b/crates/oxc_css_parser/src/parser/stmt.rs
@@ -297,7 +297,10 @@ impl<'a> Parser<'a> {
                             if let Ok(sass_var_decl) =
                                 self.try_parse(SassVariableDeclaration::parse)
                             {
-                                statements.push(Statement::SassVariableDeclaration(sass_var_decl));
+                                statements.push(Statement::SassVariableDeclaration(arena_box!(
+                                    self,
+                                    sass_var_decl
+                                )));
                             } else if self.state.in_keyframes_at_rule {
                                 statements.push(Statement::KeyframeBlock(self.parse()?));
                                 is_block_element = true;
@@ -367,7 +370,7 @@ impl<'a> Parser<'a> {
                         stmt
                     } else if let Ok(mixin_def) = self.try_parse(LessMixinDefinition::parse) {
                         is_block_element = true;
-                        Statement::LessMixinDefinition(mixin_def)
+                        Statement::LessMixinDefinition(arena_box!(self, mixin_def))
                     } else {
                         self.parse().map(Statement::LessMixinCall)?
                     };
@@ -408,7 +411,10 @@ impl<'a> Parser<'a> {
                         let at_keyword_name = at_keyword.ident.name();
                         match &*at_keyword_name {
                             "if" => {
-                                statements.push(Statement::SassIfAtRule(self.parse()?));
+                                statements.push(Statement::SassIfAtRule(arena_box!(
+                                    self,
+                                    self.parse()?
+                                )));
                                 is_block_element = true;
                             }
                             "else" => {
@@ -432,9 +438,10 @@ impl<'a> Parser<'a> {
                                 less_variable_declaration.value,
                                 ComponentValue::LessDetachedRuleset(..)
                             );
-                            statements.push(Statement::LessVariableDeclaration(
-                                less_variable_declaration,
-                            ));
+                            statements.push(Statement::LessVariableDeclaration(arena_box!(
+                                self,
+                                less_variable_declaration
+                            )));
                         } else if let Ok(variable_call) = self.try_parse(LessVariableCall::parse) {
                             statements.push(Statement::LessVariableCall(variable_call));
                         } else {
@@ -480,7 +487,10 @@ impl<'a> Parser<'a> {
                     is_block_element = true;
                 }
                 Token::DollarVar(..) if matches!(self.syntax, Syntax::Scss | Syntax::Sass) => {
-                    statements.push(Statement::SassVariableDeclaration(self.parse()?));
+                    statements.push(Statement::SassVariableDeclaration(arena_box!(
+                        self,
+                        self.parse()?
+                    )));
                 }
                 Token::GreaterThan(..) | Token::Plus(..) | Token::Tilde(..) | Token::BarBar(..) => {
                     if self.syntax == Syntax::Less {

--- a/crates/oxc_css_parser/src/parser/stmt.rs
+++ b/crates/oxc_css_parser/src/parser/stmt.rs
@@ -411,10 +411,8 @@ impl<'a> Parser<'a> {
                         let at_keyword_name = at_keyword.ident.name();
                         match &*at_keyword_name {
                             "if" => {
-                                statements.push(Statement::SassIfAtRule(arena_box!(
-                                    self,
-                                    self.parse()?
-                                )));
+                                statements
+                                    .push(Statement::SassIfAtRule(arena_box!(self, self.parse()?)));
                                 is_block_element = true;
                             }
                             "else" => {
@@ -487,10 +485,8 @@ impl<'a> Parser<'a> {
                     is_block_element = true;
                 }
                 Token::DollarVar(..) if matches!(self.syntax, Syntax::Scss | Syntax::Sass) => {
-                    statements.push(Statement::SassVariableDeclaration(arena_box!(
-                        self,
-                        self.parse()?
-                    )));
+                    statements
+                        .push(Statement::SassVariableDeclaration(arena_box!(self, self.parse()?)));
                 }
                 Token::GreaterThan(..) | Token::Plus(..) | Token::Tilde(..) | Token::BarBar(..) => {
                     if self.syntax == Syntax::Less {


### PR DESCRIPTION
> **Draft — has a tradeoff to decide on.** Big win on CSS/SCSS, a sub-0.5% regression on pure-Less/pure-Sass fixtures. Numbers below; merge only if the tradeoff is acceptable.

## Summary

`Statement` is stored in every block's `Vec<Statement>` and was **360 bytes**, pinned by four large, **syntax-specific** variants:

| variant | size |
|---|---|
| `SassVariableDeclaration` | 360 B |
| `SassIfAtRule` | 352 B |
| `LessMixinDefinition` | 288 B |
| `LessVariableDeclaration` | 288 B |

These never occur in CSS or SCSS, yet every CSS/SCSS statement paid for the 360-byte width. Boxing them into the arena (same pattern as the existing `UnknownSassAtRule` variant) drops `Statement` to **216 bytes**.

## Results (criterion, ~1.5 MB fixtures, mean of 4 runs)

| syntax | change |
|---|---|
| css  | **−4.5%** |
| scss | **−6.0%** |
| less | +0.4% |
| sass | +0.3% |

The CSS/SCSS wins are free — the boxed variants never occur there, so the enum just gets smaller. The cost lands only on files **dominated** by these statements: the `less-mixin-definition.less` (all mixin defs) and `sass-map.sass` (all `$var:` maps) fixtures pay a small per-statement box, netting a sub-0.5% regression there.

Note: stacked on #11 (`ComponentValue` boxing, −9% on those same fixtures), the combined result is a net win on every syntax.

## Correctness

- `cargo test --all-features` passes — snapshots byte-identical.
- Serialized AST **byte-identical to `main`** across all four syntaxes on the 1.5 MB corpus.
