### PR TITLE
feat: partial support `postcss-simple-vars`

### DIFF
--- a/crates/oxc_css_parser/src/ast.rs
+++ b/crates/oxc_css_parser/src/ast.rs
@@ -242,6 +242,7 @@ pub enum ComponentValue<'a> {
     Number(Number<'a>),
     Percentage(Percentage<'a>),
     Placeholder(Placeholder<'a>),
+    PostcssSimpleVar(PostcssSimpleVar<'a>),
     Ratio(Ratio<'a>),
     SassArbitraryArgument(SassArbitraryArgument<'a>),
     SassBinaryExpression(SassBinaryExpression<'a>),
@@ -1295,6 +1296,7 @@ pub enum MediaFeatureComparisonKind {
 #[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum MediaFeatureName<'a> {
     Ident(InterpolableIdent<'a>),
+    PostcssSimpleVar(PostcssSimpleVar<'a>),
     SassVariable(SassVariable<'a>),
 }
 
@@ -1511,6 +1513,24 @@ pub struct PageSelectorList<'a> {
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 pub struct Percentage<'a> {
     pub value: Number<'a>,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
+pub struct PostcssSimpleVar<'a> {
+    pub name: Ident<'a>,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
+pub struct PostcssSimpleVarDeclaration<'a> {
+    pub name: PostcssSimpleVar<'a>,
+    pub colon_span: Span,
+    pub value: Vec<'a, ComponentValue<'a>>,
     pub span: Span,
 }
 
@@ -2272,6 +2292,7 @@ pub enum Statement<'a> {
     LessVariableCall(LessVariableCall<'a>),
     LessVariableDeclaration(Box<'a, LessVariableDeclaration<'a>>),
     Placeholder(Placeholder<'a>),
+    PostcssSimpleVarDeclaration(Box<'a, PostcssSimpleVarDeclaration<'a>>),
     QualifiedRule(QualifiedRule<'a>),
     SassIfAtRule(Box<'a, SassIfAtRule<'a>>),
     SassVariableDeclaration(Box<'a, SassVariableDeclaration<'a>>),

--- a/crates/oxc_css_parser/src/ast_generated.rs
+++ b/crates/oxc_css_parser/src/ast_generated.rs
@@ -125,7 +125,7 @@ impl_spanned_enum!(ComplexSelectorChild<'a> {
     unit: [],
 });
 impl_spanned_enum!(ComponentValue<'a> {
-    tuple: [BracketBlock, Calc, Delimiter, Dimension, Function, HexColor, IdSelector, ImportantAnnotation, InterpolableIdent, InterpolableStr, LayerName, LessBinaryOperation, LessCondition, LessDetachedRuleset, LessEscapedStr, LessJavaScriptSnippet, LessList, LessMixinCall, LessNamespaceValue, LessNegativeValue, LessParenthesizedOperation, LessPercentKeyword, LessPropertyVariable, LessVariable, LessVariableVariable, Number, Percentage, Placeholder, Ratio, SassArbitraryArgument, SassBinaryExpression, SassKeywordArgument, SassList, SassMap, SassQualifiedName, SassNestingDeclaration, SassParenthesizedExpression, SassParentSelector, SassUnaryExpression, SassVariable, TokenWithSpan, UnicodeRange, Url, ],
+    tuple: [BracketBlock, Calc, Delimiter, Dimension, Function, HexColor, IdSelector, ImportantAnnotation, InterpolableIdent, InterpolableStr, LayerName, LessBinaryOperation, LessCondition, LessDetachedRuleset, LessEscapedStr, LessJavaScriptSnippet, LessList, LessMixinCall, LessNamespaceValue, LessNegativeValue, LessParenthesizedOperation, LessPercentKeyword, LessPropertyVariable, LessVariable, LessVariableVariable, Number, Percentage, Placeholder, PostcssSimpleVar, Ratio, SassArbitraryArgument, SassBinaryExpression, SassKeywordArgument, SassList, SassMap, SassQualifiedName, SassNestingDeclaration, SassParenthesizedExpression, SassParentSelector, SassUnaryExpression, SassVariable, TokenWithSpan, UnicodeRange, Url, ],
     unit: [],
 });
 impl_spanned_struct!(ComponentValues<'a>);
@@ -321,7 +321,7 @@ impl_spanned_enum!(MediaFeature<'a> {
 });
 impl_spanned_struct!(MediaFeatureComparison);
 impl_spanned_enum!(MediaFeatureName<'a> {
-    tuple: [Ident, SassVariable, ],
+    tuple: [Ident, PostcssSimpleVar, SassVariable, ],
     unit: [],
 });
 impl_spanned_struct!(MediaFeatureBoolean<'a>);
@@ -363,6 +363,8 @@ impl_spanned_struct!(Number<'a>);
 impl_spanned_struct!(PageSelector<'a>);
 impl_spanned_struct!(PageSelectorList<'a>);
 impl_spanned_struct!(Percentage<'a>);
+impl_spanned_struct!(PostcssSimpleVar<'a>);
+impl_spanned_struct!(PostcssSimpleVarDeclaration<'a>);
 impl_spanned_struct!(PseudoClassSelector<'a>);
 impl_spanned_struct!(PseudoClassSelectorArg<'a>);
 impl_spanned_enum!(PseudoClassSelectorArgKind<'a> {
@@ -487,7 +489,7 @@ impl_spanned_enum!(SimpleSelector<'a> {
     unit: [],
 });
 impl_spanned_enum!(Statement<'a> {
-    tuple: [AtRule, Declaration, KeyframeBlock, LessConditionalQualifiedRule, LessExtendRule, LessFunctionCall, LessMixinCall, LessMixinDefinition, LessVariableCall, LessVariableDeclaration, Placeholder, QualifiedRule, SassIfAtRule, SassVariableDeclaration, UnknownSassAtRule, ],
+    tuple: [AtRule, Declaration, KeyframeBlock, LessConditionalQualifiedRule, LessExtendRule, LessFunctionCall, LessMixinCall, LessMixinDefinition, LessVariableCall, LessVariableDeclaration, Placeholder, PostcssSimpleVarDeclaration, QualifiedRule, SassIfAtRule, SassVariableDeclaration, UnknownSassAtRule, ],
     unit: [],
 });
 impl_spanned_struct!(Str<'a>);
@@ -609,7 +611,7 @@ impl_span_ignored_eq_enum!(ComplexSelectorChild<'a> {
 });
 #[cfg(feature = "span_ignored_eq")]
 impl_span_ignored_eq_enum!(ComponentValue<'a> {
-    tuple: [BracketBlock, Calc, Delimiter, Dimension, Function, HexColor, IdSelector, ImportantAnnotation, InterpolableIdent, InterpolableStr, LayerName, LessBinaryOperation, LessCondition, LessDetachedRuleset, LessEscapedStr, LessJavaScriptSnippet, LessList, LessMixinCall, LessNamespaceValue, LessNegativeValue, LessParenthesizedOperation, LessPercentKeyword, LessPropertyVariable, LessVariable, LessVariableVariable, Number, Percentage, Placeholder, Ratio, SassArbitraryArgument, SassBinaryExpression, SassKeywordArgument, SassList, SassMap, SassQualifiedName, SassNestingDeclaration, SassParenthesizedExpression, SassParentSelector, SassUnaryExpression, SassVariable, TokenWithSpan, UnicodeRange, Url, ],
+    tuple: [BracketBlock, Calc, Delimiter, Dimension, Function, HexColor, IdSelector, ImportantAnnotation, InterpolableIdent, InterpolableStr, LayerName, LessBinaryOperation, LessCondition, LessDetachedRuleset, LessEscapedStr, LessJavaScriptSnippet, LessList, LessMixinCall, LessNamespaceValue, LessNegativeValue, LessParenthesizedOperation, LessPercentKeyword, LessPropertyVariable, LessVariable, LessVariableVariable, Number, Percentage, Placeholder, PostcssSimpleVar, Ratio, SassArbitraryArgument, SassBinaryExpression, SassKeywordArgument, SassList, SassMap, SassQualifiedName, SassNestingDeclaration, SassParenthesizedExpression, SassParentSelector, SassUnaryExpression, SassVariable, TokenWithSpan, UnicodeRange, Url, ],
     unit: [],
 });
 #[cfg(feature = "span_ignored_eq")]
@@ -937,7 +939,7 @@ impl_span_ignored_eq_enum!(MediaFeatureComparisonKind {
 });
 #[cfg(feature = "span_ignored_eq")]
 impl_span_ignored_eq_enum!(MediaFeatureName<'a> {
-    tuple: [Ident, SassVariable, ],
+    tuple: [Ident, PostcssSimpleVar, SassVariable, ],
     unit: [],
 });
 #[cfg(feature = "span_ignored_eq")]
@@ -1003,6 +1005,10 @@ impl_span_ignored_eq_struct!(PageSelector<'a> { name, pseudo, });
 impl_span_ignored_eq_struct!(PageSelectorList<'a> { selectors, comma_spans, });
 #[cfg(feature = "span_ignored_eq")]
 impl_span_ignored_eq_struct!(Percentage<'a> { value, });
+#[cfg(feature = "span_ignored_eq")]
+impl_span_ignored_eq_struct!(PostcssSimpleVar<'a> { name, });
+#[cfg(feature = "span_ignored_eq")]
+impl_span_ignored_eq_struct!(PostcssSimpleVarDeclaration<'a> { name, colon_span, value, });
 #[cfg(feature = "span_ignored_eq")]
 impl_span_ignored_eq_struct!(PseudoClassSelector<'a> { name, arg, });
 #[cfg(feature = "span_ignored_eq")]
@@ -1221,7 +1227,7 @@ impl_span_ignored_eq_enum!(SimpleSelector<'a> {
 });
 #[cfg(feature = "span_ignored_eq")]
 impl_span_ignored_eq_enum!(Statement<'a> {
-    tuple: [AtRule, Declaration, KeyframeBlock, LessConditionalQualifiedRule, LessExtendRule, LessFunctionCall, LessMixinCall, LessMixinDefinition, LessVariableCall, LessVariableDeclaration, Placeholder, QualifiedRule, SassIfAtRule, SassVariableDeclaration, UnknownSassAtRule, ],
+    tuple: [AtRule, Declaration, KeyframeBlock, LessConditionalQualifiedRule, LessExtendRule, LessFunctionCall, LessMixinCall, LessMixinDefinition, LessVariableCall, LessVariableDeclaration, Placeholder, PostcssSimpleVarDeclaration, QualifiedRule, SassIfAtRule, SassVariableDeclaration, UnknownSassAtRule, ],
     unit: [],
 });
 #[cfg(feature = "span_ignored_eq")]
@@ -1414,6 +1420,7 @@ impl_enum_as_is!(ComponentValue<'a> {
         Number(Number<'a>) => is_number, as_number,
         Percentage(Percentage<'a>) => is_percentage, as_percentage,
         Placeholder(Placeholder<'a>) => is_placeholder, as_placeholder,
+        PostcssSimpleVar(PostcssSimpleVar<'a>) => is_postcss_simple_var, as_postcss_simple_var,
         Ratio(Ratio<'a>) => is_ratio, as_ratio,
         SassArbitraryArgument(SassArbitraryArgument<'a>) => is_sass_arbitrary_argument, as_sass_arbitrary_argument,
         SassBinaryExpression(SassBinaryExpression<'a>) => is_sass_binary_expression, as_sass_binary_expression,
@@ -1659,6 +1666,7 @@ impl_enum_as_is!(MediaFeature<'a> {
 impl_enum_as_is!(MediaFeatureName<'a> {
     tuple: [
         Ident(InterpolableIdent<'a>) => is_ident, as_ident,
+        PostcssSimpleVar(PostcssSimpleVar<'a>) => is_postcss_simple_var, as_postcss_simple_var,
         SassVariable(SassVariable<'a>) => is_sass_variable, as_sass_variable,
     ],
     unit: [],
@@ -1846,6 +1854,7 @@ impl_enum_as_is!(Statement<'a> {
         LessVariableCall(LessVariableCall<'a>) => is_less_variable_call, as_less_variable_call,
         LessVariableDeclaration(LessVariableDeclaration<'a>) => is_less_variable_declaration, as_less_variable_declaration,
         Placeholder(Placeholder<'a>) => is_placeholder, as_placeholder,
+        PostcssSimpleVarDeclaration(PostcssSimpleVarDeclaration<'a>) => is_postcss_simple_var_declaration, as_postcss_simple_var_declaration,
         QualifiedRule(QualifiedRule<'a>) => is_qualified_rule, as_qualified_rule,
         SassIfAtRule(SassIfAtRule<'a>) => is_sass_if_at_rule, as_sass_if_at_rule,
         SassVariableDeclaration(SassVariableDeclaration<'a>) => is_sass_variable_declaration, as_sass_variable_declaration,

--- a/crates/oxc_css_parser/src/config.rs
+++ b/crates/oxc_css_parser/src/config.rs
@@ -47,6 +47,22 @@ pub struct ParserOptions {
     /// as recoverable errors, instead of raising a syntax error.
     pub tolerate_semicolon_in_sass: bool,
 
+    /// If enabled, [`Syntax::Css`] accepts the `$variable` syntax handled by the
+    /// [`postcss-simple-vars`](https://github.com/postcss/postcss-simple-vars) plugin:
+    /// `$var: value;` declarations, `$var` references in property values,
+    /// and `$var` references inside `@media` (and similar) at-rule preludes.
+    ///
+    /// The resulting AST uses dedicated [`PostcssSimpleVar`](crate::ast::PostcssSimpleVar)
+    /// and [`PostcssSimpleVarDeclaration`](crate::ast::PostcssSimpleVarDeclaration)
+    /// nodes, separate from SCSS's [`SassVariable`](crate::ast::SassVariable) family.
+    ///
+    /// NOTE: Interpolation (`$(var)`), selector references (`.$prefix`),
+    /// and comment substitutions (`<<$(var)>>`) are not yet covered.
+    ///
+    /// Ignored for [`Syntax::Scss`], [`Syntax::Sass`], and [`Syntax::Less`]
+    /// (those dialects already accept `$variable` natively).
+    pub allow_postcss_simple_vars: bool,
+
     /// If set, a backtick-delimited token of the shape `` `<prefix><decimal index>` ``
     /// (see [`TemplatePlaceholder`]) is tokenized as an atomic
     /// [`Token::Placeholder`](crate::token::Token) carrying the parsed index.

--- a/crates/oxc_css_parser/src/parser/at_rule/media.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/media.rs
@@ -69,6 +69,13 @@ impl<'a> Parse<'a> for MediaFeature<'a> {
                     span,
                 }))
             }
+            ComponentValue::PostcssSimpleVar(variable) => {
+                let span = variable.span.clone();
+                Ok(MediaFeature::Boolean(MediaFeatureBoolean {
+                    name: MediaFeatureName::PostcssSimpleVar(variable),
+                    span,
+                }))
+            }
             value => input.parse_media_feature_range_or_range_interval(value),
         }
     }

--- a/crates/oxc_css_parser/src/parser/mod.rs
+++ b/crates/oxc_css_parser/src/parser/mod.rs
@@ -1,12 +1,13 @@
 use self::state::ParserState;
 use crate::{
-    ParserOptions,
+    ParserOptions, expect,
     ast::{
         Dimension, Ident, InterpolableIdentStaticPart, InterpolableStrStaticPart,
         InterpolableUrlStaticPart, Str,
     },
     config::Syntax,
     error::{Error, PResult},
+    pos::Span,
     tokenizer::{TokenWithSpan, Tokenizer, token},
     util,
 };
@@ -18,6 +19,7 @@ mod builder;
 mod convert;
 mod less;
 mod macros;
+mod postcss_simple_vars;
 mod sass;
 mod selector;
 mod state;
@@ -96,6 +98,12 @@ impl<'a> Parser<'a> {
     #[inline]
     pub(crate) fn ident(&self, token: token::Ident<'a>, span: crate::Span) -> Ident<'a> {
         Ident { name: self.ident_name(&token), raw: token.raw, span }
+    }
+
+    pub(super) fn parse_dollar_var_ident(&mut self) -> PResult<(Ident<'a>, Span)> {
+        let (dollar_var, span) = expect!(self, DollarVar);
+        let name = self.ident(dollar_var.ident, Span { start: span.start + 1, end: span.end });
+        Ok((name, span))
     }
 
     pub(crate) fn dimension(

--- a/crates/oxc_css_parser/src/parser/mod.rs
+++ b/crates/oxc_css_parser/src/parser/mod.rs
@@ -1,12 +1,13 @@
 use self::state::ParserState;
 use crate::{
-    ParserOptions, expect,
+    ParserOptions,
     ast::{
         Dimension, Ident, InterpolableIdentStaticPart, InterpolableStrStaticPart,
         InterpolableUrlStaticPart, Str,
     },
     config::Syntax,
     error::{Error, PResult},
+    expect,
     pos::Span,
     tokenizer::{TokenWithSpan, Tokenizer, token},
     util,

--- a/crates/oxc_css_parser/src/parser/postcss_simple_vars.rs
+++ b/crates/oxc_css_parser/src/parser/postcss_simple_vars.rs
@@ -1,0 +1,41 @@
+use super::Parser;
+use crate::{
+    Parse,
+    ast::*,
+    config::Syntax,
+    error::PResult,
+    expect, peek,
+    pos::{Span, Spanned},
+    tokenizer::Token,
+};
+
+impl<'a> Parse<'a> for PostcssSimpleVar<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
+        debug_assert!(input.syntax == Syntax::Css && input.options.allow_postcss_simple_vars);
+
+        let (name, span) = input.parse_dollar_var_ident()?;
+        Ok(PostcssSimpleVar { name, span })
+    }
+}
+
+impl<'a> Parse<'a> for PostcssSimpleVarDeclaration<'a> {
+    fn parse(input: &mut Parser<'a>) -> PResult<Self> {
+        debug_assert!(input.syntax == Syntax::Css && input.options.allow_postcss_simple_vars);
+
+        let name = input.parse::<PostcssSimpleVar>()?;
+        let (_, colon_span) = expect!(input, Colon);
+        let mut value = input.parse_declaration_value()?;
+        // postcss-simple-vars is textual substitution; `!important` is just part
+        // of the value, not a structural declaration modifier (unlike CSS's
+        // `Declaration.important`). Keep it in the value stream.
+        if let Token::Exclamation(..) = &peek!(input).token {
+            let important = input.parse::<ImportantAnnotation>()?;
+            value.push(ComponentValue::ImportantAnnotation(important));
+        }
+
+        let end = value.last().map(|v| v.span().end).unwrap_or(colon_span.end);
+        let span = Span { start: name.span.start, end };
+
+        Ok(PostcssSimpleVarDeclaration { name, colon_span, value, span })
+    }
+}

--- a/crates/oxc_css_parser/src/parser/sass.rs
+++ b/crates/oxc_css_parser/src/parser/sass.rs
@@ -1410,11 +1410,8 @@ impl<'a> Parse<'a> for SassVariable<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
 
-        let (dollar_var, span) = expect!(input, DollarVar);
-        Ok(SassVariable {
-            name: input.ident(dollar_var.ident, Span { start: span.start + 1, end: span.end }),
-            span,
-        })
+        let (name, span) = input.parse_dollar_var_ident()?;
+        Ok(SassVariable { name, span })
     }
 }
 

--- a/crates/oxc_css_parser/src/parser/stmt.rs
+++ b/crates/oxc_css_parser/src/parser/stmt.rs
@@ -218,7 +218,9 @@ impl<'a> Parse<'a> for Stylesheet<'a> {
 }
 
 impl<'a> Parser<'a> {
-    fn parse_declaration_value(&mut self) -> PResult<oxc_allocator::Vec<'a, ComponentValue<'a>>> {
+    pub(super) fn parse_declaration_value(
+        &mut self,
+    ) -> PResult<oxc_allocator::Vec<'a, ComponentValue<'a>>> {
         let mut values = self.vec_with_capacity(3);
         loop {
             match &peek!(self).token {
@@ -487,6 +489,14 @@ impl<'a> Parser<'a> {
                 Token::DollarVar(..) if matches!(self.syntax, Syntax::Scss | Syntax::Sass) => {
                     statements
                         .push(Statement::SassVariableDeclaration(arena_box!(self, self.parse()?)));
+                }
+                Token::DollarVar(..)
+                    if self.syntax == Syntax::Css && self.options.allow_postcss_simple_vars =>
+                {
+                    statements.push(Statement::PostcssSimpleVarDeclaration(arena_box!(
+                        self,
+                        self.parse()?
+                    )));
                 }
                 Token::GreaterThan(..) | Token::Plus(..) | Token::Tilde(..) | Token::BarBar(..) => {
                     if self.syntax == Syntax::Less {

--- a/crates/oxc_css_parser/src/parser/value.rs
+++ b/crates/oxc_css_parser/src/parser/value.rs
@@ -174,6 +174,11 @@ impl<'a> Parser<'a> {
             Token::DollarVar(..) if matches!(self.syntax, Syntax::Scss | Syntax::Sass) => {
                 self.parse().map(ComponentValue::SassVariable)
             }
+            Token::DollarVar(..)
+                if self.syntax == Syntax::Css && self.options.allow_postcss_simple_vars =>
+            {
+                self.parse().map(ComponentValue::PostcssSimpleVar)
+            }
             Token::LParen(..) if matches!(self.syntax, Syntax::Scss | Syntax::Sass) => {
                 match self.try_parse(SassParenthesizedExpression::parse) {
                     Ok(expr) => Ok(ComponentValue::SassParenthesizedExpression(expr)),

--- a/crates/oxc_css_parser/tests/simple_vars.rs
+++ b/crates/oxc_css_parser/tests/simple_vars.rs
@@ -1,0 +1,73 @@
+use oxc_css_parser::{Allocator, ParserBuilder, ParserOptions, Syntax, ast::*};
+
+fn opts() -> ParserOptions {
+    ParserOptions { allow_postcss_simple_vars: true, ..Default::default() }
+}
+
+fn parse_css(code: &'static str, options: Option<ParserOptions>) -> Stylesheet<'static> {
+    let allocator = Box::leak(Box::new(Allocator::default()));
+    let mut builder = ParserBuilder::new(allocator, code).syntax(Syntax::Css);
+    if let Some(options) = options {
+        builder = builder.options(options);
+    }
+    builder.build().parse::<Stylesheet>().unwrap()
+}
+
+fn parse_css_err(code: &'static str, options: Option<ParserOptions>) {
+    let allocator = Allocator::default();
+    let mut builder = ParserBuilder::new(&allocator, code).syntax(Syntax::Css);
+    if let Some(options) = options {
+        builder = builder.options(options);
+    }
+    assert!(builder.build().parse::<Stylesheet>().is_err());
+}
+
+#[test]
+fn default_options_reject_dollar_variable_declaration() {
+    parse_css_err("$primary: red;", None);
+}
+
+#[test]
+fn default_options_reject_dollar_variable_reference() {
+    parse_css_err(".a { color: $primary; }", None);
+}
+
+// `@media (max-width: $var)` parses even without the flag because the parser
+// falls back to `<general-enclosed>` (W3C media query forward-compat). That
+// path keeps the prelude as a raw `TokenSeq`, so formatter output is verbatim.
+#[test]
+fn default_options_treat_dollar_variable_in_media_query_as_general_enclosed() {
+    let _ = parse_css("@media (max-width: $bp) { .a { color: red; } }", None);
+}
+
+#[test]
+fn opt_in_accepts_dollar_variable_declaration() {
+    let ss = parse_css("$primary: red;", Some(opts()));
+    assert!(matches!(ss.statements[0], Statement::PostcssSimpleVarDeclaration(_)));
+}
+
+#[test]
+fn opt_in_accepts_dollar_variable_reference_in_value() {
+    let ss = parse_css(".a { color: $primary; }", Some(opts()));
+    let Statement::QualifiedRule(rule) = &ss.statements[0] else {
+        panic!("expected qualified rule");
+    };
+    let Statement::Declaration(decl) = &rule.block.statements[0] else {
+        panic!("expected declaration");
+    };
+    assert!(matches!(decl.value[0], ComponentValue::PostcssSimpleVar(_)));
+}
+
+#[test]
+fn opt_in_accepts_dollar_variable_in_media_query() {
+    let _ = parse_css("@media (max-width: $bp) { .a { color: red; } }", Some(opts()));
+}
+
+#[test]
+fn opt_in_preserves_important_annotation_in_value() {
+    let ss = parse_css("$primary: red !important;", Some(opts()));
+    let Statement::PostcssSimpleVarDeclaration(decl) = &ss.statements[0] else {
+        panic!("expected dollar variable declaration");
+    };
+    assert!(matches!(decl.value.last(), Some(ComponentValue::ImportantAnnotation(_))));
+}


### PR DESCRIPTION
Refs: https://github.com/oxc-project/oxc/issues/23969

- Add new option to support `postcss-simple-vars`
  - https://github.com/postcss/postcss-simple-vars
  - Not fully supported, `margin-$(dir): 10px` does not work yet
- Add `PostcssSimpleVarDeclaration` and `PostcssSimpleVar` AST
  - Similar to `SassVariable`, but different