### PR TITLE
chore: skip csswg draft conformance

### DIFF
--- a/tasks/conformance/snapshots/csswg-drafts.snap
+++ b/tasks/conformance/snapshots/csswg-drafts.snap
@@ -1,7 +1,0 @@
-suite: csswg-drafts
-sha: cca93bb94ae073c964ffe076bbe75d6baef90dd6
-files: 9   success: 9   failed: 0   expected: 0
-clean: 9  recovered: 0  hard_error: 0  panic: 0
-
-failures:
-none

--- a/tasks/conformance/snapshots/summary.snap
+++ b/tasks/conformance/snapshots/summary.snap
@@ -5,17 +5,16 @@
 suite                   files  success  failed  expected   clean  recov  harderr  panic
 css-parsing-tests           0        0       0         0       0      0        0      0
 wpt                         7        5       0         2       5      0        0      0
-csswg-drafts                9        9       0         0       9      0        0      0
 webref                      0        0       0         0       0      0        0      0
 postcss-parser-tests       30       28       2         0      28      1        1      0
 sass-spec               26787    26490       2       295   26490      0        2      0
 less.js                   459      427       8        24     427      0        8      0
 ------------------------------------------------------------------------
-total                   27292    26959      12       321   26959      1       11      0
+total                   27283    26950      12       321   26950      1       11      0
 
 # by syntax
 syntax                  files  success  failed  expected   clean  recov  harderr  panic
-css                     11797    11765       7        25   11765      1        6      0
+css                     11788    11756       7        25   11756      1        6      0
 scss                    14750    14517       1       232   14517      0        1      0
 sass                      439      398       1        40     398      0        1      0
 less                      306      279       3        24     279      0        3      0

--- a/tasks/conformance/src/main.rs
+++ b/tasks/conformance/src/main.rs
@@ -92,26 +92,6 @@ const SUITES: &[Suite] = &[
         note: "Phase 3 — testharness assertions need an HTML/JS harness",
     },
     Suite {
-        name: "csswg-drafts",
-        url: "https://github.com/w3c/csswg-drafts.git",
-        sha: "cca93bb94ae073c964ffe076bbe75d6baef90dd6",
-        sparse: &[
-            "css-syntax-3",
-            "selectors-4",
-            "css-color-4",
-            "css-values-4",
-            "mediaqueries-5",
-            "css-conditional-5",
-            "css-ui-4",
-            "scroll-animations-1",
-            "css-cascade-5",
-        ],
-        walk: "",
-        expect_error_under: &[],
-        postcss_simple_vars: false,
-        note: "Phase 2 — extract examples from Bikeshed (.bs) sources",
-    },
-    Suite {
         name: "webref",
         url: "https://github.com/w3c/webref.git",
         sha: "9cce6ee56b9b281df9a81baa4cfc4a931e103333",
@@ -216,7 +196,7 @@ fn ensure_repo(suite: &Suite) -> io::Result<bool> {
 
     // GitHub allows fetching an arbitrary commit by SHA. `--depth 1` skips
     // history; for sparse checkouts we also add `--filter=blob:none` so only the
-    // in-cone blobs are pulled (keeps huge repos like wpt/csswg-drafts small).
+    // in-cone blobs are pulled (keeps huge repos like wpt small).
     // For full checkouts we skip the filter — it would just force a second,
     // flakier round-trip to lazily fetch every blob at checkout time.
     let mut fetch = vec!["fetch", "-q", "--depth", "1"];
@@ -748,7 +728,7 @@ fn run_and_snapshot(selected: &[&Suite], full_run: bool) {
         return;
     }
     for (suite, report) in &reports {
-        // Suites whose CSS is embedded in HTML/.bs/JSON ship no plain files; skip
+        // Suites whose CSS is embedded in HTML/JSON ship no plain files; skip
         // writing an empty failures snapshot for them (they still appear in the summary).
         if report.tally.files == 0 {
             continue;


### PR DESCRIPTION
Removes the CSSWG draft conformance corpus from the conformance runner.

Regenerates the summary snapshot without the CSSWG draft suite.

Validated with `cargo run -p conformance`.