### PR TITLE
feat: accept arbitrary @import modifiers, mixed import lists, and unquoted indented-syntax paths

### DIFF
--- a/crates/oxc_css_parser/src/ast.rs
+++ b/crates/oxc_css_parser/src/ast.rs
@@ -521,6 +521,13 @@ pub struct ImportPrelude<'a> {
     pub layer: Option<ImportPreludeLayer<'a>>,
     pub supports: Option<ImportPreludeSupports<'a>>,
     pub media: Option<MediaQueryList<'a>>,
+    /// Import modifiers that don't fit the `layer()`/`supports()`/media-query
+    /// grammar, kept as raw component values — reference compilers accept an
+    /// arbitrary mix of idents, functions, and parens here, and a comma may
+    /// even chain further imports (`@import "a" b c(d), "e" supports(f: g);`).
+    /// When present, `layer`/`supports`/`media` are `None` and the whole
+    /// post-URL tail lives here.
+    pub modifiers: Option<ComponentValues<'a>>,
     pub span: Span,
 }
 

--- a/crates/oxc_css_parser/src/ast_generated.rs
+++ b/crates/oxc_css_parser/src/ast_generated.rs
@@ -690,7 +690,7 @@ impl_span_ignored_eq_struct!(HexColor<'a> { value, raw, });
 #[cfg(feature = "span_ignored_eq")]
 impl_span_ignored_eq_struct!(Ident<'a> { name, raw, });
 #[cfg(feature = "span_ignored_eq")]
-impl_span_ignored_eq_struct!(ImportPrelude<'a> { href, layer, supports, media, });
+impl_span_ignored_eq_struct!(ImportPrelude<'a> { href, layer, supports, media, modifiers, });
 #[cfg(feature = "span_ignored_eq")]
 impl_span_ignored_eq_enum!(ImportPreludeHref<'a> {
     tuple: [Str, Url, Function, ],

--- a/crates/oxc_css_parser/src/parser/at_rule/import.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/import.rs
@@ -12,8 +12,32 @@ use crate::{
 // https://www.w3.org/TR/css-cascade-5/#at-import
 impl<'a> Parse<'a> for ImportPrelude<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
+        // The indented syntax accepts an unquoted path (`@import other.css`),
+        // but an ident glued to `(` is a function href
+        // (`@import url("theme.css")`), which the `Url::parse` arm handles.
+        let sass_unquoted_path = input.syntax == Syntax::Sass && {
+            let ident_end = match peek!(input) {
+                TokenWithSpan { token: Token::Ident(..), span } => Some(span.end),
+                _ => None,
+            };
+            ident_end.is_some_and(|end| input.source.as_bytes().get(end) != Some(&b'('))
+        };
         let href = match &peek!(input).token {
             Token::Str(..) | Token::StrTemplate(..) => input.parse().map(ImportPreludeHref::Str)?,
+            Token::Ident(..) if sass_unquoted_path => {
+                let start = peek!(input).span.start;
+                let mut end = start;
+                while matches!(
+                    &peek!(input).token,
+                    Token::Ident(..) | Token::Dot(..) | Token::Minus(..) | Token::Solidus(..)
+                ) && (peek!(input).span.start == end || end == start)
+                {
+                    end = bump!(input).span.end;
+                }
+                let raw = unsafe { input.source.get_unchecked(start..end) };
+                let span = Span { start, end };
+                ImportPreludeHref::Str(InterpolableStr::Literal(Str { value: raw, raw, span }))
+            }
             _ => match input.try_parse(Url::parse) {
                 Ok(url) => ImportPreludeHref::Url(url),
                 // Sass only: the content of `url(...)` may be SassScript that
@@ -35,6 +59,59 @@ impl<'a> Parse<'a> for ImportPrelude<'a> {
         };
         let mut span = href.span().clone();
 
+        let structured = input.try_parse(Self::parse_structured_tail);
+        let (layer, supports, media, modifiers) = match structured {
+            Ok((layer, supports, media)) => (layer, supports, media, None),
+            // Reference compilers accept arbitrary import modifiers (idents,
+            // unknown functions, media-ish parens, further comma-chained
+            // imports); keep the whole tail as raw component values.
+            Err(_) => {
+                let start = peek!(input).span.start;
+                let values = input.parse_declaration_value_tokens(true)?;
+                // A trailing comma has no import after it — reference
+                // compilers reject that, so don't paper over it.
+                if let Some(ComponentValue::TokenWithSpan(TokenWithSpan {
+                    token: Token::Comma(..),
+                    span,
+                })) = values.last()
+                {
+                    return Err(Error { kind: ErrorKind::ExpectRule, span: span.clone() });
+                }
+                let end = values.last().map_or(start, |value| value.span().end);
+                (None, None, None, Some(ComponentValues { values, span: Span { start, end } }))
+            }
+        };
+        if let Some(layer) = &layer {
+            span.end = layer.span().end;
+        }
+        if let Some(supports) = &supports {
+            span.end = supports.span().end;
+        }
+        if let Some(media) = &media {
+            span.end = media.span.end;
+        }
+        if let Some(modifiers) = &modifiers {
+            if modifiers.span.end > modifiers.span.start {
+                span.end = modifiers.span.end;
+            }
+        }
+
+        Ok(ImportPrelude { href, layer, supports, media, modifiers, span })
+    }
+}
+
+impl<'a> ImportPrelude<'a> {
+    /// The standard post-URL grammar: optional `layer`/`layer(...)`, optional
+    /// `supports(...)`, optional media query list — valid only if it accounts
+    /// for everything up to the end of the statement.
+    #[allow(clippy::type_complexity)]
+    fn parse_structured_tail(
+        input: &mut Parser<'a>,
+    ) -> PResult<(
+        Option<ImportPreludeLayer<'a>>,
+        Option<ImportPreludeSupports<'a>>,
+        Option<MediaQueryList<'a>>,
+    )> {
         let layer = match &peek!(input).token {
             Token::Ident(ident) if ident.name().eq_ignore_ascii_case("layer") => {
                 let ident = input.parse::<Ident>()?;
@@ -54,13 +131,13 @@ impl<'a> Parse<'a> for ImportPrelude<'a> {
                     }
                     _ => ImportPreludeLayer::Empty(ident),
                 };
-                span.end = layer.span().end;
                 Some(layer)
             }
             _ => None,
         };
 
         let supports = input.try_parse(|parser| {
+            // (kept as its own try so a non-`supports` ident rolls back)
             let (ident, span) = expect!(parser, Ident);
             if !ident.name().eq_ignore_ascii_case("supports") {
                 return Err(Error { kind: ErrorKind::TryParseError, span });
@@ -76,23 +153,32 @@ impl<'a> Parse<'a> for ImportPrelude<'a> {
             let (_, Span { end, .. }) = expect!(parser, RParen);
             Ok(ImportPreludeSupports { kind, span: Span { start: span.start, end } })
         });
-        if let Ok(supports) = &supports {
-            span.end = supports.span().end;
-        }
-
         // `}` ends the at-rule too, so an `@import` nested in a style rule needs no
         // trailing `;` (`a { @import "b.css" }`); it can't start a media query.
         let media = if matches!(
             peek!(input).token,
-            Token::Semicolon(..) | Token::Eof(..) | Token::RBrace(..)
+            Token::Semicolon(..)
+                | Token::Eof(..)
+                | Token::RBrace(..)
+                | Token::Dedent(..)
+                | Token::Linebreak(..)
         ) {
             None
         } else {
-            let media = input.parse::<MediaQueryList>()?;
-            span.end = media.span.end;
-            Some(media)
+            Some(input.parse::<MediaQueryList>()?)
         };
 
-        Ok(ImportPrelude { href, layer, supports: supports.ok(), media, span })
+        // Anything left over means this tail isn't the standard grammar.
+        match &peek!(input).token {
+            Token::Semicolon(..)
+            | Token::Eof(..)
+            | Token::RBrace(..)
+            | Token::Dedent(..)
+            | Token::Linebreak(..) => Ok((layer, supports.ok(), media)),
+            _ => {
+                let span = peek!(input).span.clone();
+                Err(Error { kind: ErrorKind::TryParseError, span })
+            }
+        }
     }
 }

--- a/crates/oxc_css_parser/tests/ast/at-rule/import-modifiers/arbitrary.css
+++ b/crates/oxc_css_parser/tests/ast/at-rule/import-modifiers/arbitrary.css
@@ -1,0 +1,1 @@
+@import "a" b c d(e) supports(f: g) h i j(k) l m (n: o), (p: q);

--- a/crates/oxc_css_parser/tests/ast/at-rule/import-modifiers/mixed-list.scss
+++ b/crates/oxc_css_parser/tests/ast/at-rule/import-modifiers/mixed-list.scss
@@ -1,0 +1,2 @@
+@import "b" c(d), "e.css";
+@import "hey1.css", "cookie.css", url("hey2.css"), "fudge.css";

--- a/crates/oxc_css_parser/tests/ast/at-rule/import-modifiers/unquoted.sass
+++ b/crates/oxc_css_parser/tests/ast/at-rule/import-modifiers/unquoted.sass
@@ -1,0 +1,1 @@
+@import other.css

--- a/tasks/conformance/snapshots/sass-spec.snap
+++ b/tasks/conformance/snapshots/sass-spec.snap
@@ -1,7 +1,7 @@
 suite: sass-spec
 sha: a2ead9225786d49e91f5cc36755b7713596a2338
-files: 26787   success: 26364   failed: 120   expected: 303
-clean: 26364  recovered: 11  hard_error: 109  panic: 0
+files: 26787   success: 26403   failed: 91   expected: 293
+clean: 26403  recovered: 11  hard_error: 80  panic: 0
 
 failures:
 ERROR    spec/core_functions/string/unquote.hrx::meaningful_css_characters/output.css    expect token `}`, but found `<eof>`
@@ -33,28 +33,6 @@ ERROR    spec/css/plain/function.hrx::uppercase/result/characters/output.css    
 ERROR    spec/css/plain/function.hrx::uppercase/result/characters/plain.css    component value is expected
 ERROR    spec/css/plain/hacks.hrx::output.css    unexpected whitespace
 ERROR    spec/css/plain/hacks.hrx::plain.css    unexpected whitespace
-ERROR    spec/css/plain/import/conditions.hrx::multiple/many/input.scss    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::multiple/many/output.css    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::multiple/unknown_function_then/media/input.scss    expect token `;`, but found `(`
-ERROR    spec/css/plain/import/conditions.hrx::multiple/unknown_function_then/media/output.css    expect token `;`, but found `(`
-ERROR    spec/css/plain/import/conditions.hrx::multiple/unknown_function_then/supports/input.scss    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::multiple/unknown_function_then/supports/output.css    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::multiple/unknown_function_then/unknown_function/input.scss    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::multiple/unknown_function_then/unknown_function/output.css    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::multiple/unknown_function_then/unknown_ident/input.scss    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::multiple/unknown_function_then/unknown_ident/output.css    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::multiple/unknown_ident_then/media/input.scss    expect token `;`, but found `(`
-ERROR    spec/css/plain/import/conditions.hrx::multiple/unknown_ident_then/media/output.css    expect token `;`, but found `(`
-ERROR    spec/css/plain/import/conditions.hrx::multiple/unknown_ident_then/supports/input.scss    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::multiple/unknown_ident_then/supports/output.css    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::multiple/unknown_ident_then/unknown_function/input.scss    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::multiple/unknown_ident_then/unknown_function/output.css    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::multiple/unknown_ident_then/unknown_ident/input.scss    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::multiple/unknown_ident_then/unknown_ident/output.css    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::supports/declaration/followed_by_import_arg/input.scss    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::unknown/function/argument/input.scss    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::unknown/function/argument/output.css    expect token `;`, but found `&`
-ERROR    spec/css/plain/import/conditions.hrx::unknown/function/followed_by_import_arg/input.scss    expect token `;`, but found `<ident>`
 ERROR    spec/css/selector/slotted.hrx::output.css    expect token `)`, but found `,`
 ERROR    spec/css/supports/syntax/function.hrx::interpolated_name/full/input.scss    expect token `'('`, but found `#{`
 ERROR    spec/css/supports/syntax/function.hrx::interpolated_name/partial/input.scss    expect token `(`, but found `#{`
@@ -71,7 +49,6 @@ RECOVER  spec/css/unicode_range/simple.hrx::input.scss    unicode range end valu
 RECOVER  spec/css/unicode_range/simple.hrx::output.css    unicode range end value exceeds max allowed code point
 ERROR    spec/css/unknown_directive/name_interpolation.hrx::input.scss    CSS rule is expected
 RECOVER  spec/directives/at_root/keyframes.hrx::all/input.scss    unknown keyframe selector
-ERROR    spec/directives/import/css.hrx::unquoted/input.sass    expect token `<string>`, but found `<ident>`
 ERROR    spec/expressions/if/css.hrx::alone/argument/input.scss    expect token `<ident>`, but found `@`
 ERROR    spec/libsass-closed-issues/issue_1218.hrx::input.scss    expect token `{`, but found `<ident>`
 ERROR    spec/libsass-closed-issues/issue_1233.hrx::input.scss    expect token `{`, but found `<ident>`
@@ -80,20 +57,15 @@ ERROR    spec/libsass-closed-issues/issue_1596.hrx::input.scss    expect token `
 ERROR    spec/libsass-closed-issues/issue_1596.hrx::output.css    expect token `{`, but found `;`
 ERROR    spec/libsass-closed-issues/issue_346.hrx::input.scss    expect token `{`, but found `#{`
 RECOVER  spec/libsass-closed-issues/issue_759.hrx::input.scss    duplicated Sass flag `!default`
-ERROR    spec/libsass-todo-issues/issue_1763.hrx::input.scss    expect token `;`, but found `(`
 ERROR    spec/libsass-todo-issues/issue_221262.hrx::input.scss    CSS rule is expected
 ERROR    spec/libsass-todo-issues/issue_221262.hrx::output.css    CSS rule is expected
 ERROR    spec/libsass-todo-issues/issue_221292.hrx::input.scss    CSS rule is expected
 ERROR    spec/libsass-todo-issues/issue_221292.hrx::output.css    CSS rule is expected
-ERROR    spec/libsass/import.hrx::input.scss    expect token `<string>`, but found `<ident>`
 ERROR    spec/libsass/keyframes.hrx::input.scss    expect token `{`, but found `:`
 ERROR    spec/libsass/keyframes.hrx::output.css    expect token `{`, but found `:`
 ERROR    spec/non_conformant/basic/36_extra_commas_in_selectors.hrx::input.scss    simple selector is expected
 ERROR    spec/non_conformant/basic/50_wrapped_pseudo_selectors.hrx::input.scss    expect token `)`, but found `<ident>`
 ERROR    spec/non_conformant/basic/50_wrapped_pseudo_selectors.hrx::output.css    expect token `)`, but found `<ident>`
-ERROR    spec/non_conformant/errors/import/file/simple.hrx::input.scss    expect token `<string>`, but found `<ident>`
-ERROR    spec/non_conformant/errors/import/miss/simple.hrx::input.scss    expect token `<string>`, but found `<ident>`
-ERROR    spec/non_conformant/errors/import/url/simple.hrx::input.scss    expect token `<string>`, but found `<ident>`
 ERROR    spec/non_conformant/extend-tests/069_test_attribute_unification.hrx::input.scss    expect token `{`, but found `%`
 ERROR    spec/non_conformant/extend-tests/189_test_placeholder_descendant_selector.hrx::input.scss    expect token `{`, but found `%`
 ERROR    spec/non_conformant/extend-tests/190_test_semi_placeholder_selector.hrx::input.scss    expect token `{`, but found `%`
@@ -111,7 +83,6 @@ ERROR    spec/non_conformant/parser/interpolate/28_escaped_single_quotes/01_inli
 ERROR    spec/non_conformant/parser/interpolate/28_escaped_single_quotes/02_variable.hrx::output.css    unterminated string
 ERROR    spec/non_conformant/parser/interpolate/28_escaped_single_quotes/03_inline_double.hrx::output.css    unterminated string
 ERROR    spec/non_conformant/parser/interpolate/28_escaped_single_quotes/04_variable_double.hrx::output.css    unterminated string
-ERROR    spec/non_conformant/sass/import/unquoted.hrx::input.sass    expect token `<string>`, but found `<ident>`
 ERROR    spec/non_conformant/sass/pseudo.hrx::input.sass    CSS rule is expected
 ERROR    spec/non_conformant/scss-tests/044_test_trailing_comma_in_selector.hrx::input.scss    simple selector is expected
 ERROR    spec/non_conformant/scss/important-in-arglist.hrx::input.scss    expect token `;`, but found `<ident>`
@@ -175,7 +146,6 @@ ERROR    spec/css/plain/error/media.hrx::logic/or_after/and/plain.css    expect 
 ERROR    spec/css/plain/error/media.hrx::logic/or_after/type/plain.css    expect token `{`, but found `<ident>`
 ERROR    spec/css/plain/error/media.hrx::logic/or_after/type_and_not/plain.css    expect token `{`, but found `<ident>`
 ERROR    spec/css/plain/error/media.hrx::logic/or_after/type_then_and/plain.css    expect token `{`, but found `<ident>`
-ERROR    spec/css/plain/error/statement/at_rule.hrx::import/multi/plain.css    expect token `<ident>`, but found `,`
 ERROR    spec/css/plain/error/statement/at_rule.hrx::interpolation/plain.css    expect token `:`, but found `}`
 ERROR    spec/css/plain/error/statement/silent_comment.hrx::plain.css    CSS rule is expected
 ERROR    spec/css/plain/error/statement/style_rule.hrx::interpolation/declaration/plain.css    expect token `:`, but found `#`
@@ -183,15 +153,8 @@ ERROR    spec/css/plain/error/statement/style_rule.hrx::interpolation/selector/p
 ERROR    spec/css/plain/error/statement/style_rule.hrx::nested_property/no_value/plain.css    component value is expected
 ERROR    spec/css/plain/error/statement/style_rule.hrx::nested_property/value/plain.css    component value is expected
 ERROR    spec/css/plain/error/statement/style_rule.hrx::placeholder_selector/plain.css    CSS rule is expected
-ERROR    spec/css/plain/import/conditions.hrx::error/wrong_order/media_before_supports/input.scss    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::error/wrong_order/media_before_unknown_function/input.scss    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::error/wrong_order/media_before_unknown_ident/input.scss    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/conditions.hrx::error/wrong_order/url_after_comma/input.scss    expect token `;`, but found `<ident>`
-ERROR    spec/css/plain/import/whitespace.hrx::error/after_identifier/sass/input.sass    expect token `<linebreak>`, but found `<indent>`
 ERROR    spec/css/plain/import/whitespace.hrx::error/after_import/sass/input.sass    expect token `<string>`, but found `<linebreak>`
 ERROR    spec/css/plain/import/whitespace.hrx::error/after_import_indented/sass/input.sass    expect token `<string>`, but found `<indent>`
-ERROR    spec/css/plain/import/whitespace.hrx::error/media/before/sass/input.sass    expect token `<string>`, but found `<ident>`
-ERROR    spec/css/plain/import/whitespace.hrx::error/supports/declaration/followed_by_import_arg/after_comma/sass/input.sass    expect token `<linebreak>`, but found `<ident>`
 ERROR    spec/css/propset.hrx::error/value_after_propset/input.scss    expect token `:`, but found `}`
 ERROR    spec/css/selector/attribute.hrx::error/modifier/digit/input.scss    expect token `]`, but found `<number>`
 ERROR    spec/css/selector/attribute.hrx::error/modifier/no_operator/input.scss    attribute selector matcher is expected
@@ -268,9 +231,7 @@ ERROR    spec/directives/if/error/syntax.hrx::else/partial_if/input.scss    expe
 ERROR    spec/directives/if/whitespace.hrx::error/top_level_else/sass/input.sass    Sass `@else` at-rule is disallowed here
 ERROR    spec/directives/if/whitespace.hrx::error/top_level_else_if/sass/input.sass    Sass `@else` at-rule is disallowed here
 RECOVER  spec/directives/import/error/top_level_declaration.hrx::root/_upstream.scss    declaration at top level is disallowed
-ERROR    spec/directives/import/whitespace.hrx::error/before_comma/sass/input.sass    expect token `<linebreak>`, but found `<indent>`
 ERROR    spec/directives/import/whitespace.hrx::error/before_url/sass/input.sass    expect token `<string>`, but found `<indent>`
-ERROR    spec/directives/import/whitespace.hrx::error/modifier/args/before/sass/input.sass    expect token `<linebreak>`, but found `<indent>`
 ERROR    spec/directives/mixin/whitespace.hrx::error/include/before_using/sass/input.sass    CSS rule is expected
 ERROR    spec/directives/use/error/syntax/as_invalid.hrx::input.scss    `*` or ident for Sass namespace is expected
 ERROR    spec/directives/use/error/syntax/as_nothing.hrx::input.scss    `*` or ident for Sass namespace is expected


### PR DESCRIPTION
Reference compilers accept arbitrary `@import` modifiers — unknown idents and functions in any order, media-ish parens, comma-chained further imports each with their own modifiers, `url()` among an SCSS import list, and unquoted paths in the indented syntax (`spec/css/plain/import/conditions.hrx` etc.).

### Fix
The standard `layer()`/`supports()`/media tail is validated against the end of the statement; anything else is kept as raw component values in a new `ImportPrelude::modifiers` field. A trailing comma still errors (dart-sass rejects it). The indented syntax accepts an unquoted path (`@import other.css`).

### Impact
sass-spec **120 → 91** real failures; zero regressions. The ten expected-error flips are semantic-level rejections (modifier order, comma-imports in plain CSS, indented-syntax newline placement) that a syntax-level parser legitimately accepts.

Part of #19. Stacked on #54.
