### PR TITLE
fix: allow a nested `@import` to be terminated by `}` (no trailing `;`)

### DIFF
--- a/crates/oxc_css_parser/src/parser/at_rule/import.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/import.rs
@@ -80,7 +80,12 @@ impl<'a> Parse<'a> for ImportPrelude<'a> {
             span.end = supports.span().end;
         }
 
-        let media = if matches!(peek!(input).token, Token::Semicolon(..) | Token::Eof(..)) {
+        // `}` ends the at-rule too, so an `@import` nested in a style rule needs no
+        // trailing `;` (`a { @import "b.css" }`); it can't start a media query.
+        let media = if matches!(
+            peek!(input).token,
+            Token::Semicolon(..) | Token::Eof(..) | Token::RBrace(..)
+        ) {
             None
         } else {
             let media = input.parse::<MediaQueryList>()?;

--- a/crates/oxc_css_parser/tests/ast/at-rule/import-nested.css
+++ b/crates/oxc_css_parser/tests/ast/at-rule/import-nested.css
@@ -1,0 +1,3 @@
+a { @import "a.css" }
+a { @import "a.css" screen }
+a { @import "a.css"; }

--- a/tasks/conformance/snapshots/postcss-parser-tests.snap
+++ b/tasks/conformance/snapshots/postcss-parser-tests.snap
@@ -1,12 +1,11 @@
 suite: postcss-parser-tests
 sha: de1bc546de3678dd1c85e57cb2e9eece0098ddb9
-files: 30   success: 24   failed: 6
-clean: 24  recovered: 1  hard_error: 5  panic: 0
+files: 30   success: 25   failed: 5
+clean: 25  recovered: 1  hard_error: 4  panic: 0
 
 failures:
 ERROR    cases/comments.css    component value is expected
 ERROR    cases/escape.css    attribute selector value is expected
 RECOVER  cases/extends.css    declaration at top level is disallowed
-ERROR    cases/inside.css    expect token `<ident>`, but found `}`
 ERROR    cases/prop.css    unknown token
 ERROR    cases/rule-at.css    component value is expected

--- a/tasks/conformance/snapshots/summary.snap
+++ b/tasks/conformance/snapshots/summary.snap
@@ -6,15 +6,15 @@ css-parsing-tests           0        0       0       0      0        0      0
 wpt                         5        3       2       3      0        2      0
 csswg-drafts                9        8       1       8      0        1      0
 webref                      0        0       0       0      0        0      0
-postcss-parser-tests       30       24       6      24      1        5      0
+postcss-parser-tests       30       25       5      25      1        4      0
 sass-spec               26785    25411    1374   25411     29     1345      0
 less.js                   459      385      74     385      3       71      0
 ------------------------------------------------------------------------
-total                   27288    25831    1457   25831     33     1424      0
+total                   27288    25832    1456   25832     33     1423      0
 
 # by syntax
 syntax                  files  success  failed   clean  recov  harderr  panic
-css                     11795    10963     832   10963      5      827      0
+css                     11795    10964     831   10964      5      826      0
 scss                    14748    14388     360   14388     22      338      0
 sass                      439      226     213     226      4      209      0
 less                      306      254      52     254      2       50      0


### PR DESCRIPTION
`a { @import "b.css" }` was rejected with `expect \`<ident>\`, but found \`}\``. After parsing the href, the `@import` prelude tried to parse a media query and ran straight into the block's closing `}`.

### Fix
Treat `}` as an `@import` terminator alongside `;` and EOF — a `}` can never begin a media query, and it always ends the enclosing block. This mirrors the earlier EOF terminator fix (#40). The optional `layer`/`supports()` parts already handle `}` gracefully (default / `try_parse`).

### Impact
Resolves `cases/inside.css` (postcss-parser-tests **23 → 24**), no regressions. Top-level `@import`, the `;`-terminated form, and nested `@import ... screen }` (media stops at `}`) all still parse.

Closes #35