### PR TITLE
fix: accept unquoted numeric attribute selector values like [size=1]

### DIFF
--- a/crates/oxc_css_parser/src/ast.rs
+++ b/crates/oxc_css_parser/src/ast.rs
@@ -116,6 +116,8 @@ pub struct AttributeSelectorModifier<'a> {
 pub enum AttributeSelectorValue<'a> {
     Ident(InterpolableIdent<'a>),
     Str(InterpolableStr<'a>),
+    Number(Number<'a>),
+    Dimension(Dimension<'a>),
     Percentage(Percentage<'a>),
     LessEscapedStr(LessEscapedStr<'a>),
 }

--- a/crates/oxc_css_parser/src/ast_generated.rs
+++ b/crates/oxc_css_parser/src/ast_generated.rs
@@ -103,7 +103,7 @@ impl_spanned_struct!(AttributeSelector<'a>);
 impl_spanned_struct!(AttributeSelectorMatcher);
 impl_spanned_struct!(AttributeSelectorModifier<'a>);
 impl_spanned_enum!(AttributeSelectorValue<'a> {
-    tuple: [Ident, Str, Percentage, LessEscapedStr, ],
+    tuple: [Ident, Str, Number, Dimension, Percentage, LessEscapedStr, ],
     unit: [],
 });
 impl_spanned_struct!(BracketBlock<'a>);
@@ -574,7 +574,7 @@ impl_span_ignored_eq_enum!(AttributeSelectorMatcherKind {
 impl_span_ignored_eq_struct!(AttributeSelectorModifier<'a> { ident, });
 #[cfg(feature = "span_ignored_eq")]
 impl_span_ignored_eq_enum!(AttributeSelectorValue<'a> {
-    tuple: [Ident, Str, Percentage, LessEscapedStr, ],
+    tuple: [Ident, Str, Number, Dimension, Percentage, LessEscapedStr, ],
     unit: [],
 });
 #[cfg(feature = "span_ignored_eq")]
@@ -1368,6 +1368,8 @@ impl_enum_as_is!(AttributeSelectorValue<'a> {
     tuple: [
         Ident(InterpolableIdent<'a>) => is_ident, as_ident,
         Str(InterpolableStr<'a>) => is_str, as_str,
+        Number(Number<'a>) => is_number, as_number,
+        Dimension(Dimension<'a>) => is_dimension, as_dimension,
         Percentage(Percentage<'a>) => is_percentage, as_percentage,
         LessEscapedStr(LessEscapedStr<'a>) => is_less_escaped_str, as_less_escaped_str,
     ],

--- a/crates/oxc_css_parser/src/parser/selector.rs
+++ b/crates/oxc_css_parser/src/parser/selector.rs
@@ -428,6 +428,15 @@ impl<'a> Parse<'a> for AttributeSelector<'a> {
                 TokenWithSpan { token: Token::Str(..) | Token::StrTemplate(..), .. } => {
                     Some(AttributeSelectorValue::Str(input.parse()?))
                 }
+                // Unquoted numeric values such as `[size=1]` or `[size=1px]` are
+                // technically non-conforming (Selectors wants an ident or string), but
+                // browsers accept them and they appear in real CSS (incl. UA stylesheets).
+                TokenWithSpan { token: Token::Number(..), .. } => {
+                    Some(AttributeSelectorValue::Number(input.parse()?))
+                }
+                TokenWithSpan { token: Token::Dimension(..), .. } => {
+                    Some(AttributeSelectorValue::Dimension(input.parse()?))
+                }
                 TokenWithSpan { token: Token::Percentage(..), .. }
                     if input.syntax == Syntax::Less =>
                 {

--- a/crates/oxc_css_parser/tests/ast/selectors/attribute_selector.css
+++ b/crates/oxc_css_parser/tests/ast/selectors/attribute_selector.css
@@ -52,3 +52,11 @@ a[href='te"s"t'] {}
 [* |b] {}
 [*| b] {}
 [* | b] {}
+
+[size=1] {}
+[size=10] {}
+[tabindex=-1] {}
+[size=1px] {}
+[size=2.5] {}
+[size=1 i] {}
+select[size=1] {}

--- a/crates/oxc_css_parser/tests/ast/selectors/attribute_selector.snap
+++ b/crates/oxc_css_parser/tests/ast/selectors/attribute_selector.snap
@@ -4732,9 +4732,660 @@ Stylesheet(
         end: 970,
       ),
     ),
+    QualifiedRule(
+      type: "QualifiedRule",
+      selector: SelectorList(
+        type: "SelectorList",
+        selectors: [
+          ComplexSelector(
+            type: "ComplexSelector",
+            children: [
+              CompoundSelector(
+                type: "CompoundSelector",
+                children: [
+                  AttributeSelector(
+                    type: "AttributeSelector",
+                    name: WqName(
+                      type: "WqName",
+                      name: Ident(
+                        type: "Ident",
+                        name: "size",
+                        raw: "size",
+                        span: Span(
+                          start: 973,
+                          end: 977,
+                        ),
+                      ),
+                      prefix: None,
+                      span: Span(
+                        start: 973,
+                        end: 977,
+                      ),
+                    ),
+                    matcher: Some(AttributeSelectorMatcher(
+                      type: "AttributeSelectorMatcher",
+                      kind: Exact,
+                      span: Span(
+                        start: 977,
+                        end: 978,
+                      ),
+                    )),
+                    value: Some(Number(
+                      type: "Number",
+                      value: 1.0,
+                      raw: "1",
+                      span: Span(
+                        start: 978,
+                        end: 979,
+                      ),
+                    )),
+                    modifier: None,
+                    span: Span(
+                      start: 972,
+                      end: 980,
+                    ),
+                  ),
+                ],
+                span: Span(
+                  start: 972,
+                  end: 980,
+                ),
+              ),
+            ],
+            span: Span(
+              start: 972,
+              end: 980,
+            ),
+          ),
+        ],
+        commaSpans: [],
+        span: Span(
+          start: 972,
+          end: 980,
+        ),
+      ),
+      block: SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 981,
+          end: 983,
+        ),
+      ),
+      span: Span(
+        start: 972,
+        end: 983,
+      ),
+    ),
+    QualifiedRule(
+      type: "QualifiedRule",
+      selector: SelectorList(
+        type: "SelectorList",
+        selectors: [
+          ComplexSelector(
+            type: "ComplexSelector",
+            children: [
+              CompoundSelector(
+                type: "CompoundSelector",
+                children: [
+                  AttributeSelector(
+                    type: "AttributeSelector",
+                    name: WqName(
+                      type: "WqName",
+                      name: Ident(
+                        type: "Ident",
+                        name: "size",
+                        raw: "size",
+                        span: Span(
+                          start: 985,
+                          end: 989,
+                        ),
+                      ),
+                      prefix: None,
+                      span: Span(
+                        start: 985,
+                        end: 989,
+                      ),
+                    ),
+                    matcher: Some(AttributeSelectorMatcher(
+                      type: "AttributeSelectorMatcher",
+                      kind: Exact,
+                      span: Span(
+                        start: 989,
+                        end: 990,
+                      ),
+                    )),
+                    value: Some(Number(
+                      type: "Number",
+                      value: 10.0,
+                      raw: "10",
+                      span: Span(
+                        start: 990,
+                        end: 992,
+                      ),
+                    )),
+                    modifier: None,
+                    span: Span(
+                      start: 984,
+                      end: 993,
+                    ),
+                  ),
+                ],
+                span: Span(
+                  start: 984,
+                  end: 993,
+                ),
+              ),
+            ],
+            span: Span(
+              start: 984,
+              end: 993,
+            ),
+          ),
+        ],
+        commaSpans: [],
+        span: Span(
+          start: 984,
+          end: 993,
+        ),
+      ),
+      block: SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 994,
+          end: 996,
+        ),
+      ),
+      span: Span(
+        start: 984,
+        end: 996,
+      ),
+    ),
+    QualifiedRule(
+      type: "QualifiedRule",
+      selector: SelectorList(
+        type: "SelectorList",
+        selectors: [
+          ComplexSelector(
+            type: "ComplexSelector",
+            children: [
+              CompoundSelector(
+                type: "CompoundSelector",
+                children: [
+                  AttributeSelector(
+                    type: "AttributeSelector",
+                    name: WqName(
+                      type: "WqName",
+                      name: Ident(
+                        type: "Ident",
+                        name: "tabindex",
+                        raw: "tabindex",
+                        span: Span(
+                          start: 998,
+                          end: 1006,
+                        ),
+                      ),
+                      prefix: None,
+                      span: Span(
+                        start: 998,
+                        end: 1006,
+                      ),
+                    ),
+                    matcher: Some(AttributeSelectorMatcher(
+                      type: "AttributeSelectorMatcher",
+                      kind: Exact,
+                      span: Span(
+                        start: 1006,
+                        end: 1007,
+                      ),
+                    )),
+                    value: Some(Number(
+                      type: "Number",
+                      value: -1.0,
+                      raw: "-1",
+                      span: Span(
+                        start: 1007,
+                        end: 1009,
+                      ),
+                    )),
+                    modifier: None,
+                    span: Span(
+                      start: 997,
+                      end: 1010,
+                    ),
+                  ),
+                ],
+                span: Span(
+                  start: 997,
+                  end: 1010,
+                ),
+              ),
+            ],
+            span: Span(
+              start: 997,
+              end: 1010,
+            ),
+          ),
+        ],
+        commaSpans: [],
+        span: Span(
+          start: 997,
+          end: 1010,
+        ),
+      ),
+      block: SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 1011,
+          end: 1013,
+        ),
+      ),
+      span: Span(
+        start: 997,
+        end: 1013,
+      ),
+    ),
+    QualifiedRule(
+      type: "QualifiedRule",
+      selector: SelectorList(
+        type: "SelectorList",
+        selectors: [
+          ComplexSelector(
+            type: "ComplexSelector",
+            children: [
+              CompoundSelector(
+                type: "CompoundSelector",
+                children: [
+                  AttributeSelector(
+                    type: "AttributeSelector",
+                    name: WqName(
+                      type: "WqName",
+                      name: Ident(
+                        type: "Ident",
+                        name: "size",
+                        raw: "size",
+                        span: Span(
+                          start: 1015,
+                          end: 1019,
+                        ),
+                      ),
+                      prefix: None,
+                      span: Span(
+                        start: 1015,
+                        end: 1019,
+                      ),
+                    ),
+                    matcher: Some(AttributeSelectorMatcher(
+                      type: "AttributeSelectorMatcher",
+                      kind: Exact,
+                      span: Span(
+                        start: 1019,
+                        end: 1020,
+                      ),
+                    )),
+                    value: Some(Dimension(
+                      type: "Dimension",
+                      value: Number(
+                        type: "Number",
+                        value: 1.0,
+                        raw: "1",
+                        span: Span(
+                          start: 1020,
+                          end: 1021,
+                        ),
+                      ),
+                      unit: Ident(
+                        type: "Ident",
+                        name: "px",
+                        raw: "px",
+                        span: Span(
+                          start: 1021,
+                          end: 1023,
+                        ),
+                      ),
+                      kind: Length,
+                      span: Span(
+                        start: 1020,
+                        end: 1023,
+                      ),
+                    )),
+                    modifier: None,
+                    span: Span(
+                      start: 1014,
+                      end: 1024,
+                    ),
+                  ),
+                ],
+                span: Span(
+                  start: 1014,
+                  end: 1024,
+                ),
+              ),
+            ],
+            span: Span(
+              start: 1014,
+              end: 1024,
+            ),
+          ),
+        ],
+        commaSpans: [],
+        span: Span(
+          start: 1014,
+          end: 1024,
+        ),
+      ),
+      block: SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 1025,
+          end: 1027,
+        ),
+      ),
+      span: Span(
+        start: 1014,
+        end: 1027,
+      ),
+    ),
+    QualifiedRule(
+      type: "QualifiedRule",
+      selector: SelectorList(
+        type: "SelectorList",
+        selectors: [
+          ComplexSelector(
+            type: "ComplexSelector",
+            children: [
+              CompoundSelector(
+                type: "CompoundSelector",
+                children: [
+                  AttributeSelector(
+                    type: "AttributeSelector",
+                    name: WqName(
+                      type: "WqName",
+                      name: Ident(
+                        type: "Ident",
+                        name: "size",
+                        raw: "size",
+                        span: Span(
+                          start: 1029,
+                          end: 1033,
+                        ),
+                      ),
+                      prefix: None,
+                      span: Span(
+                        start: 1029,
+                        end: 1033,
+                      ),
+                    ),
+                    matcher: Some(AttributeSelectorMatcher(
+                      type: "AttributeSelectorMatcher",
+                      kind: Exact,
+                      span: Span(
+                        start: 1033,
+                        end: 1034,
+                      ),
+                    )),
+                    value: Some(Number(
+                      type: "Number",
+                      value: 2.5,
+                      raw: "2.5",
+                      span: Span(
+                        start: 1034,
+                        end: 1037,
+                      ),
+                    )),
+                    modifier: None,
+                    span: Span(
+                      start: 1028,
+                      end: 1038,
+                    ),
+                  ),
+                ],
+                span: Span(
+                  start: 1028,
+                  end: 1038,
+                ),
+              ),
+            ],
+            span: Span(
+              start: 1028,
+              end: 1038,
+            ),
+          ),
+        ],
+        commaSpans: [],
+        span: Span(
+          start: 1028,
+          end: 1038,
+        ),
+      ),
+      block: SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 1039,
+          end: 1041,
+        ),
+      ),
+      span: Span(
+        start: 1028,
+        end: 1041,
+      ),
+    ),
+    QualifiedRule(
+      type: "QualifiedRule",
+      selector: SelectorList(
+        type: "SelectorList",
+        selectors: [
+          ComplexSelector(
+            type: "ComplexSelector",
+            children: [
+              CompoundSelector(
+                type: "CompoundSelector",
+                children: [
+                  AttributeSelector(
+                    type: "AttributeSelector",
+                    name: WqName(
+                      type: "WqName",
+                      name: Ident(
+                        type: "Ident",
+                        name: "size",
+                        raw: "size",
+                        span: Span(
+                          start: 1043,
+                          end: 1047,
+                        ),
+                      ),
+                      prefix: None,
+                      span: Span(
+                        start: 1043,
+                        end: 1047,
+                      ),
+                    ),
+                    matcher: Some(AttributeSelectorMatcher(
+                      type: "AttributeSelectorMatcher",
+                      kind: Exact,
+                      span: Span(
+                        start: 1047,
+                        end: 1048,
+                      ),
+                    )),
+                    value: Some(Number(
+                      type: "Number",
+                      value: 1.0,
+                      raw: "1",
+                      span: Span(
+                        start: 1048,
+                        end: 1049,
+                      ),
+                    )),
+                    modifier: Some(AttributeSelectorModifier(
+                      type: "AttributeSelectorModifier",
+                      ident: Ident(
+                        type: "Ident",
+                        name: "i",
+                        raw: "i",
+                        span: Span(
+                          start: 1050,
+                          end: 1051,
+                        ),
+                      ),
+                      span: Span(
+                        start: 1050,
+                        end: 1051,
+                      ),
+                    )),
+                    span: Span(
+                      start: 1042,
+                      end: 1052,
+                    ),
+                  ),
+                ],
+                span: Span(
+                  start: 1042,
+                  end: 1052,
+                ),
+              ),
+            ],
+            span: Span(
+              start: 1042,
+              end: 1052,
+            ),
+          ),
+        ],
+        commaSpans: [],
+        span: Span(
+          start: 1042,
+          end: 1052,
+        ),
+      ),
+      block: SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 1053,
+          end: 1055,
+        ),
+      ),
+      span: Span(
+        start: 1042,
+        end: 1055,
+      ),
+    ),
+    QualifiedRule(
+      type: "QualifiedRule",
+      selector: SelectorList(
+        type: "SelectorList",
+        selectors: [
+          ComplexSelector(
+            type: "ComplexSelector",
+            children: [
+              CompoundSelector(
+                type: "CompoundSelector",
+                children: [
+                  TagNameSelector(
+                    type: "TagNameSelector",
+                    name: WqName(
+                      type: "WqName",
+                      name: Ident(
+                        type: "Ident",
+                        name: "select",
+                        raw: "select",
+                        span: Span(
+                          start: 1056,
+                          end: 1062,
+                        ),
+                      ),
+                      prefix: None,
+                      span: Span(
+                        start: 1056,
+                        end: 1062,
+                      ),
+                    ),
+                    span: Span(
+                      start: 1056,
+                      end: 1062,
+                    ),
+                  ),
+                  AttributeSelector(
+                    type: "AttributeSelector",
+                    name: WqName(
+                      type: "WqName",
+                      name: Ident(
+                        type: "Ident",
+                        name: "size",
+                        raw: "size",
+                        span: Span(
+                          start: 1063,
+                          end: 1067,
+                        ),
+                      ),
+                      prefix: None,
+                      span: Span(
+                        start: 1063,
+                        end: 1067,
+                      ),
+                    ),
+                    matcher: Some(AttributeSelectorMatcher(
+                      type: "AttributeSelectorMatcher",
+                      kind: Exact,
+                      span: Span(
+                        start: 1067,
+                        end: 1068,
+                      ),
+                    )),
+                    value: Some(Number(
+                      type: "Number",
+                      value: 1.0,
+                      raw: "1",
+                      span: Span(
+                        start: 1068,
+                        end: 1069,
+                      ),
+                    )),
+                    modifier: None,
+                    span: Span(
+                      start: 1062,
+                      end: 1070,
+                    ),
+                  ),
+                ],
+                span: Span(
+                  start: 1056,
+                  end: 1070,
+                ),
+              ),
+            ],
+            span: Span(
+              start: 1056,
+              end: 1070,
+            ),
+          ),
+        ],
+        commaSpans: [],
+        span: Span(
+          start: 1056,
+          end: 1070,
+        ),
+      ),
+      block: SimpleBlock(
+        type: "SimpleBlock",
+        statements: [],
+        span: Span(
+          start: 1071,
+          end: 1073,
+        ),
+      ),
+      span: Span(
+        start: 1056,
+        end: 1073,
+      ),
+    ),
   ],
   span: Span(
     start: 0,
-    end: 971,
+    end: 1074,
   ),
 )


### PR DESCRIPTION
## Summary

`select[size=1]` and similar attribute selectors with an unquoted numeric value previously failed to parse with `attribute selector value is expected`.

The Selectors grammar only permits an `<ident>` or `<string>` as an attribute value, but browsers accept unquoted `<number>` / `<dimension>` values, and they appear in real CSS — including UA stylesheets (the CSS-UI spec's own example uses `select[size=1]`).

This adds `Number` and `Dimension` variants to `AttributeSelectorValue` and accepts those tokens in all syntaxes, so `[size=1]`, `[size=1px]`, `[tabindex=-1]`, `[size=2.5]`, and `[size=1 i]` now parse. New fixtures cover these in `tests/ast/selectors/attribute_selector.css`.

Found via a conformance run over the `csswg-drafts` spec corpus (see #19).

**Scope note:** `Percentage` attribute values remain Less-only as before; making `[a=50%]` parse in CSS too is a deliberate follow-up, left out to avoid changing existing behavior here.

Closes #20
