### PR TITLE
Accept CSS rules with an empty selector (e.g. bare `{}`)

### DIFF
--- a/crates/oxc_css_parser/src/error.rs
+++ b/crates/oxc_css_parser/src/error.rs
@@ -91,6 +91,7 @@ pub enum ErrorKind {
     UnexpectedSemicolonInSass,
     UnexpectedSimpleBlock,
     TopLevelDeclaration,
+    EmptySelector,
 }
 
 impl Display for ErrorKind {
@@ -205,6 +206,7 @@ impl Display for ErrorKind {
             Self::UnexpectedSemicolonInSass => write!(f, "semicolon in Sass is disallowed"),
             Self::UnexpectedSimpleBlock => write!(f, "simple block is disallowed"),
             Self::TopLevelDeclaration => write!(f, "declaration at top level is disallowed"),
+            Self::EmptySelector => write!(f, "selector is expected before `{{`"),
         }
     }
 }

--- a/crates/oxc_css_parser/src/parser/stmt.rs
+++ b/crates/oxc_css_parser/src/parser/stmt.rs
@@ -529,6 +529,37 @@ impl<'a> Parser<'a> {
                     statements.push(Statement::KeyframeBlock(self.parse()?));
                     is_block_element = true;
                 }
+                Token::LBrace(..)
+                    if !self.state.in_keyframes_at_rule
+                        && matches!(self.syntax, Syntax::Css | Syntax::Scss | Syntax::Less) =>
+                {
+                    // A rule with no selector at all (e.g. a bare `{}`) is invalid
+                    // per the CSS spec, but postcss and browsers parse it leniently
+                    // as a rule with an empty selector. Accept it and record a
+                    // recoverable error instead of hard-failing.
+                    let pos = span.start;
+                    self.recoverable_errors.push(Error {
+                        kind: ErrorKind::EmptySelector,
+                        span: Span { start: pos, end: pos },
+                    });
+                    let empty_selector = ComplexSelector {
+                        children: arena_vec!(self),
+                        span: Span { start: pos, end: pos },
+                    };
+                    let selector = SelectorList {
+                        selectors: arena_vec!(self; empty_selector),
+                        comma_spans: arena_vec!(self),
+                        span: Span { start: pos, end: pos },
+                    };
+                    let block = self.parse::<SimpleBlock>()?;
+                    let rule_span = Span { start: pos, end: block.span.end };
+                    statements.push(Statement::QualifiedRule(QualifiedRule {
+                        selector,
+                        block,
+                        span: rule_span,
+                    }));
+                    is_block_element = true;
+                }
                 Token::RBrace(..) | Token::Eof(..) | Token::Dedent(..) => break,
                 Token::Semicolon(..) | Token::Linebreak(..) => {
                     bump!(self);


### PR DESCRIPTION
## Summary
- A rule with an empty selector (e.g. a bare `{}`) was hard-rejected with `CSS rule is expected`, even though postcss and browsers parse it leniently as a rule with an empty selector.
- `parse_statements` in `crates/oxc_css_parser/src/parser/stmt.rs` had no match arm for `Token::LBrace` as the first token of a statement, so it always fell through to the generic `ExpectRule` error.
- Added a dedicated arm (for `Css`/`Scss`/`Less`, outside `@keyframes`) that accepts the empty prelude, builds a `QualifiedRule` with an empty `SelectorList`/`ComplexSelector`, and records a new recoverable `EmptySelector` error instead of hard-failing — following the same "accept + recoverable error" pattern already used for `TopLevelDeclaration` etc.

Fixes #33 (part of #19).

## Verification caveat
I don't have a Rust toolchain available in my environment, so I could not run `cargo build`/`cargo test --all-features` or `cargo run -p conformance` locally. I reviewed the change by hand:
- Checked field names/types/lifetimes against `ast.rs` and existing sibling match arms in the same function.
- Confirmed the new `Token::LBrace` arm doesn't collide with any existing arm and only triggers when `{` is the very first token of a statement (not reachable from the pre-existing `RBrace`/block-closing logic).
- Checked every existing fixture that currently produces `CSS rule is expected` in `crates/oxc_css_parser/tests/error/**` and `crates/oxc_css_parser/tests/recoverable/**` — none of them start with a bare `{`, so none should be affected by this change.
- The `postcss-parser-tests` conformance suite's `cases/no-selector.css` (referenced directly in the issue) should now flip from `ERROR ... CSS rule is expected` to `RECOVER ... selector is expected before \`{\`` — this will make `tasks/conformance/snapshots/postcss-parser-tests.snap` (and `summary.snap`) stale. I didn't hand-edit those generated snapshots since I can't verify there's no wider fallout across the much larger `sass-spec.snap`/`less.js.snap` suites (fetched from external repos at conformance-run time, not present in this checkout).

Please let the `conformance` CI job regenerate/verify the snapshots (or point me at the diff) — happy to push a follow-up commit once I can see it, or a maintainer can run `just conformance` and push the snapshot update directly.

## Test plan
- [ ] `cargo test --all-features` passes
- [ ] `cargo run -p conformance` regenerates snapshots with only the expected `no-selector.css` classification change
- [ ] Manually confirm `{}`, `a { } {}`, and `@media screen { {} }` all parse without a hard error and surface a recoverable `EmptySelector` diagnostic