### PR TITLE
feat: support `<general-enclosed>` in `@media` and `@supports`

### DIFF
--- a/crates/oxc_css_parser/src/ast.rs
+++ b/crates/oxc_css_parser/src/ast.rs
@@ -1352,6 +1352,7 @@ pub struct MediaInParens<'a> {
 pub enum MediaInParensKind<'a> {
     MediaCondition(MediaCondition<'a>),
     MediaFeature(Box<'a, MediaFeature<'a>>),
+    GeneralEnclosed(TokenSeq<'a>),
     SassInterpolation(SassInterpolatedIdent<'a>),
 }
 
@@ -2414,6 +2415,7 @@ pub enum SupportsInParensKind<'a> {
     Feature(Box<'a, SupportsDecl<'a>>),
     Selector(SelectorList<'a>),
     Function(Function<'a>),
+    GeneralEnclosed(TokenSeq<'a>),
 }
 
 #[derive(Debug)]

--- a/crates/oxc_css_parser/src/ast_generated.rs
+++ b/crates/oxc_css_parser/src/ast_generated.rs
@@ -330,7 +330,7 @@ impl_spanned_struct!(MediaFeatureRange<'a>);
 impl_spanned_struct!(MediaFeatureRangeInterval<'a>);
 impl_spanned_struct!(MediaInParens<'a>);
 impl_spanned_enum!(MediaInParensKind<'a> {
-    tuple: [MediaCondition, MediaFeature, SassInterpolation, ],
+    tuple: [MediaCondition, MediaFeature, GeneralEnclosed, SassInterpolation, ],
     unit: [],
 });
 impl_spanned_struct!(MediaNot<'a>);
@@ -518,7 +518,7 @@ impl_spanned_enum!(SupportsConditionKind<'a> {
 impl_spanned_struct!(SupportsDecl<'a>);
 impl_spanned_struct!(SupportsInParens<'a>);
 impl_spanned_enum!(SupportsInParensKind<'a> {
-    tuple: [SupportsCondition, Feature, Selector, Function, ],
+    tuple: [SupportsCondition, Feature, Selector, Function, GeneralEnclosed, ],
     unit: [],
 });
 impl_spanned_struct!(SupportsNot<'a>);
@@ -952,7 +952,7 @@ impl_span_ignored_eq_struct!(MediaFeatureRangeInterval<'a> { left, left_comparis
 impl_span_ignored_eq_struct!(MediaInParens<'a> { kind, });
 #[cfg(feature = "span_ignored_eq")]
 impl_span_ignored_eq_enum!(MediaInParensKind<'a> {
-    tuple: [MediaCondition, MediaFeature, SassInterpolation, ],
+    tuple: [MediaCondition, MediaFeature, GeneralEnclosed, SassInterpolation, ],
     unit: [],
 });
 #[cfg(feature = "span_ignored_eq")]
@@ -1268,7 +1268,7 @@ impl_span_ignored_eq_struct!(SupportsDecl<'a> { decl, });
 impl_span_ignored_eq_struct!(SupportsInParens<'a> { kind, });
 #[cfg(feature = "span_ignored_eq")]
 impl_span_ignored_eq_enum!(SupportsInParensKind<'a> {
-    tuple: [SupportsCondition, Feature, Selector, Function, ],
+    tuple: [SupportsCondition, Feature, Selector, Function, GeneralEnclosed, ],
     unit: [],
 });
 #[cfg(feature = "span_ignored_eq")]
@@ -1668,6 +1668,7 @@ impl_enum_as_is!(MediaInParensKind<'a> {
     tuple: [
         MediaCondition(MediaCondition<'a>) => is_media_condition, as_media_condition,
         MediaFeature(Box<'a, MediaFeature<'a>>) => is_media_feature, as_media_feature,
+        GeneralEnclosed(TokenSeq<'a>) => is_general_enclosed, as_general_enclosed,
         SassInterpolation(SassInterpolatedIdent<'a>) => is_sass_interpolation, as_sass_interpolation,
     ],
     unit: [],
@@ -1895,6 +1896,7 @@ impl_enum_as_is!(SupportsInParensKind<'a> {
         Feature(Box<'a, SupportsDecl<'a>>) => is_feature, as_feature,
         Selector(SelectorList<'a>) => is_selector, as_selector,
         Function(Function<'a>) => is_function, as_function,
+        GeneralEnclosed(TokenSeq<'a>) => is_general_enclosed, as_general_enclosed,
     ],
     unit: [],
 });

--- a/crates/oxc_css_parser/src/parser/at_rule/media.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/media.rs
@@ -141,9 +141,20 @@ impl<'a> Parse<'a> for MediaInParensKind<'a> {
             }
         }) {
             Ok(MediaInParensKind::MediaCondition(media_condition))
-        } else {
-            let media_feature = input.parse()?;
+        } else if let Ok(media_feature) = input.try_parse(|parser| {
+            let media_feature = parser.parse::<MediaFeature>()?;
+            if matches!(&peek!(parser).token, Token::RParen(..)) {
+                Ok(media_feature)
+            } else {
+                let span = peek!(parser).span.clone();
+                Err(Error { kind: ErrorKind::ExpectMediaFeatureName, span })
+            }
+        }) {
             Ok(MediaInParensKind::MediaFeature(arena_box!(input, media_feature)))
+        } else {
+            // <general-enclosed>: MQ L4 forward-compat catch-all, evaluates false at runtime.
+            let tokens = input.parse_tokens_in_parens()?;
+            Ok(MediaInParensKind::GeneralEnclosed(tokens))
         }
     }
 }

--- a/crates/oxc_css_parser/src/parser/at_rule/supports.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/supports.rs
@@ -77,11 +77,24 @@ impl<'a> Parse<'a> for SupportsInParens<'a> {
                     })
                 })
                 .or_else(|_| {
+                    input.try_parse(|parser| {
+                        let (_, Span { start, .. }) = expect!(parser, LParen);
+                        let condition = parser.parse::<SupportsCondition>()?;
+                        let (_, Span { end, .. }) = expect!(parser, RParen);
+                        Ok(SupportsInParens {
+                            kind: SupportsInParensKind::SupportsCondition(condition),
+                            span: Span { start, end },
+                        })
+                    })
+                })
+                .or_else(|_| {
+                    // <general-enclosed>: MQ L4 catch-all (referenced from <supports-condition>),
+                    // evaluates false at runtime.
                     let (_, Span { start, .. }) = expect!(input, LParen);
-                    let condition = input.parse()?;
+                    let tokens = input.parse_tokens_in_parens()?;
                     let (_, Span { end, .. }) = expect!(input, RParen);
                     Ok(SupportsInParens {
-                        kind: SupportsInParensKind::SupportsCondition(condition),
+                        kind: SupportsInParensKind::GeneralEnclosed(tokens),
                         span: Span { start, end },
                     })
                 }),

--- a/crates/oxc_css_parser/tests/ast/at-rule/media-general-enclosed.css
+++ b/crates/oxc_css_parser/tests/ast/at-rule/media-general-enclosed.css
@@ -1,0 +1,16 @@
+/* MQ Level 4 <general-enclosed> forward-compat catch-all.
+   These do not match <media-condition> or <media-feature>, so they fall
+   through to <general-enclosed> and are accepted syntactically (evaluated
+   as false at runtime). */
+@media (not all) {}
+@media (not screen) {}
+@media (not all) and (color) {}
+@media (screen and (color)) {}
+@media (not (screen and (color))) {}
+@media (not all) and (monochrome) {}
+@media (not (screen and (color))), print and (color) {}
+
+/* Unknown future feature names with arbitrary token sequences. */
+@media (unknown-feature) and (color) {}
+@media (foo bar baz) {}
+@media (--custom-feature: 10) {}

--- a/crates/oxc_css_parser/tests/ast/at-rule/media-general-enclosed.snap
+++ b/crates/oxc_css_parser/tests/ast/at-rule/media-general-enclosed.snap
@@ -1,0 +1,1180 @@
+---
+source: crates/oxc_css_parser/tests/ast.rs
+---
+Stylesheet(
+  type: "Stylesheet",
+  statements: [
+    AtRule(
+      type: "AtRule",
+      name: Ident(
+        type: "Ident",
+        name: "media",
+        raw: "media",
+        span: Span(
+          start: 236,
+          end: 241,
+        ),
+      ),
+      prelude: Some(MediaQueryList(
+        type: "MediaQueryList",
+        queries: [
+          MediaCondition(
+            type: "MediaCondition",
+            conditions: [
+              MediaInParens(
+                type: "MediaInParens",
+                kind: TokenSeq(
+                  type: "TokenSeq",
+                  tokens: [
+                    TokenWithSpan(
+                      type: "TokenWithSpan",
+                      token: Ident(Ident(
+                        kind: "Ident",
+                        escaped: false,
+                        raw: "not",
+                      )),
+                      span: Span(
+                        start: 243,
+                        end: 246,
+                      ),
+                    ),
+                    TokenWithSpan(
+                      type: "TokenWithSpan",
+                      token: Ident(Ident(
+                        kind: "Ident",
+                        escaped: false,
+                        raw: "all",
+                      )),
+                      span: Span(
+                        start: 247,
+                        end: 250,
+                      ),
+                    ),
+                  ],
+                  span: Span(
+                    start: 243,
+                    end: 250,
+                  ),
+                ),
+                span: Span(
+                  start: 242,
+                  end: 251,
+                ),
+              ),
+            ],
+            span: Span(
+              start: 242,
+              end: 251,
+            ),
+          ),
+        ],
+        commaSpans: [],
+        span: Span(
+          start: 242,
+          end: 251,
+        ),
+      )),
+      block: Some(SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 252,
+          end: 254,
+        ),
+      )),
+      span: Span(
+        start: 235,
+        end: 254,
+      ),
+    ),
+    AtRule(
+      type: "AtRule",
+      name: Ident(
+        type: "Ident",
+        name: "media",
+        raw: "media",
+        span: Span(
+          start: 256,
+          end: 261,
+        ),
+      ),
+      prelude: Some(MediaQueryList(
+        type: "MediaQueryList",
+        queries: [
+          MediaCondition(
+            type: "MediaCondition",
+            conditions: [
+              MediaInParens(
+                type: "MediaInParens",
+                kind: TokenSeq(
+                  type: "TokenSeq",
+                  tokens: [
+                    TokenWithSpan(
+                      type: "TokenWithSpan",
+                      token: Ident(Ident(
+                        kind: "Ident",
+                        escaped: false,
+                        raw: "not",
+                      )),
+                      span: Span(
+                        start: 263,
+                        end: 266,
+                      ),
+                    ),
+                    TokenWithSpan(
+                      type: "TokenWithSpan",
+                      token: Ident(Ident(
+                        kind: "Ident",
+                        escaped: false,
+                        raw: "screen",
+                      )),
+                      span: Span(
+                        start: 267,
+                        end: 273,
+                      ),
+                    ),
+                  ],
+                  span: Span(
+                    start: 263,
+                    end: 273,
+                  ),
+                ),
+                span: Span(
+                  start: 262,
+                  end: 274,
+                ),
+              ),
+            ],
+            span: Span(
+              start: 262,
+              end: 274,
+            ),
+          ),
+        ],
+        commaSpans: [],
+        span: Span(
+          start: 262,
+          end: 274,
+        ),
+      )),
+      block: Some(SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 275,
+          end: 277,
+        ),
+      )),
+      span: Span(
+        start: 255,
+        end: 277,
+      ),
+    ),
+    AtRule(
+      type: "AtRule",
+      name: Ident(
+        type: "Ident",
+        name: "media",
+        raw: "media",
+        span: Span(
+          start: 279,
+          end: 284,
+        ),
+      ),
+      prelude: Some(MediaQueryList(
+        type: "MediaQueryList",
+        queries: [
+          MediaCondition(
+            type: "MediaCondition",
+            conditions: [
+              MediaInParens(
+                type: "MediaInParens",
+                kind: TokenSeq(
+                  type: "TokenSeq",
+                  tokens: [
+                    TokenWithSpan(
+                      type: "TokenWithSpan",
+                      token: Ident(Ident(
+                        kind: "Ident",
+                        escaped: false,
+                        raw: "not",
+                      )),
+                      span: Span(
+                        start: 286,
+                        end: 289,
+                      ),
+                    ),
+                    TokenWithSpan(
+                      type: "TokenWithSpan",
+                      token: Ident(Ident(
+                        kind: "Ident",
+                        escaped: false,
+                        raw: "all",
+                      )),
+                      span: Span(
+                        start: 290,
+                        end: 293,
+                      ),
+                    ),
+                  ],
+                  span: Span(
+                    start: 286,
+                    end: 293,
+                  ),
+                ),
+                span: Span(
+                  start: 285,
+                  end: 294,
+                ),
+              ),
+              MediaAnd(
+                type: "MediaAnd",
+                keyword: Ident(
+                  type: "Ident",
+                  name: "and",
+                  raw: "and",
+                  span: Span(
+                    start: 295,
+                    end: 298,
+                  ),
+                ),
+                mediaInParens: MediaInParens(
+                  type: "MediaInParens",
+                  kind: MediaFeatureBoolean(
+                    type: "MediaFeatureBoolean",
+                    name: Ident(
+                      type: "Ident",
+                      name: "color",
+                      raw: "color",
+                      span: Span(
+                        start: 300,
+                        end: 305,
+                      ),
+                    ),
+                    span: Span(
+                      start: 300,
+                      end: 305,
+                    ),
+                  ),
+                  span: Span(
+                    start: 299,
+                    end: 306,
+                  ),
+                ),
+                span: Span(
+                  start: 295,
+                  end: 306,
+                ),
+              ),
+            ],
+            span: Span(
+              start: 285,
+              end: 306,
+            ),
+          ),
+        ],
+        commaSpans: [],
+        span: Span(
+          start: 285,
+          end: 306,
+        ),
+      )),
+      block: Some(SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 307,
+          end: 309,
+        ),
+      )),
+      span: Span(
+        start: 278,
+        end: 309,
+      ),
+    ),
+    AtRule(
+      type: "AtRule",
+      name: Ident(
+        type: "Ident",
+        name: "media",
+        raw: "media",
+        span: Span(
+          start: 311,
+          end: 316,
+        ),
+      ),
+      prelude: Some(MediaQueryList(
+        type: "MediaQueryList",
+        queries: [
+          MediaCondition(
+            type: "MediaCondition",
+            conditions: [
+              MediaInParens(
+                type: "MediaInParens",
+                kind: TokenSeq(
+                  type: "TokenSeq",
+                  tokens: [
+                    TokenWithSpan(
+                      type: "TokenWithSpan",
+                      token: Ident(Ident(
+                        kind: "Ident",
+                        escaped: false,
+                        raw: "screen",
+                      )),
+                      span: Span(
+                        start: 318,
+                        end: 324,
+                      ),
+                    ),
+                    TokenWithSpan(
+                      type: "TokenWithSpan",
+                      token: Ident(Ident(
+                        kind: "Ident",
+                        escaped: false,
+                        raw: "and",
+                      )),
+                      span: Span(
+                        start: 325,
+                        end: 328,
+                      ),
+                    ),
+                    TokenWithSpan(
+                      type: "TokenWithSpan",
+                      token: LParen(LParen(
+                        kind: "LParen",
+                      )),
+                      span: Span(
+                        start: 329,
+                        end: 330,
+                      ),
+                    ),
+                    TokenWithSpan(
+                      type: "TokenWithSpan",
+                      token: Ident(Ident(
+                        kind: "Ident",
+                        escaped: false,
+                        raw: "color",
+                      )),
+                      span: Span(
+                        start: 330,
+                        end: 335,
+                      ),
+                    ),
+                    TokenWithSpan(
+                      type: "TokenWithSpan",
+                      token: RParen(RParen(
+                        kind: "RParen",
+                      )),
+                      span: Span(
+                        start: 335,
+                        end: 336,
+                      ),
+                    ),
+                  ],
+                  span: Span(
+                    start: 318,
+                    end: 336,
+                  ),
+                ),
+                span: Span(
+                  start: 317,
+                  end: 337,
+                ),
+              ),
+            ],
+            span: Span(
+              start: 317,
+              end: 337,
+            ),
+          ),
+        ],
+        commaSpans: [],
+        span: Span(
+          start: 317,
+          end: 337,
+        ),
+      )),
+      block: Some(SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 338,
+          end: 340,
+        ),
+      )),
+      span: Span(
+        start: 310,
+        end: 340,
+      ),
+    ),
+    AtRule(
+      type: "AtRule",
+      name: Ident(
+        type: "Ident",
+        name: "media",
+        raw: "media",
+        span: Span(
+          start: 342,
+          end: 347,
+        ),
+      ),
+      prelude: Some(MediaQueryList(
+        type: "MediaQueryList",
+        queries: [
+          MediaCondition(
+            type: "MediaCondition",
+            conditions: [
+              MediaInParens(
+                type: "MediaInParens",
+                kind: MediaCondition(
+                  type: "MediaCondition",
+                  conditions: [
+                    MediaNot(
+                      type: "MediaNot",
+                      keyword: Ident(
+                        type: "Ident",
+                        name: "not",
+                        raw: "not",
+                        span: Span(
+                          start: 349,
+                          end: 352,
+                        ),
+                      ),
+                      mediaInParens: MediaInParens(
+                        type: "MediaInParens",
+                        kind: TokenSeq(
+                          type: "TokenSeq",
+                          tokens: [
+                            TokenWithSpan(
+                              type: "TokenWithSpan",
+                              token: Ident(Ident(
+                                kind: "Ident",
+                                escaped: false,
+                                raw: "screen",
+                              )),
+                              span: Span(
+                                start: 354,
+                                end: 360,
+                              ),
+                            ),
+                            TokenWithSpan(
+                              type: "TokenWithSpan",
+                              token: Ident(Ident(
+                                kind: "Ident",
+                                escaped: false,
+                                raw: "and",
+                              )),
+                              span: Span(
+                                start: 361,
+                                end: 364,
+                              ),
+                            ),
+                            TokenWithSpan(
+                              type: "TokenWithSpan",
+                              token: LParen(LParen(
+                                kind: "LParen",
+                              )),
+                              span: Span(
+                                start: 365,
+                                end: 366,
+                              ),
+                            ),
+                            TokenWithSpan(
+                              type: "TokenWithSpan",
+                              token: Ident(Ident(
+                                kind: "Ident",
+                                escaped: false,
+                                raw: "color",
+                              )),
+                              span: Span(
+                                start: 366,
+                                end: 371,
+                              ),
+                            ),
+                            TokenWithSpan(
+                              type: "TokenWithSpan",
+                              token: RParen(RParen(
+                                kind: "RParen",
+                              )),
+                              span: Span(
+                                start: 371,
+                                end: 372,
+                              ),
+                            ),
+                          ],
+                          span: Span(
+                            start: 354,
+                            end: 372,
+                          ),
+                        ),
+                        span: Span(
+                          start: 353,
+                          end: 373,
+                        ),
+                      ),
+                      span: Span(
+                        start: 349,
+                        end: 373,
+                      ),
+                    ),
+                  ],
+                  span: Span(
+                    start: 349,
+                    end: 373,
+                  ),
+                ),
+                span: Span(
+                  start: 348,
+                  end: 374,
+                ),
+              ),
+            ],
+            span: Span(
+              start: 348,
+              end: 374,
+            ),
+          ),
+        ],
+        commaSpans: [],
+        span: Span(
+          start: 348,
+          end: 374,
+        ),
+      )),
+      block: Some(SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 375,
+          end: 377,
+        ),
+      )),
+      span: Span(
+        start: 341,
+        end: 377,
+      ),
+    ),
+    AtRule(
+      type: "AtRule",
+      name: Ident(
+        type: "Ident",
+        name: "media",
+        raw: "media",
+        span: Span(
+          start: 379,
+          end: 384,
+        ),
+      ),
+      prelude: Some(MediaQueryList(
+        type: "MediaQueryList",
+        queries: [
+          MediaCondition(
+            type: "MediaCondition",
+            conditions: [
+              MediaInParens(
+                type: "MediaInParens",
+                kind: TokenSeq(
+                  type: "TokenSeq",
+                  tokens: [
+                    TokenWithSpan(
+                      type: "TokenWithSpan",
+                      token: Ident(Ident(
+                        kind: "Ident",
+                        escaped: false,
+                        raw: "not",
+                      )),
+                      span: Span(
+                        start: 386,
+                        end: 389,
+                      ),
+                    ),
+                    TokenWithSpan(
+                      type: "TokenWithSpan",
+                      token: Ident(Ident(
+                        kind: "Ident",
+                        escaped: false,
+                        raw: "all",
+                      )),
+                      span: Span(
+                        start: 390,
+                        end: 393,
+                      ),
+                    ),
+                  ],
+                  span: Span(
+                    start: 386,
+                    end: 393,
+                  ),
+                ),
+                span: Span(
+                  start: 385,
+                  end: 394,
+                ),
+              ),
+              MediaAnd(
+                type: "MediaAnd",
+                keyword: Ident(
+                  type: "Ident",
+                  name: "and",
+                  raw: "and",
+                  span: Span(
+                    start: 395,
+                    end: 398,
+                  ),
+                ),
+                mediaInParens: MediaInParens(
+                  type: "MediaInParens",
+                  kind: MediaFeatureBoolean(
+                    type: "MediaFeatureBoolean",
+                    name: Ident(
+                      type: "Ident",
+                      name: "monochrome",
+                      raw: "monochrome",
+                      span: Span(
+                        start: 400,
+                        end: 410,
+                      ),
+                    ),
+                    span: Span(
+                      start: 400,
+                      end: 410,
+                    ),
+                  ),
+                  span: Span(
+                    start: 399,
+                    end: 411,
+                  ),
+                ),
+                span: Span(
+                  start: 395,
+                  end: 411,
+                ),
+              ),
+            ],
+            span: Span(
+              start: 385,
+              end: 411,
+            ),
+          ),
+        ],
+        commaSpans: [],
+        span: Span(
+          start: 385,
+          end: 411,
+        ),
+      )),
+      block: Some(SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 412,
+          end: 414,
+        ),
+      )),
+      span: Span(
+        start: 378,
+        end: 414,
+      ),
+    ),
+    AtRule(
+      type: "AtRule",
+      name: Ident(
+        type: "Ident",
+        name: "media",
+        raw: "media",
+        span: Span(
+          start: 416,
+          end: 421,
+        ),
+      ),
+      prelude: Some(MediaQueryList(
+        type: "MediaQueryList",
+        queries: [
+          MediaCondition(
+            type: "MediaCondition",
+            conditions: [
+              MediaInParens(
+                type: "MediaInParens",
+                kind: MediaCondition(
+                  type: "MediaCondition",
+                  conditions: [
+                    MediaNot(
+                      type: "MediaNot",
+                      keyword: Ident(
+                        type: "Ident",
+                        name: "not",
+                        raw: "not",
+                        span: Span(
+                          start: 423,
+                          end: 426,
+                        ),
+                      ),
+                      mediaInParens: MediaInParens(
+                        type: "MediaInParens",
+                        kind: TokenSeq(
+                          type: "TokenSeq",
+                          tokens: [
+                            TokenWithSpan(
+                              type: "TokenWithSpan",
+                              token: Ident(Ident(
+                                kind: "Ident",
+                                escaped: false,
+                                raw: "screen",
+                              )),
+                              span: Span(
+                                start: 428,
+                                end: 434,
+                              ),
+                            ),
+                            TokenWithSpan(
+                              type: "TokenWithSpan",
+                              token: Ident(Ident(
+                                kind: "Ident",
+                                escaped: false,
+                                raw: "and",
+                              )),
+                              span: Span(
+                                start: 435,
+                                end: 438,
+                              ),
+                            ),
+                            TokenWithSpan(
+                              type: "TokenWithSpan",
+                              token: LParen(LParen(
+                                kind: "LParen",
+                              )),
+                              span: Span(
+                                start: 439,
+                                end: 440,
+                              ),
+                            ),
+                            TokenWithSpan(
+                              type: "TokenWithSpan",
+                              token: Ident(Ident(
+                                kind: "Ident",
+                                escaped: false,
+                                raw: "color",
+                              )),
+                              span: Span(
+                                start: 440,
+                                end: 445,
+                              ),
+                            ),
+                            TokenWithSpan(
+                              type: "TokenWithSpan",
+                              token: RParen(RParen(
+                                kind: "RParen",
+                              )),
+                              span: Span(
+                                start: 445,
+                                end: 446,
+                              ),
+                            ),
+                          ],
+                          span: Span(
+                            start: 428,
+                            end: 446,
+                          ),
+                        ),
+                        span: Span(
+                          start: 427,
+                          end: 447,
+                        ),
+                      ),
+                      span: Span(
+                        start: 423,
+                        end: 447,
+                      ),
+                    ),
+                  ],
+                  span: Span(
+                    start: 423,
+                    end: 447,
+                  ),
+                ),
+                span: Span(
+                  start: 422,
+                  end: 448,
+                ),
+              ),
+            ],
+            span: Span(
+              start: 422,
+              end: 448,
+            ),
+          ),
+          MediaQueryWithType(
+            type: "MediaQueryWithType",
+            modifier: None,
+            mediaType: Ident(
+              type: "Ident",
+              name: "print",
+              raw: "print",
+              span: Span(
+                start: 450,
+                end: 455,
+              ),
+            ),
+            condition: Some(MediaConditionAfterMediaType(
+              type: "MediaConditionAfterMediaType",
+              and: Ident(
+                type: "Ident",
+                name: "and",
+                raw: "and",
+                span: Span(
+                  start: 456,
+                  end: 459,
+                ),
+              ),
+              condition: MediaCondition(
+                type: "MediaCondition",
+                conditions: [
+                  MediaInParens(
+                    type: "MediaInParens",
+                    kind: MediaFeatureBoolean(
+                      type: "MediaFeatureBoolean",
+                      name: Ident(
+                        type: "Ident",
+                        name: "color",
+                        raw: "color",
+                        span: Span(
+                          start: 461,
+                          end: 466,
+                        ),
+                      ),
+                      span: Span(
+                        start: 461,
+                        end: 466,
+                      ),
+                    ),
+                    span: Span(
+                      start: 460,
+                      end: 467,
+                    ),
+                  ),
+                ],
+                span: Span(
+                  start: 460,
+                  end: 467,
+                ),
+              ),
+              span: Span(
+                start: 456,
+                end: 467,
+              ),
+            )),
+            span: Span(
+              start: 450,
+              end: 467,
+            ),
+          ),
+        ],
+        commaSpans: [
+          Span(
+            start: 448,
+            end: 449,
+          ),
+        ],
+        span: Span(
+          start: 422,
+          end: 467,
+        ),
+      )),
+      block: Some(SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 468,
+          end: 470,
+        ),
+      )),
+      span: Span(
+        start: 415,
+        end: 470,
+      ),
+    ),
+    AtRule(
+      type: "AtRule",
+      name: Ident(
+        type: "Ident",
+        name: "media",
+        raw: "media",
+        span: Span(
+          start: 540,
+          end: 545,
+        ),
+      ),
+      prelude: Some(MediaQueryList(
+        type: "MediaQueryList",
+        queries: [
+          MediaCondition(
+            type: "MediaCondition",
+            conditions: [
+              MediaInParens(
+                type: "MediaInParens",
+                kind: MediaFeatureBoolean(
+                  type: "MediaFeatureBoolean",
+                  name: Ident(
+                    type: "Ident",
+                    name: "unknown-feature",
+                    raw: "unknown-feature",
+                    span: Span(
+                      start: 547,
+                      end: 562,
+                    ),
+                  ),
+                  span: Span(
+                    start: 547,
+                    end: 562,
+                  ),
+                ),
+                span: Span(
+                  start: 546,
+                  end: 563,
+                ),
+              ),
+              MediaAnd(
+                type: "MediaAnd",
+                keyword: Ident(
+                  type: "Ident",
+                  name: "and",
+                  raw: "and",
+                  span: Span(
+                    start: 564,
+                    end: 567,
+                  ),
+                ),
+                mediaInParens: MediaInParens(
+                  type: "MediaInParens",
+                  kind: MediaFeatureBoolean(
+                    type: "MediaFeatureBoolean",
+                    name: Ident(
+                      type: "Ident",
+                      name: "color",
+                      raw: "color",
+                      span: Span(
+                        start: 569,
+                        end: 574,
+                      ),
+                    ),
+                    span: Span(
+                      start: 569,
+                      end: 574,
+                    ),
+                  ),
+                  span: Span(
+                    start: 568,
+                    end: 575,
+                  ),
+                ),
+                span: Span(
+                  start: 564,
+                  end: 575,
+                ),
+              ),
+            ],
+            span: Span(
+              start: 546,
+              end: 575,
+            ),
+          ),
+        ],
+        commaSpans: [],
+        span: Span(
+          start: 546,
+          end: 575,
+        ),
+      )),
+      block: Some(SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 576,
+          end: 578,
+        ),
+      )),
+      span: Span(
+        start: 539,
+        end: 578,
+      ),
+    ),
+    AtRule(
+      type: "AtRule",
+      name: Ident(
+        type: "Ident",
+        name: "media",
+        raw: "media",
+        span: Span(
+          start: 580,
+          end: 585,
+        ),
+      ),
+      prelude: Some(MediaQueryList(
+        type: "MediaQueryList",
+        queries: [
+          MediaCondition(
+            type: "MediaCondition",
+            conditions: [
+              MediaInParens(
+                type: "MediaInParens",
+                kind: TokenSeq(
+                  type: "TokenSeq",
+                  tokens: [
+                    TokenWithSpan(
+                      type: "TokenWithSpan",
+                      token: Ident(Ident(
+                        kind: "Ident",
+                        escaped: false,
+                        raw: "foo",
+                      )),
+                      span: Span(
+                        start: 587,
+                        end: 590,
+                      ),
+                    ),
+                    TokenWithSpan(
+                      type: "TokenWithSpan",
+                      token: Ident(Ident(
+                        kind: "Ident",
+                        escaped: false,
+                        raw: "bar",
+                      )),
+                      span: Span(
+                        start: 591,
+                        end: 594,
+                      ),
+                    ),
+                    TokenWithSpan(
+                      type: "TokenWithSpan",
+                      token: Ident(Ident(
+                        kind: "Ident",
+                        escaped: false,
+                        raw: "baz",
+                      )),
+                      span: Span(
+                        start: 595,
+                        end: 598,
+                      ),
+                    ),
+                  ],
+                  span: Span(
+                    start: 587,
+                    end: 598,
+                  ),
+                ),
+                span: Span(
+                  start: 586,
+                  end: 599,
+                ),
+              ),
+            ],
+            span: Span(
+              start: 586,
+              end: 599,
+            ),
+          ),
+        ],
+        commaSpans: [],
+        span: Span(
+          start: 586,
+          end: 599,
+        ),
+      )),
+      block: Some(SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 600,
+          end: 602,
+        ),
+      )),
+      span: Span(
+        start: 579,
+        end: 602,
+      ),
+    ),
+    AtRule(
+      type: "AtRule",
+      name: Ident(
+        type: "Ident",
+        name: "media",
+        raw: "media",
+        span: Span(
+          start: 604,
+          end: 609,
+        ),
+      ),
+      prelude: Some(MediaQueryList(
+        type: "MediaQueryList",
+        queries: [
+          MediaCondition(
+            type: "MediaCondition",
+            conditions: [
+              MediaInParens(
+                type: "MediaInParens",
+                kind: MediaFeaturePlain(
+                  type: "MediaFeaturePlain",
+                  name: Ident(
+                    type: "Ident",
+                    name: "--custom-feature",
+                    raw: "--custom-feature",
+                    span: Span(
+                      start: 611,
+                      end: 627,
+                    ),
+                  ),
+                  colonSpan: Span(
+                    start: 627,
+                    end: 628,
+                  ),
+                  value: Number(
+                    type: "Number",
+                    value: 10.0,
+                    raw: "10",
+                    span: Span(
+                      start: 629,
+                      end: 631,
+                    ),
+                  ),
+                  span: Span(
+                    start: 611,
+                    end: 631,
+                  ),
+                ),
+                span: Span(
+                  start: 610,
+                  end: 632,
+                ),
+              ),
+            ],
+            span: Span(
+              start: 610,
+              end: 632,
+            ),
+          ),
+        ],
+        commaSpans: [],
+        span: Span(
+          start: 610,
+          end: 632,
+        ),
+      )),
+      block: Some(SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 633,
+          end: 635,
+        ),
+      )),
+      span: Span(
+        start: 603,
+        end: 635,
+      ),
+    ),
+  ],
+  span: Span(
+    start: 0,
+    end: 636,
+  ),
+)

--- a/crates/oxc_css_parser/tests/ast/at-rule/supports-general-enclosed.css
+++ b/crates/oxc_css_parser/tests/ast/at-rule/supports-general-enclosed.css
@@ -1,0 +1,8 @@
+/* <general-enclosed> forward-compat catch-all referenced from
+   <supports-condition>. Contents that do not match <supports-decl>,
+   <supports-condition>, or known function forms are accepted syntactically
+   (evaluated as false at runtime). */
+@supports (foo bar baz) {}
+@supports (not all) {}
+@supports (--custom-feature: 10) and (display: grid) {}
+@supports (foo bar) or (display: grid) {}

--- a/crates/oxc_css_parser/tests/ast/at-rule/supports-general-enclosed.snap
+++ b/crates/oxc_css_parser/tests/ast/at-rule/supports-general-enclosed.snap
@@ -1,0 +1,454 @@
+---
+source: crates/oxc_css_parser/tests/ast.rs
+---
+Stylesheet(
+  type: "Stylesheet",
+  statements: [
+    AtRule(
+      type: "AtRule",
+      name: Ident(
+        type: "Ident",
+        name: "supports",
+        raw: "supports",
+        span: Span(
+          start: 248,
+          end: 256,
+        ),
+      ),
+      prelude: Some(SupportsCondition(
+        type: "SupportsCondition",
+        conditions: [
+          SupportsInParens(
+            type: "SupportsInParens",
+            kind: TokenSeq(
+              type: "TokenSeq",
+              tokens: [
+                TokenWithSpan(
+                  type: "TokenWithSpan",
+                  token: Ident(Ident(
+                    kind: "Ident",
+                    escaped: false,
+                    raw: "foo",
+                  )),
+                  span: Span(
+                    start: 258,
+                    end: 261,
+                  ),
+                ),
+                TokenWithSpan(
+                  type: "TokenWithSpan",
+                  token: Ident(Ident(
+                    kind: "Ident",
+                    escaped: false,
+                    raw: "bar",
+                  )),
+                  span: Span(
+                    start: 262,
+                    end: 265,
+                  ),
+                ),
+                TokenWithSpan(
+                  type: "TokenWithSpan",
+                  token: Ident(Ident(
+                    kind: "Ident",
+                    escaped: false,
+                    raw: "baz",
+                  )),
+                  span: Span(
+                    start: 266,
+                    end: 269,
+                  ),
+                ),
+              ],
+              span: Span(
+                start: 258,
+                end: 269,
+              ),
+            ),
+            span: Span(
+              start: 257,
+              end: 270,
+            ),
+          ),
+        ],
+        span: Span(
+          start: 257,
+          end: 270,
+        ),
+      )),
+      block: Some(SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 271,
+          end: 273,
+        ),
+      )),
+      span: Span(
+        start: 247,
+        end: 273,
+      ),
+    ),
+    AtRule(
+      type: "AtRule",
+      name: Ident(
+        type: "Ident",
+        name: "supports",
+        raw: "supports",
+        span: Span(
+          start: 275,
+          end: 283,
+        ),
+      ),
+      prelude: Some(SupportsCondition(
+        type: "SupportsCondition",
+        conditions: [
+          SupportsInParens(
+            type: "SupportsInParens",
+            kind: TokenSeq(
+              type: "TokenSeq",
+              tokens: [
+                TokenWithSpan(
+                  type: "TokenWithSpan",
+                  token: Ident(Ident(
+                    kind: "Ident",
+                    escaped: false,
+                    raw: "not",
+                  )),
+                  span: Span(
+                    start: 285,
+                    end: 288,
+                  ),
+                ),
+                TokenWithSpan(
+                  type: "TokenWithSpan",
+                  token: Ident(Ident(
+                    kind: "Ident",
+                    escaped: false,
+                    raw: "all",
+                  )),
+                  span: Span(
+                    start: 289,
+                    end: 292,
+                  ),
+                ),
+              ],
+              span: Span(
+                start: 285,
+                end: 292,
+              ),
+            ),
+            span: Span(
+              start: 284,
+              end: 293,
+            ),
+          ),
+        ],
+        span: Span(
+          start: 284,
+          end: 293,
+        ),
+      )),
+      block: Some(SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 294,
+          end: 296,
+        ),
+      )),
+      span: Span(
+        start: 274,
+        end: 296,
+      ),
+    ),
+    AtRule(
+      type: "AtRule",
+      name: Ident(
+        type: "Ident",
+        name: "supports",
+        raw: "supports",
+        span: Span(
+          start: 298,
+          end: 306,
+        ),
+      ),
+      prelude: Some(SupportsCondition(
+        type: "SupportsCondition",
+        conditions: [
+          SupportsInParens(
+            type: "SupportsInParens",
+            kind: SupportsDecl(
+              type: "SupportsDecl",
+              decl: Declaration(
+                type: "Declaration",
+                name: Ident(
+                  type: "Ident",
+                  name: "--custom-feature",
+                  raw: "--custom-feature",
+                  span: Span(
+                    start: 308,
+                    end: 324,
+                  ),
+                ),
+                nameSuffix: None,
+                colonSpan: Span(
+                  start: 324,
+                  end: 325,
+                ),
+                value: [
+                  TokenWithSpan(
+                    type: "TokenWithSpan",
+                    token: Number(Number(
+                      kind: "Number",
+                      raw: "10",
+                    )),
+                    span: Span(
+                      start: 326,
+                      end: 328,
+                    ),
+                  ),
+                ],
+                important: None,
+                lessPropertyMerge: None,
+                span: Span(
+                  start: 308,
+                  end: 328,
+                ),
+              ),
+              span: Span(
+                start: 307,
+                end: 329,
+              ),
+            ),
+            span: Span(
+              start: 307,
+              end: 329,
+            ),
+          ),
+          SupportsAnd(
+            type: "SupportsAnd",
+            keyword: Ident(
+              type: "Ident",
+              name: "and",
+              raw: "and",
+              span: Span(
+                start: 330,
+                end: 333,
+              ),
+            ),
+            condition: SupportsInParens(
+              type: "SupportsInParens",
+              kind: SupportsDecl(
+                type: "SupportsDecl",
+                decl: Declaration(
+                  type: "Declaration",
+                  name: Ident(
+                    type: "Ident",
+                    name: "display",
+                    raw: "display",
+                    span: Span(
+                      start: 335,
+                      end: 342,
+                    ),
+                  ),
+                  nameSuffix: None,
+                  colonSpan: Span(
+                    start: 342,
+                    end: 343,
+                  ),
+                  value: [
+                    Ident(
+                      type: "Ident",
+                      name: "grid",
+                      raw: "grid",
+                      span: Span(
+                        start: 344,
+                        end: 348,
+                      ),
+                    ),
+                  ],
+                  important: None,
+                  lessPropertyMerge: None,
+                  span: Span(
+                    start: 335,
+                    end: 348,
+                  ),
+                ),
+                span: Span(
+                  start: 334,
+                  end: 349,
+                ),
+              ),
+              span: Span(
+                start: 334,
+                end: 349,
+              ),
+            ),
+            span: Span(
+              start: 330,
+              end: 349,
+            ),
+          ),
+        ],
+        span: Span(
+          start: 307,
+          end: 349,
+        ),
+      )),
+      block: Some(SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 350,
+          end: 352,
+        ),
+      )),
+      span: Span(
+        start: 297,
+        end: 352,
+      ),
+    ),
+    AtRule(
+      type: "AtRule",
+      name: Ident(
+        type: "Ident",
+        name: "supports",
+        raw: "supports",
+        span: Span(
+          start: 354,
+          end: 362,
+        ),
+      ),
+      prelude: Some(SupportsCondition(
+        type: "SupportsCondition",
+        conditions: [
+          SupportsInParens(
+            type: "SupportsInParens",
+            kind: TokenSeq(
+              type: "TokenSeq",
+              tokens: [
+                TokenWithSpan(
+                  type: "TokenWithSpan",
+                  token: Ident(Ident(
+                    kind: "Ident",
+                    escaped: false,
+                    raw: "foo",
+                  )),
+                  span: Span(
+                    start: 364,
+                    end: 367,
+                  ),
+                ),
+                TokenWithSpan(
+                  type: "TokenWithSpan",
+                  token: Ident(Ident(
+                    kind: "Ident",
+                    escaped: false,
+                    raw: "bar",
+                  )),
+                  span: Span(
+                    start: 368,
+                    end: 371,
+                  ),
+                ),
+              ],
+              span: Span(
+                start: 364,
+                end: 371,
+              ),
+            ),
+            span: Span(
+              start: 363,
+              end: 372,
+            ),
+          ),
+          SupportsOr(
+            type: "SupportsOr",
+            keyword: Ident(
+              type: "Ident",
+              name: "or",
+              raw: "or",
+              span: Span(
+                start: 373,
+                end: 375,
+              ),
+            ),
+            condition: SupportsInParens(
+              type: "SupportsInParens",
+              kind: SupportsDecl(
+                type: "SupportsDecl",
+                decl: Declaration(
+                  type: "Declaration",
+                  name: Ident(
+                    type: "Ident",
+                    name: "display",
+                    raw: "display",
+                    span: Span(
+                      start: 377,
+                      end: 384,
+                    ),
+                  ),
+                  nameSuffix: None,
+                  colonSpan: Span(
+                    start: 384,
+                    end: 385,
+                  ),
+                  value: [
+                    Ident(
+                      type: "Ident",
+                      name: "grid",
+                      raw: "grid",
+                      span: Span(
+                        start: 386,
+                        end: 390,
+                      ),
+                    ),
+                  ],
+                  important: None,
+                  lessPropertyMerge: None,
+                  span: Span(
+                    start: 377,
+                    end: 390,
+                  ),
+                ),
+                span: Span(
+                  start: 376,
+                  end: 391,
+                ),
+              ),
+              span: Span(
+                start: 376,
+                end: 391,
+              ),
+            ),
+            span: Span(
+              start: 373,
+              end: 391,
+            ),
+          ),
+        ],
+        span: Span(
+          start: 363,
+          end: 391,
+        ),
+      )),
+      block: Some(SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 392,
+          end: 394,
+        ),
+      )),
+      span: Span(
+        start: 353,
+        end: 394,
+      ),
+    ),
+  ],
+  span: Span(
+    start: 0,
+    end: 395,
+  ),
+)


### PR DESCRIPTION
Add MQ Level 4 `<general-enclosed>` fallback to `<media-in-parens>` and `<supports-in-parens>`, accepting forward-compat catch-alls like `(not all)` and `(screen and (color))` as opaque `TokenSeq` instead of hard-erroring.

https://www.w3.org/TR/mediaqueries-4/#mq-syntax

NOTE: Found in prettier 3.9.1's fixture, but IMO this is rare usecase. Also, `<function-token>` is not covered yet.