### PR TITLE
fix: glued placeholder handling

### DIFF
--- a/crates/oxc_css_parser/src/parser/stmt.rs
+++ b/crates/oxc_css_parser/src/parser/stmt.rs
@@ -578,27 +578,37 @@ impl<'a> Parser<'a> {
     /// - a bare `{` after the placeholder IS absorbed — the placeholder is the
     ///   selector for that block (`${mixin}\n{ color: red }` is one rule; a bare
     ///   `{...}` is meaningless without a selector, so this is the only valid read)
-    /// - but selector CONTENT appearing after a newline splits into a separate
-    ///   rule (`${mixin}\n& > .x {}` is two statements, not one)
+    /// - a placeholder separated by whitespace from what follows, then a newline,
+    ///   then selector content = a separate rule (`${mixin}\n& > .x {}` and
+    ///   `${a} ${b}\nhtml {}` are two statements, not one — spaced placeholders
+    ///   are typically mixin invocations, not selector pieces)
+    /// - but a placeholder IMMEDIATELY glued to non-whitespace (e.g. `${p}:hover`
+    ///   or `${p},`) is a compound-selector piece, so a multi-line selector list
+    ///   (`${p}:hover &,\n${q}:focus &, { ... }`) is one rule — keep scanning for `{` across newlines.
     ///
-    /// So this only answers "is a `{` reachable before any non-whitespace content
-    /// appears past a newline?" — the real grammar (strings, comments, `#{...}`
-    /// interpolations, validity) is left to `QualifiedRule::parse`, which runs
-    /// next and rolls back if this guess was wrong. Deliberately NOT a tokenizer:
-    /// it never early-exits on `;`/`}` (those may sit inside an attribute string
-    /// or comment), so it can't misclassify a same-line selector containing them.
+    /// The real grammar (strings, comments, `#{...}` interpolations, validity) is
+    /// left to `QualifiedRule::parse`, which runs next and rolls back if this guess was wrong.
+    /// Deliberately NOT a tokenizer: it never early-exits on `;`/`}`
+    /// (those may sit inside an attribute string or comment),
+    /// so it can't misclassify a same-line selector containing them.
     fn placeholder_starts_qualified_rule(&self, from: usize) -> bool {
+        let bytes = &self.source.as_bytes()[from..];
+        // Immediately-adjacent non-whitespace (`${p}:hover`, `${p},`) means the
+        // placeholder is a compound-selector piece: only `{` matters from here, regardless of newlines.
+        if bytes.first().is_some_and(|b| !b.is_ascii_whitespace()) {
+            return bytes.contains(&b'{');
+        }
+        // Otherwise the placeholder is separated by whitespace from what follows.
+        // A `{` on the same line (whitespace-only prefix) still makes the
+        // placeholder its selector; any non-whitespace after a newline starts a separate rule.
         let mut newline_seen = false;
-        for &b in &self.source.as_bytes()[from..] {
+        for &b in bytes {
             match b {
-                // First `{` (block opener or `#{` interpolation), even after a
-                // newline with no content yet: the placeholder is its selector.
                 b'{' => return true,
                 // `\r`, `\r\n`, and `\n` all count as a newline (the tokenizer
                 // treats a bare `\r` as a line break too).
                 b'\n' | b'\r' => newline_seen = true,
                 _ if b.is_ascii_whitespace() => {}
-                // Non-whitespace content after a newline = a separate rule.
                 _ if newline_seen => return false,
                 _ => {}
             }

--- a/crates/oxc_css_parser/tests/placeholder.rs
+++ b/crates/oxc_css_parser/tests/placeholder.rs
@@ -208,6 +208,28 @@ fn placeholder_led_selector_does_not_cross_newline() {
     let ss = parse("`PLACEHOLDER-0`\r& > .x { color: red }", Some(opts()));
     assert!(matches!(ss.statements[0], Statement::Placeholder(Placeholder { index: 0, .. })));
     assert!(matches!(ss.statements[1], Statement::QualifiedRule(_)));
+
+    // BUT a placeholder immediately GLUED to non-whitespace (no space) is a
+    // compound-selector piece — commas + newlines to the next placeholder
+    // must NOT split it into a bare placeholder + separate rule.
+    let ss = parse(
+        "`PLACEHOLDER-0`:hover &,\n  `PLACEHOLDER-1`:focus-within &,\n  `PLACEHOLDER-2`:after { color: red }",
+        Some(opts()),
+    );
+    assert_eq!(ss.statements.len(), 1);
+    assert!(matches!(ss.statements[0], Statement::QualifiedRule(_)));
+
+    // Space between placeholders is the standalone signal: two bare-placeholder
+    // mixin invocations followed by a separate rule on the next line, matching
+    // styled-components' `${sanitize} ${fonts}\nhtml {}` idiom.
+    let ss = parse(
+        "`PLACEHOLDER-0` `PLACEHOLDER-1`\nhtml { color: red }",
+        Some(opts()),
+    );
+    assert_eq!(ss.statements.len(), 3);
+    assert!(matches!(ss.statements[0], Statement::Placeholder(Placeholder { index: 0, .. })));
+    assert!(matches!(ss.statements[1], Statement::Placeholder(Placeholder { index: 1, .. })));
+    assert!(matches!(ss.statements[2], Statement::QualifiedRule(_)));
 }
 
 #[test]

--- a/crates/oxc_css_parser/tests/placeholder.rs
+++ b/crates/oxc_css_parser/tests/placeholder.rs
@@ -222,10 +222,7 @@ fn placeholder_led_selector_does_not_cross_newline() {
     // Space between placeholders is the standalone signal: two bare-placeholder
     // mixin invocations followed by a separate rule on the next line, matching
     // styled-components' `${sanitize} ${fonts}\nhtml {}` idiom.
-    let ss = parse(
-        "`PLACEHOLDER-0` `PLACEHOLDER-1`\nhtml { color: red }",
-        Some(opts()),
-    );
+    let ss = parse("`PLACEHOLDER-0` `PLACEHOLDER-1`\nhtml { color: red }", Some(opts()));
     assert_eq!(ss.statements.len(), 3);
     assert!(matches!(ss.statements[0], Statement::Placeholder(Placeholder { index: 0, .. })));
     assert!(matches!(ss.statements[1], Statement::Placeholder(Placeholder { index: 1, .. })));


### PR DESCRIPTION
Keep `${v}:hover` tight, NOT `${v} :hover`.

Also keep `${v}\ndiv`, NOT `${v} div`.