### PR TITLE
refactor(parser): replace cursor macros with methods

### DIFF
--- a/crates/oxc_css_parser/src/parser/at_rule/container.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/container.rs
@@ -4,14 +4,14 @@ use crate::{
     ast::*,
     eat,
     error::{Error, ErrorKind, PResult},
-    expect, expect_without_ws_or_comments, peek,
+    expect, expect_without_ws_or_comments,
     pos::{Span, Spanned},
     tokenizer::{Token, TokenWithSpan},
 };
 
 impl<'a> Parse<'a> for ContainerCondition<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match &peek!(input).token {
+        match &input.cursor.peek()?.token {
             Token::Ident(ident) if ident.name().eq_ignore_ascii_case("not") => {
                 let container_condition_not = input.parse::<ContainerConditionNot>()?;
                 let span = container_condition_not.span.clone();
@@ -28,7 +28,7 @@ impl<'a> Parse<'a> for ContainerCondition<'a> {
                 // is leading-only, but real-world code (less.js) chains them
                 // freely: `(a) or (b) and (c)`, `(a) not (b)`.
                 loop {
-                    let kind = match &peek!(input).token {
+                    let kind = match &input.cursor.peek()?.token {
                         Token::Ident(ident) if ident.name().eq_ignore_ascii_case("and") => {
                             ContainerConditionKind::And(input.parse()?)
                         }
@@ -126,7 +126,7 @@ impl<'a> Parse<'a> for QueryInParens<'a> {
 
 impl<'a> Parse<'a> for StyleCondition<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match &peek!(input).token {
+        match &input.cursor.peek()?.token {
             Token::Ident(ident) if ident.name().eq_ignore_ascii_case("not") => {
                 let style_condition_not = input.parse::<StyleConditionNot>()?;
                 let span = style_condition_not.span.clone();
@@ -139,12 +139,12 @@ impl<'a> Parse<'a> for StyleCondition<'a> {
                 let first = input.parse::<StyleInParens>()?;
                 let mut span = first.span.clone();
                 let mut conditions = input.vec1(StyleConditionKind::StyleInParens(first));
-                if let Token::Ident(ident) = &peek!(input).token {
+                if let Token::Ident(ident) = &input.cursor.peek()?.token {
                     let name = ident.name();
                     if name.eq_ignore_ascii_case("and") {
                         loop {
                             conditions.push(StyleConditionKind::And(input.parse()?));
-                            match &peek!(input).token {
+                            match &input.cursor.peek()?.token {
                                 Token::Ident(ident) if ident.name().eq_ignore_ascii_case("and") => {
                                 }
                                 _ => break,
@@ -153,7 +153,7 @@ impl<'a> Parse<'a> for StyleCondition<'a> {
                     } else if name.eq_ignore_ascii_case("or") {
                         loop {
                             conditions.push(StyleConditionKind::Or(input.parse()?));
-                            match &peek!(input).token {
+                            match &input.cursor.peek()?.token {
                                 Token::Ident(ident) if ident.name().eq_ignore_ascii_case("or") => {}
                                 _ => break,
                             }
@@ -235,14 +235,14 @@ impl<'a> Parse<'a> for StyleQuery<'a> {
         } else if let Ok(name) = input.try_parse(|p| {
             // a bare custom-property existence test: `style(--theme)`
             let name = p.parse::<InterpolableIdent>()?;
-            match (&name, &peek!(p).token) {
+            match (&name, &p.cursor.peek()?.token) {
                 (InterpolableIdent::Literal(ident), Token::RParen(..))
                     if ident.name.starts_with("--") =>
                 {
                     Ok(name)
                 }
                 _ => {
-                    let span = peek!(p).span.clone();
+                    let span = p.cursor.peek()?.span.clone();
                     Err(Error { kind: ErrorKind::TryParseError, span })
                 }
             }
@@ -267,7 +267,7 @@ impl<'a> Parse<'a> for ContainerPrelude<'a> {
                 Err(Error { kind: ErrorKind::TryParseError, span: ident.span })
             }
             InterpolableIdent::Literal(ident) if ident.name.eq_ignore_ascii_case("style") => {
-                match peek!(parser) {
+                match parser.cursor.peek()? {
                     TokenWithSpan { token: Token::LParen(..), span }
                         if span.start == ident.span.end =>
                     {

--- a/crates/oxc_css_parser/src/parser/at_rule/custom_media.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/custom_media.rs
@@ -3,7 +3,6 @@ use crate::{
     Parse,
     ast::*,
     error::PResult,
-    peek,
     pos::{Span, Spanned},
     tokenizer::Token,
 };
@@ -20,7 +19,7 @@ impl<'a> Parse<'a> for CustomMedia<'a> {
 
 impl<'a> Parse<'a> for CustomMediaValue<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match &peek!(input).token {
+        match &input.cursor.peek()?.token {
             Token::Ident(ident) => {
                 let name = ident.name();
                 if name.eq_ignore_ascii_case("true") {

--- a/crates/oxc_css_parser/src/parser/at_rule/custom_selector.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/custom_selector.rs
@@ -1,9 +1,9 @@
 use super::Parser;
-use crate::{Parse, ast::*, error::PResult, expect, peek, pos::Span, tokenizer::Token, util};
+use crate::{Parse, ast::*, error::PResult, expect, pos::Span, tokenizer::Token, util};
 
 impl<'a> Parse<'a> for CustomSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        let prefix_arg = if matches!(peek!(input).token, Token::DollarVar(..)) {
+        let prefix_arg = if matches!(input.cursor.peek()?.token, Token::DollarVar(..)) {
             Some(input.parse::<CustomSelectorArg>()?)
         } else {
             None
@@ -16,7 +16,7 @@ impl<'a> Parse<'a> for CustomSelector<'a> {
         let name = input.parse::<Ident>()?;
         util::assert_no_ws_or_comment(&colon_span, &name.span)?;
 
-        let args = if matches!(peek!(input).token, Token::LParen(..)) {
+        let args = if matches!(input.cursor.peek()?.token, Token::LParen(..)) {
             Some(input.parse::<CustomSelectorArgs>()?)
         } else {
             None
@@ -52,9 +52,9 @@ impl<'a> Parse<'a> for CustomSelectorArgs<'a> {
 
         let mut args = input.vec();
         let mut comma_spans = input.vec();
-        while !matches!(peek!(input).token, Token::RParen(..)) {
+        while !matches!(input.cursor.peek()?.token, Token::RParen(..)) {
             args.push(input.parse()?);
-            if !matches!(peek!(input).token, Token::RParen(..)) {
+            if !matches!(input.cursor.peek()?.token, Token::RParen(..)) {
                 comma_spans.push(expect!(input, Comma).1);
             }
         }

--- a/crates/oxc_css_parser/src/parser/at_rule/font_feature_values.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/font_feature_values.rs
@@ -1,10 +1,10 @@
 use super::Parser;
-use crate::{Parse, Spanned, ast::*, error::PResult, peek, tokenizer::Token};
+use crate::{Parse, Spanned, ast::*, error::PResult, tokenizer::Token};
 
 // https://drafts.csswg.org/css-fonts/Overview.bs
 impl<'a> Parse<'a> for FontFamilyName<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match &peek!(input).token {
+        match &input.cursor.peek()?.token {
             Token::Str(..) | Token::StrTemplate(..) => input.parse().map(FontFamilyName::Str),
             _ => {
                 let first = input.parse::<InterpolableIdent>()?;
@@ -12,7 +12,7 @@ impl<'a> Parse<'a> for FontFamilyName<'a> {
 
                 let mut idents = input.vec1(first);
                 while let Token::Ident(..) | Token::HashLBrace(..) | Token::AtLBraceVar(..) =
-                    &peek!(input).token
+                    &input.cursor.peek()?.token
                 {
                     idents.push(input.parse()?);
                 }

--- a/crates/oxc_css_parser/src/parser/at_rule/import.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/import.rs
@@ -2,9 +2,8 @@ use super::Parser;
 use crate::{
     Parse, Syntax,
     ast::*,
-    bump,
     error::{Error, ErrorKind, PResult},
-    expect, expect_without_ws_or_comments, peek,
+    expect, expect_without_ws_or_comments,
     pos::{Span, Spanned},
     tokenizer::{Token, TokenWithSpan},
 };
@@ -16,19 +15,19 @@ impl<'a> Parse<'a> for ImportPrelude<'a> {
         // but an ident glued to `(` is a function href
         // (`@import url("theme.css")`), which the `Url::parse` arm handles.
         let sass_unquoted_path = input.syntax == Syntax::Sass
-            && matches!(peek!(input), TokenWithSpan { token: Token::Ident(..), span }
+            && matches!(input.cursor.peek()?, TokenWithSpan { token: Token::Ident(..), span }
                 if input.source.as_bytes().get(span.end) != Some(&b'('));
-        let href = match &peek!(input).token {
+        let href = match &input.cursor.peek()?.token {
             Token::Str(..) | Token::StrTemplate(..) => input.parse().map(ImportPreludeHref::Str)?,
             Token::Ident(..) if sass_unquoted_path => {
-                let start = peek!(input).span.start;
+                let start = input.cursor.peek()?.span.start;
                 let mut end = start;
                 while matches!(
-                    &peek!(input).token,
+                    &input.cursor.peek()?.token,
                     Token::Ident(..) | Token::Dot(..) | Token::Minus(..) | Token::Solidus(..)
-                ) && peek!(input).span.start == end
+                ) && input.cursor.peek()?.span.start == end
                 {
-                    end = bump!(input).span.end;
+                    end = input.cursor.bump()?.span.end;
                 }
                 let raw = unsafe { input.source.get_unchecked(start..end) };
                 let span = Span { start, end };
@@ -62,7 +61,7 @@ impl<'a> Parse<'a> for ImportPrelude<'a> {
             // unknown functions, media-ish parens, further comma-chained
             // imports); keep the whole tail as raw component values.
             Err(_) => {
-                let start = peek!(input).span.start;
+                let start = input.cursor.peek()?.span.start;
                 let values = input.parse_declaration_value_tokens(true)?;
                 // A trailing comma has no import after it — reference
                 // compilers reject that, so don't paper over it.
@@ -108,14 +107,14 @@ impl<'a> ImportPrelude<'a> {
         Option<ImportPreludeSupports<'a>>,
         Option<MediaQueryList<'a>>,
     )> {
-        let layer = match &peek!(input).token {
+        let layer = match &input.cursor.peek()?.token {
             Token::Ident(ident) if ident.name().eq_ignore_ascii_case("layer") => {
                 let ident = input.parse::<Ident>()?;
-                let layer = match peek!(input) {
+                let layer = match input.cursor.peek()? {
                     TokenWithSpan { token: Token::LParen(..), span }
                         if span.start == ident.span.end =>
                     {
-                        bump!(input);
+                        input.cursor.bump()?;
                         let layer_name = input.parse().map(ComponentValue::LayerName)?;
                         let args = input.vec1(layer_name);
                         let end = expect!(input, RParen).1.end;
@@ -152,17 +151,17 @@ impl<'a> ImportPrelude<'a> {
         });
         // `}` ends the at-rule too, so an `@import` nested in a style rule needs no
         // trailing `;` (`a { @import "b.css" }`); it can't start a media query.
-        let media = if at_import_prelude_end(&peek!(input).token) {
+        let media = if at_import_prelude_end(&input.cursor.peek()?.token) {
             None
         } else {
             Some(input.parse::<MediaQueryList>()?)
         };
 
         // Anything left over means this tail isn't the standard grammar.
-        if at_import_prelude_end(&peek!(input).token) {
+        if at_import_prelude_end(&input.cursor.peek()?.token) {
             Ok((layer, supports.ok(), media))
         } else {
-            let span = peek!(input).span.clone();
+            let span = input.cursor.peek()?.span.clone();
             Err(Error { kind: ErrorKind::TryParseError, span })
         }
     }

--- a/crates/oxc_css_parser/src/parser/at_rule/keyframes.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/keyframes.rs
@@ -5,7 +5,6 @@ use crate::{
     eat,
     error::{Error, ErrorKind, PResult},
     parser::state::ParserState,
-    peek,
     pos::{Span, Spanned},
     tokenizer::Token,
     util,
@@ -37,7 +36,7 @@ impl<'a> Parse<'a> for KeyframeBlock<'a> {
 
 impl<'a> Parse<'a> for KeyframeSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match &peek!(input).token {
+        match &input.cursor.peek()?.token {
             Token::Percentage(..) => Ok(KeyframeSelector::Percentage(input.parse()?)),
             _ => {
                 let ident = input.parse()?;
@@ -62,7 +61,7 @@ impl<'a> Parse<'a> for KeyframeSelector<'a> {
 // https://drafts.csswg.org/css-animations/#keyframes
 impl<'a> Parse<'a> for KeyframesName<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match &peek!(input).token {
+        match &input.cursor.peek()?.token {
             Token::Ident(..) | Token::HashLBrace(..) | Token::AtLBraceVar(..) => {
                 let ident = input.parse()?;
                 match &ident {

--- a/crates/oxc_css_parser/src/parser/at_rule/layer.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/layer.rs
@@ -2,9 +2,8 @@ use super::Parser;
 use crate::{
     Parse,
     ast::*,
-    bump, eat,
+    eat,
     error::{Error, PResult},
-    peek,
     pos::{Span, Spanned},
     tokenizer::{Token, TokenWithSpan},
     util,
@@ -38,9 +37,9 @@ impl<'a> Parse<'a> for LayerName<'a> {
         let mut end = first.span().end;
 
         let mut idents = input.vec1(first);
-        while let TokenWithSpan { token: Token::Dot(..), span } = peek!(input) {
+        while let TokenWithSpan { token: Token::Dot(..), span } = input.cursor.peek()? {
             if span.start == end {
-                let span = bump!(input).span;
+                let span = input.cursor.bump()?.span;
                 let ident = input.parse::<InterpolableIdent>()?;
                 util::assert_no_ws_or_comment(&span, ident.span())?;
                 end = ident.span().end;

--- a/crates/oxc_css_parser/src/parser/at_rule/media.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/media.rs
@@ -2,9 +2,9 @@ use super::Parser;
 use crate::{
     Parse, Syntax,
     ast::*,
-    bump, eat,
+    eat,
     error::{Error, ErrorKind, PResult},
-    expect, peek,
+    expect,
     pos::{Span, Spanned},
     tokenizer::{Token, TokenWithSpan},
 };
@@ -24,7 +24,7 @@ impl<'a> Parse<'a> for MediaAnd<'a> {
 
 impl<'a> Parse<'a> for MediaConditionAfterMediaType<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        let and: Ident = match bump!(input) {
+        let and: Ident = match input.cursor.bump()? {
             TokenWithSpan { token: Token::Ident(ident), span }
                 if ident.name().eq_ignore_ascii_case("and") =>
             {
@@ -47,7 +47,7 @@ impl<'a> Parse<'a> for MediaConditionAfterMediaType<'a> {
 impl<'a> Parse<'a> for MediaFeature<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.parse_media_feature_value()? {
-            ComponentValue::InterpolableIdent(ident) => match &peek!(input).token {
+            ComponentValue::InterpolableIdent(ident) => match &input.cursor.peek()?.token {
                 Token::Colon(..) => input.parse_media_feature_plain(ident).map(MediaFeature::Plain),
                 Token::LessThan(..)
                 | Token::LessThanEqual(..)
@@ -85,7 +85,7 @@ impl<'a> Parse<'a> for MediaFeature<'a> {
 
 impl<'a> Parse<'a> for MediaFeatureComparison {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match bump!(input) {
+        match input.cursor.bump()? {
             TokenWithSpan { token: Token::LessThan(..), span } => {
                 Ok(MediaFeatureComparison { kind: MediaFeatureComparisonKind::LessThan, span })
             }
@@ -117,7 +117,7 @@ impl<'a> Parse<'a> for MediaInParens<'a> {
         // Sass allows an interpolation wherever `<media-in-parens>` is expected,
         // e.g. `@media screen and #{$query} {}`.
         if matches!(input.syntax, Syntax::Scss | Syntax::Sass)
-            && matches!(&peek!(input).token, Token::HashLBrace(..))
+            && matches!(&input.cursor.peek()?.token, Token::HashLBrace(..))
             && let InterpolableIdent::SassInterpolated(interpolation) =
                 input.parse_sass_interpolated_ident()?
         {
@@ -144,20 +144,20 @@ impl<'a> Parse<'a> for MediaInParensKind<'a> {
             // `SassInterpolation` media condition, but a trailing `:` means it is
             // really a media feature name. Require the closing `)` here so such
             // cases fall through to the media-feature branch below.
-            if matches!(&peek!(parser).token, Token::RParen(..)) {
+            if matches!(&parser.cursor.peek()?.token, Token::RParen(..)) {
                 Ok(media_condition)
             } else {
-                let span = peek!(parser).span.clone();
+                let span = parser.cursor.peek()?.span.clone();
                 Err(Error { kind: ErrorKind::ExpectMediaFeatureName, span })
             }
         }) {
             Ok(MediaInParensKind::MediaCondition(media_condition))
         } else if let Ok(media_feature) = input.try_parse(|parser| {
             let media_feature = parser.parse::<MediaFeature>()?;
-            if matches!(&peek!(parser).token, Token::RParen(..)) {
+            if matches!(&parser.cursor.peek()?.token, Token::RParen(..)) {
                 Ok(media_feature)
             } else {
-                let span = peek!(parser).span.clone();
+                let span = parser.cursor.peek()?.span.clone();
                 Err(Error { kind: ErrorKind::ExpectMediaFeatureName, span })
             }
         }) {
@@ -205,7 +205,7 @@ impl<'a> Parse<'a> for MediaQuery<'a> {
         }) {
             Ok(MediaQuery::ConditionOnly(condition_only))
         } else if input.syntax == Syntax::Less {
-            match peek!(input).token {
+            match input.cursor.peek()?.token {
                 Token::AtKeyword(..) => {
                     input.parse_less_maybe_variable_or_with_lookups().map(|value| match value {
                         ComponentValue::LessVariable(variable) => {
@@ -254,7 +254,7 @@ impl<'a> Parse<'a> for MediaQueryList<'a> {
 
 impl<'a> Parse<'a> for MediaQueryWithType<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        let modifier = if let Token::Ident(ident) = &peek!(input).token {
+        let modifier = if let Token::Ident(ident) = &input.cursor.peek()?.token {
             let name = ident.name();
             if name.eq_ignore_ascii_case("not") || name.eq_ignore_ascii_case("only") {
                 Some(input.parse::<Ident>()?)
@@ -277,7 +277,7 @@ impl<'a> Parse<'a> for MediaQueryWithType<'a> {
                 span: span.clone(),
             });
         }
-        let condition = match &peek!(input).token {
+        let condition = match &input.cursor.peek()?.token {
             Token::Ident(ident) if ident.name().eq_ignore_ascii_case("and") => {
                 input.parse::<MediaConditionAfterMediaType>().map(Some)?
             }
@@ -303,11 +303,11 @@ impl<'a> Parser<'a> {
     /// relax: elsewhere an ident is a media type (`@media print`).
     fn parse_media_in_parens_after_logic(&mut self) -> PResult<MediaInParens<'a>> {
         if self.syntax == Syntax::Css
-            && let TokenWithSpan { token: Token::Ident(ident), span } = peek!(self)
+            && let TokenWithSpan { token: Token::Ident(ident), span } = self.cursor.peek()?
             && !ident.name().eq_ignore_ascii_case("not")
             && self.source.as_bytes().get(span.end) != Some(&b'(')
         {
-            let token = bump!(self);
+            let token = self.cursor.bump()?;
             let span = token.span.clone();
             return Ok(MediaInParens {
                 kind: MediaInParensKind::GeneralEnclosed(TokenSeq {
@@ -325,7 +325,7 @@ impl<'a> Parser<'a> {
         allow_or: bool,
         after_logic_keyword: bool,
     ) -> PResult<MediaCondition<'a>> {
-        match &peek!(self).token {
+        match &self.cursor.peek()?.token {
             Token::Ident(ident) if ident.name().eq_ignore_ascii_case("not") => {
                 let media_not = self.parse::<MediaNot>()?;
                 let span = media_not.span.clone();
@@ -342,12 +342,12 @@ impl<'a> Parser<'a> {
                 };
                 let mut span = first.span.clone();
                 let mut conditions = self.vec1(MediaConditionKind::MediaInParens(first));
-                if let Token::Ident(ident) = &peek!(self).token {
+                if let Token::Ident(ident) = &self.cursor.peek()?.token {
                     let name = ident.name();
                     if name.eq_ignore_ascii_case("and") {
                         loop {
                             conditions.push(MediaConditionKind::And(self.parse()?));
-                            match &peek!(self).token {
+                            match &self.cursor.peek()?.token {
                                 Token::Ident(ident) if ident.name().eq_ignore_ascii_case("and") => {
                                 }
                                 _ => break,
@@ -356,7 +356,7 @@ impl<'a> Parser<'a> {
                     } else if allow_or && name.eq_ignore_ascii_case("or") {
                         loop {
                             conditions.push(MediaConditionKind::Or(self.parse()?));
-                            match &peek!(self).token {
+                            match &self.cursor.peek()?.token {
                                 Token::Ident(ident) if ident.name().eq_ignore_ascii_case("or") => {}
                                 _ => break,
                             }
@@ -389,7 +389,7 @@ impl<'a> Parser<'a> {
         let comparison = self.parse()?;
         let name_or_right = self.parse_media_feature_value()?;
         if let ComponentValue::InterpolableIdent(ident) = name_or_right {
-            match &peek!(self).token {
+            match &self.cursor.peek()?.token {
                 Token::LessThan(..)
                 | Token::LessThanEqual(..)
                 | Token::GreaterThan(..)
@@ -446,7 +446,8 @@ impl<'a> Parser<'a> {
         };
         match value {
             ComponentValue::Number(number)
-                if number.value >= 0.0 && matches!(peek!(self).token, Token::Solidus(..)) =>
+                if number.value >= 0.0
+                    && matches!(self.cursor.peek()?.token, Token::Solidus(..)) =>
             {
                 self.parse_ratio(number).map(ComponentValue::Ratio)
             }
@@ -456,7 +457,7 @@ impl<'a> Parser<'a> {
 
     fn parse_media_query_with_type_or_function(&mut self) -> PResult<MediaQuery<'a>> {
         let media_query_with_type = self.parse::<MediaQueryWithType>()?;
-        match (media_query_with_type, peek!(self)) {
+        match (media_query_with_type, self.cursor.peek()?) {
             (
                 MediaQueryWithType {
                     modifier: None,
@@ -466,7 +467,7 @@ impl<'a> Parser<'a> {
                 },
                 TokenWithSpan { token: crate::token::Token::LParen(..), span: lparen_span },
             ) if mq_span.end == lparen_span.start => {
-                bump!(self);
+                self.cursor.bump()?;
                 let args = self.parse_function_args()?;
                 let (_, Span { end, .. }) = expect!(self, RParen);
                 Ok(MediaQuery::Function(Function {

--- a/crates/oxc_css_parser/src/parser/at_rule/mod.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/mod.rs
@@ -2,9 +2,8 @@ use super::{Parser, state::ParserState};
 use crate::{
     Parse, Syntax,
     ast::*,
-    bump,
     error::{Error, ErrorKind, PResult},
-    expect, peek,
+    expect,
     pos::{Span, Spanned},
     tokenizer::Token,
 };
@@ -37,7 +36,12 @@ impl<'a> Parse<'a> for AtRule<'a> {
                 .try_parse_full_prelude(|p| MediaQueryList::parse(p).map(AtRulePrelude::Media))
             {
                 Ok(prelude) => Some(prelude),
-                Err(_) if matches!(peek!(input).token, Token::LBrace(..) | Token::Indent(..)) => {
+                Err(_)
+                    if matches!(
+                        input.cursor.peek()?.token,
+                        Token::LBrace(..) | Token::Indent(..)
+                    ) =>
+                {
                     None
                 }
                 // Only interpolation justifies the raw form — dart-sass
@@ -67,14 +71,14 @@ impl<'a> Parse<'a> for AtRule<'a> {
                             if has_substitution {
                                 Ok(raw)
                             } else {
-                                let span = peek!(p).span.clone();
+                                let span = p.cursor.peek()?.span.clone();
                                 Err(Error { kind: ErrorKind::TryParseError, span })
                             }
                         })
                     } else {
                         Err(Error {
                             kind: ErrorKind::TryParseError,
-                            span: peek!(input).span.clone(),
+                            span: input.cursor.peek()?.span.clone(),
                         })
                     };
                     match raw {
@@ -95,7 +99,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
             // A nameless `@keyframes {}` is invalid CSS, but Sass parses it
             // (the name may be produced elsewhere, e.g. a keyframes mixin
             // emitting vendor-prefixed blocks around `@content`).
-            let prelude = match &peek!(input).token {
+            let prelude = match &input.cursor.peek()?.token {
                 Token::LBrace(..) => None,
                 _ => {
                     // A typed name normally ends the prelude; real-world code
@@ -143,7 +147,8 @@ impl<'a> Parse<'a> for AtRule<'a> {
         } else if at_rule_name.eq_ignore_ascii_case("charset") {
             // https://drafts.csswg.org/css2/#charset%E2%91%A0
             // Less may interpolate into it: `@charset "UTF-@{Eight}";`
-            if input.syntax == Syntax::Less && matches!(peek!(input).token, Token::StrTemplate(..))
+            if input.syntax == Syntax::Less
+                && matches!(input.cursor.peek()?.token, Token::StrTemplate(..))
             {
                 let prelude = input.parse::<InterpolableStr>()?;
                 let end = prelude.span().end;
@@ -176,18 +181,19 @@ impl<'a> Parse<'a> for AtRule<'a> {
                 // a Less variable may stand for the name: `@layer @layer-name {`
                 Err(_)
                     if input.syntax == Syntax::Less
-                        && matches!(peek!(input).token, Token::AtKeyword(..)) =>
+                        && matches!(input.cursor.peek()?.token, Token::AtKeyword(..)) =>
                 {
                     let raw = input.parse_raw_at_rule_prelude()?;
                     Some(AtRulePrelude::Unknown(input.alloc(raw)))
                 }
                 Err(_) => None,
             };
-            let block = if matches!(peek!(input).token, Token::LBrace(..) | Token::Indent(..)) {
-                Some(input.parse::<SimpleBlock>()?)
-            } else {
-                None
-            };
+            let block =
+                if matches!(input.cursor.peek()?.token, Token::LBrace(..) | Token::Indent(..)) {
+                    Some(input.parse::<SimpleBlock>()?)
+                } else {
+                    None
+                };
             if let Some(block) = &block
                 && matches!(&prelude, Some(AtRulePrelude::Layer(names)) if names.names.len() > 1)
             {
@@ -214,10 +220,10 @@ impl<'a> Parse<'a> for AtRule<'a> {
                         let is_query_list = input
                             .try_parse(|p| {
                                 p.parse::<ContainerPrelude>()?;
-                                if matches!(peek!(p).token, Token::Comma(..)) {
+                                if matches!(p.cursor.peek()?.token, Token::Comma(..)) {
                                     Ok(())
                                 } else {
-                                    let span = peek!(p).span.clone();
+                                    let span = p.cursor.peek()?.span.clone();
                                     Err(Error { kind: ErrorKind::TryParseError, span })
                                 }
                             })
@@ -225,7 +231,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
                         // a Less variable may stand for the container name:
                         // `@container @varfoo (min-width: @threshold) {`
                         let less_variable_name = input.syntax == Syntax::Less
-                            && matches!(peek!(input).token, Token::AtKeyword(..));
+                            && matches!(input.cursor.peek()?.token, Token::AtKeyword(..));
                         if !is_query_list && !less_variable_name {
                             return Err(error);
                         }
@@ -247,7 +253,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
             (prelude, block, end)
         } else if at_rule_name.eq_ignore_ascii_case("namespace")
             && input.syntax == Syntax::Less
-            && matches!(peek!(input).token, Token::AtKeyword(..))
+            && matches!(input.cursor.peek()?.token, Token::AtKeyword(..))
         {
             // `@namespace @ns "http://...";` — a Less variable prefix
             let raw = input.parse_raw_at_rule_prelude()?;
@@ -305,7 +311,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
             let end = block.span.end;
             (prelude, Some(block), end)
         } else if at_rule_name.eq_ignore_ascii_case("scope") {
-            let prelude = if let Token::LParen(..) | Token::Ident(..) = peek!(input).token {
+            let prelude = if let Token::LParen(..) | Token::Ident(..) = input.cursor.peek()?.token {
                 let scope = input.parse()?;
                 Some(AtRulePrelude::Scope(input.alloc(scope)))
             } else {
@@ -323,7 +329,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
                 // an empty prelude (`@document {}`) stays an error.
                 Err(error) => {
                     if matches!(
-                        peek!(input).token,
+                        input.cursor.peek()?.token,
                         Token::LBrace(..) | Token::Indent(..) | Token::Semicolon(..)
                     ) {
                         return Err(error);
@@ -333,11 +339,12 @@ impl<'a> Parse<'a> for AtRule<'a> {
                 }
             };
             // real-world code also writes a block-less `@document ...;`
-            let block = if matches!(peek!(input).token, Token::LBrace(..) | Token::Indent(..)) {
-                Some(input.parse::<SimpleBlock>()?)
-            } else {
-                None
-            };
+            let block =
+                if matches!(input.cursor.peek()?.token, Token::LBrace(..) | Token::Indent(..)) {
+                    Some(input.parse::<SimpleBlock>()?)
+                } else {
+                    None
+                };
             let end = block.as_ref().map_or(prelude.span().end, |block| block.span.end);
             (Some(prelude), block, end)
         } else if at_rule_name.eq_ignore_ascii_case("stylistic")
@@ -375,7 +382,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
             let end = prelude.span.end;
             (Some(AtRulePrelude::LessPlugin(input.alloc(prelude))), None, end)
         } else if at_rule_name.eq_ignore_ascii_case("function")
-            && matches!(&peek!(input).token, Token::Ident(ident) if ident.raw.starts_with("--"))
+            && matches!(&input.cursor.peek()?.token, Token::Ident(ident) if ident.raw.starts_with("--"))
         {
             // A CSS custom function (css-mixins spec): `@function --name(params)
             // returns <type> { declarations }`. dart-sass parses this as plain
@@ -425,31 +432,32 @@ impl<'a> Parse<'a> for AtRule<'a> {
                 }
                 "include" => {
                     let prelude = input.parse::<SassInclude>()?;
-                    let block =
-                        if matches!(peek!(input).token, Token::LBrace(..) | Token::Indent(..)) {
-                            Some(
-                                input
-                                    .with_state(ParserState {
-                                        sass_ctx: input.state.sass_ctx
-                                            | SASS_CTX_ALLOW_KEYFRAME_BLOCK,
-                                        ..input.state.clone()
-                                    })
-                                    .parse::<SimpleBlock>()?,
-                            )
-                        } else {
-                            None
-                        };
+                    let block = if matches!(
+                        input.cursor.peek()?.token,
+                        Token::LBrace(..) | Token::Indent(..)
+                    ) {
+                        Some(
+                            input
+                                .with_state(ParserState {
+                                    sass_ctx: input.state.sass_ctx | SASS_CTX_ALLOW_KEYFRAME_BLOCK,
+                                    ..input.state.clone()
+                                })
+                                .parse::<SimpleBlock>()?,
+                        )
+                    } else {
+                        None
+                    };
                     let end =
                         block.as_ref().map(|block| block.span.end).unwrap_or(prelude.span.end);
                     (Some(AtRulePrelude::SassInclude(input.alloc(prelude))), block, end)
                 }
                 "content" => {
-                    if matches!(peek!(input).token, Token::LParen(..)) {
+                    if matches!(input.cursor.peek()?.token, Token::LParen(..)) {
                         let prelude = input.parse::<SassContent>()?;
                         let end = prelude.span.end;
                         (Some(AtRulePrelude::SassContent(prelude)), None, end)
                     } else {
-                        (None, None, input.tokenizer.current_offset())
+                        (None, None, input.cursor.tokenizer.current_offset())
                     }
                 }
                 "use" => {
@@ -503,7 +511,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
                 }
                 "at-root" => {
                     let prelude = if !matches!(
-                        peek!(input).token,
+                        input.cursor.peek()?.token,
                         Token::LBrace(..)
                             | Token::Indent(..)
                             | Token::Linebreak(..)
@@ -564,7 +572,7 @@ impl<'a> Parser<'a> {
     fn try_parse_full_prelude<T>(&mut self, f: impl FnOnce(&mut Self) -> PResult<T>) -> PResult<T> {
         self.try_parse(|p| {
             let value = f(p)?;
-            match &peek!(p).token {
+            match &p.cursor.peek()?.token {
                 Token::LBrace(..)
                 | Token::Indent(..)
                 | Token::Semicolon(..)
@@ -572,7 +580,7 @@ impl<'a> Parser<'a> {
                 | Token::Linebreak(..)
                 | Token::Eof(..) => Ok(value),
                 _ => {
-                    let span = peek!(p).span.clone();
+                    let span = p.cursor.peek()?.span.clone();
                     Err(Error { kind: ErrorKind::TryParseError, span })
                 }
             }
@@ -584,11 +592,11 @@ impl<'a> Parser<'a> {
     /// through — CSS custom function preludes (`--name(--arg) returns <type>`)
     /// and media queries the typed grammar can't express.
     fn parse_raw_at_rule_prelude(&mut self) -> PResult<UnknownAtRulePrelude<'a>> {
-        let start = self.tokenizer.current_offset();
+        let start = self.cursor.tokenizer.current_offset();
         let mut tokens = self.vec();
         let mut pairs: Vec<crate::util::PairedToken> = Vec::new();
         loop {
-            match &peek!(self).token {
+            match &self.cursor.peek()?.token {
                 Token::Semicolon(..)
                 | Token::Dedent(..)
                 | Token::Linebreak(..)
@@ -608,7 +616,7 @@ impl<'a> Parser<'a> {
                     }
                 }
             }
-            tokens.push(bump!(self));
+            tokens.push(self.cursor.bump()?);
         }
         let span = Span {
             start: tokens.first().map_or(start, |token| token.span.start),
@@ -621,7 +629,7 @@ impl<'a> Parser<'a> {
         &mut self,
     ) -> PResult<(Option<UnknownAtRulePrelude<'a>>, Option<SimpleBlock<'a>>, Option<usize>)> {
         let prelude = self.parse_unknown_at_rule_prelude()?;
-        let block = match &peek!(self).token {
+        let block = match &self.cursor.peek()?.token {
             // An unknown at-rule's children parse generically; in Sass that
             // includes keyframe-style `10% { ... }` blocks
             // (`@keyfr#{"ames"} a {...}`). less.js keeps them an error.
@@ -649,7 +657,7 @@ impl<'a> Parser<'a> {
         if let Ok(prelude) = self.try_parse(|parser| {
             let mut tokens = parser.vec();
             loop {
-                match &peek!(parser).token {
+                match &parser.cursor.peek()?.token {
                     Token::LBrace(..)
                     | Token::RBrace(..)
                     | Token::Semicolon(..)
@@ -660,10 +668,10 @@ impl<'a> Parser<'a> {
                     Token::StrTemplate(..) | Token::HashLBrace(..) => {
                         return Err(Error {
                             kind: ErrorKind::TryParseError,
-                            span: bump!(parser).span,
+                            span: parser.cursor.bump()?.span,
                         });
                     }
-                    _ => tokens.push(bump!(parser)),
+                    _ => tokens.push(parser.cursor.bump()?),
                 }
             }
             if let Some((first, last)) = tokens.first().zip(tokens.last()) {

--- a/crates/oxc_css_parser/src/parser/at_rule/namespace.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/namespace.rs
@@ -1,10 +1,10 @@
 use super::Parser;
-use crate::{Parse, Spanned, ast::*, error::PResult, peek, tokenizer::Token};
+use crate::{Parse, Spanned, ast::*, error::PResult, tokenizer::Token};
 
 // https://www.w3.org/TR/css-namespaces-3/#syntax
 impl<'a> Parse<'a> for NamespacePrelude<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        let prefix = match &peek!(input).token {
+        let prefix = match &input.cursor.peek()?.token {
             Token::Ident(ident) => {
                 if ident.name().eq_ignore_ascii_case("url") {
                     None
@@ -17,7 +17,7 @@ impl<'a> Parse<'a> for NamespacePrelude<'a> {
             }
             _ => None,
         };
-        let uri = match &peek!(input).token {
+        let uri = match &input.cursor.peek()?.token {
             Token::Str(..) | Token::StrTemplate(..) => {
                 input.parse().map(NamespacePreludeUri::Str)?
             }

--- a/crates/oxc_css_parser/src/parser/at_rule/page.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/page.rs
@@ -4,7 +4,7 @@ use crate::{
     ast::*,
     eat,
     error::PResult,
-    expect, peek,
+    expect,
     pos::{Span, Spanned},
     tokenizer::{Token, TokenWithSpan},
     util,
@@ -18,7 +18,7 @@ impl<'a> Parse<'a> for PageSelector<'a> {
         let start;
         let mut end;
 
-        if let Token::Colon(..) = &peek!(input).token {
+        if let Token::Colon(..) = &input.cursor.peek()?.token {
             let first = input.parse::<PseudoPage>()?;
             start = first.span.start;
             end = first.span.end;
@@ -32,7 +32,7 @@ impl<'a> Parse<'a> for PageSelector<'a> {
         }
 
         loop {
-            match peek!(input) {
+            match input.cursor.peek()? {
                 TokenWithSpan { token: Token::Colon(..), span } if span.start == end => {
                     let item = input.parse::<PseudoPage>()?;
                     end = item.span.end;

--- a/crates/oxc_css_parser/src/parser/at_rule/scope.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/scope.rs
@@ -2,16 +2,15 @@ use super::Parser;
 use crate::{
     Parse,
     ast::*,
-    bump,
     error::{Error, ErrorKind, PResult},
-    expect, peek,
+    expect,
     pos::Span,
     tokenizer::{Token, TokenWithSpan},
 };
 
 impl<'a> Parse<'a> for ScopeEnd<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        let to_span = match bump!(input) {
+        let to_span = match input.cursor.bump()? {
             TokenWithSpan { token: Token::Ident(ident), span }
                 if ident.name().eq_ignore_ascii_case("to") =>
             {
@@ -34,12 +33,12 @@ impl<'a> Parse<'a> for ScopeEnd<'a> {
 // https://drafts.csswg.org/css-cascade-6/#scope-syntax
 impl<'a> Parse<'a> for ScopePrelude<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        let start = if let Token::LParen(..) = peek!(input).token {
+        let start = if let Token::LParen(..) = input.cursor.peek()?.token {
             Some(input.parse::<ScopeStart>()?)
         } else {
             None
         };
-        let end = match &peek!(input).token {
+        let end = match &input.cursor.peek()?.token {
             Token::Ident(ident) if ident.name().eq_ignore_ascii_case("to") => {
                 Some(input.parse::<ScopeEnd>()?)
             }
@@ -55,7 +54,7 @@ impl<'a> Parse<'a> for ScopePrelude<'a> {
             (None, Some(end)) => Ok(ScopePrelude::EndOnly(end)),
             (None, None) => {
                 use crate::{token::LParen, tokenizer::TokenSymbol};
-                let TokenWithSpan { token, span } = bump!(input);
+                let TokenWithSpan { token, span } = input.cursor.bump()?;
                 Err(Error { kind: ErrorKind::Unexpected(LParen::symbol(), token.symbol()), span })
             }
         }

--- a/crates/oxc_css_parser/src/parser/at_rule/supports.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/supports.rs
@@ -3,7 +3,7 @@ use crate::{
     Parse,
     ast::*,
     error::{Error, ErrorKind, PResult},
-    expect, peek,
+    expect,
     pos::{Span, Spanned},
     tokenizer::{Token, TokenWithSpan},
 };
@@ -11,7 +11,7 @@ use crate::{
 // https://drafts.csswg.org/css-conditional-3/#at-supports
 impl<'a> Parse<'a> for SupportsCondition<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match &peek!(input).token {
+        match &input.cursor.peek()?.token {
             Token::Ident(token) if token.name().eq_ignore_ascii_case("not") => {
                 let keyword = input.parse::<Ident>()?;
                 let condition = input.parse::<SupportsInParens>()?;
@@ -29,7 +29,7 @@ impl<'a> Parse<'a> for SupportsCondition<'a> {
                 let first = input.parse::<SupportsInParens>()?;
                 let mut span = first.span().clone();
                 let mut conditions = input.vec1(SupportsConditionKind::SupportsInParens(first));
-                while let Token::Ident(ident) = &peek!(input).token {
+                while let Token::Ident(ident) = &input.cursor.peek()?.token {
                     let name = ident.name();
                     if name.eq_ignore_ascii_case("and") {
                         let ident = input.parse::<Ident>()?;
@@ -64,7 +64,7 @@ impl<'a> Parse<'a> for SupportsCondition<'a> {
 
 impl<'a> Parse<'a> for SupportsInParens<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match peek!(input) {
+        match input.cursor.peek()? {
             TokenWithSpan { token: Token::LParen(..), .. } => input
                 .try_parse(|parser| {
                     parser.parse::<SupportsDecl>().map(|supports_decl| {
@@ -118,7 +118,7 @@ impl<'a> Parse<'a> for SupportsInParens<'a> {
                     }
                     name => {
                         let glued_lparen = matches!(
-                            peek!(input),
+                            input.cursor.peek()?,
                             TokenWithSpan { token: Token::LParen(..), span }
                                 if span.start == name_end
                         );
@@ -149,7 +149,7 @@ impl<'a> Parse<'a> for SupportsInParens<'a> {
                                 span,
                             })
                         } else {
-                            let TokenWithSpan { token, span } = peek!(input);
+                            let TokenWithSpan { token, span } = input.cursor.peek()?;
                             Err(Error {
                                 kind: ErrorKind::Unexpected("'('", token.symbol()),
                                 span: span.clone(),

--- a/crates/oxc_css_parser/src/parser/builder.rs
+++ b/crates/oxc_css_parser/src/parser/builder.rs
@@ -1,4 +1,4 @@
-use super::Parser;
+use super::{Parser, ParserCursor};
 use crate::{ParserOptions, Syntax, tokenizer::Tokenizer};
 use oxc_allocator::Allocator;
 
@@ -70,16 +70,15 @@ impl<'a> ParserBuilder<'a> {
             source: self.source,
             syntax: self.syntax,
             options,
-            tokenizer: Tokenizer::new(
+            cursor: ParserCursor::new(Tokenizer::new(
                 self.allocator,
                 self.source,
                 self.syntax,
                 options.template_placeholder,
                 self.collect_comments,
-            ),
+            )),
             state: Default::default(),
             recoverable_errors: vec![],
-            cached_token: None,
             sass_pending_indents: 0,
         }
     }

--- a/crates/oxc_css_parser/src/parser/less.rs
+++ b/crates/oxc_css_parser/src/parser/less.rs
@@ -5,11 +5,10 @@ use super::{
 use crate::{
     Parse,
     ast::*,
-    bump,
     config::Syntax,
     eat,
     error::{Error, ErrorKind, PResult},
-    expect, expect_without_ws_or_comments, peek,
+    expect, expect_without_ws_or_comments,
     pos::{Span, Spanned},
     tokenizer::{Token, TokenWithSpan},
     util,
@@ -34,32 +33,32 @@ impl<'a> Parser<'a> {
         let left =
             self.parse_less_operation(/* allow_mixin_call */ false).map(LessCondition::Value)?;
 
-        let op = match &peek!(self).token {
+        let op = match &self.cursor.peek()?.token {
             Token::GreaterThan(..) => LessBinaryConditionOperator {
                 kind: LessBinaryConditionOperatorKind::GreaterThan,
-                span: bump!(self).span,
+                span: self.cursor.bump()?.span,
             },
             Token::GreaterThanEqual(..) => LessBinaryConditionOperator {
                 kind: LessBinaryConditionOperatorKind::GreaterThanOrEqual,
-                span: bump!(self).span,
+                span: self.cursor.bump()?.span,
             },
             Token::LessThan(..) => LessBinaryConditionOperator {
                 kind: LessBinaryConditionOperatorKind::LessThan,
-                span: bump!(self).span,
+                span: self.cursor.bump()?.span,
             },
             Token::LessThanEqual(..) => LessBinaryConditionOperator {
                 kind: LessBinaryConditionOperatorKind::LessThanOrEqual,
-                span: bump!(self).span,
+                span: self.cursor.bump()?.span,
             },
             Token::Equal(..) => {
-                let eq_span = bump!(self).span;
-                match peek!(self) {
+                let eq_span = self.cursor.bump()?.span;
+                match self.cursor.peek()? {
                     TokenWithSpan { token: Token::GreaterThan(..), span: gt_span }
                         if eq_span.end == gt_span.start =>
                     {
                         LessBinaryConditionOperator {
                             kind: LessBinaryConditionOperatorKind::EqualOrGreaterThan,
-                            span: Span { start: eq_span.start, end: bump!(self).span.end },
+                            span: Span { start: eq_span.start, end: self.cursor.bump()?.span.end },
                         }
                     }
                     TokenWithSpan { token: Token::LessThan(..), span: lt_span }
@@ -67,7 +66,7 @@ impl<'a> Parser<'a> {
                     {
                         LessBinaryConditionOperator {
                             kind: LessBinaryConditionOperatorKind::EqualOrLessThan,
-                            span: Span { start: eq_span.start, end: bump!(self).span.end },
+                            span: Span { start: eq_span.start, end: self.cursor.bump()?.span.end },
                         }
                     }
                     _ => LessBinaryConditionOperator {
@@ -121,7 +120,7 @@ impl<'a> Parser<'a> {
                 })) => match &**inner_condition {
                     LessCondition::Value(ComponentValue::LessBinaryOperation(..))
                         if matches!(
-                            peek!(parser).token,
+                            parser.cursor.peek()?.token,
                             Token::GreaterThan(..)
                                 | Token::GreaterThanEqual(..)
                                 | Token::LessThan(..)
@@ -152,9 +151,9 @@ impl<'a> Parser<'a> {
         precedence: u8,
     ) -> PResult<LessCondition<'a>> {
         let mut left = if precedence >= PRECEDENCE_AND {
-            match &peek!(self).token {
+            match &self.cursor.peek()?.token {
                 Token::LParen(..) => {
-                    let Span { start, .. } = bump!(self).span;
+                    let Span { start, .. } = self.cursor.bump()?.span;
                     let (condition, end) = self.parse_less_guard_paren_condition(needs_parens)?;
                     LessCondition::Parenthesized(LessParenthesizedCondition {
                         condition: self.alloc(condition),
@@ -162,7 +161,7 @@ impl<'a> Parser<'a> {
                     })
                 }
                 Token::Ident(ident) if ident.raw == "not" => {
-                    let Span { start, .. } = bump!(self).span;
+                    let Span { start, .. } = self.cursor.bump()?.span;
                     let (condition, end) = if eat!(self, LParen).is_some() {
                         self.parse_less_guard_paren_condition(needs_parens)?
                     } else {
@@ -179,7 +178,7 @@ impl<'a> Parser<'a> {
                 _ => {
                     if needs_parens {
                         use crate::{token::LParen, tokenizer::TokenSymbol};
-                        let TokenWithSpan { token, span } = bump!(self);
+                        let TokenWithSpan { token, span } = self.cursor.bump()?;
                         return Err(Error {
                             kind: ErrorKind::Unexpected(LParen::symbol(), token.symbol()),
                             span,
@@ -194,17 +193,17 @@ impl<'a> Parser<'a> {
         };
 
         loop {
-            let op = match &peek!(self).token {
+            let op = match &self.cursor.peek()?.token {
                 Token::Ident(token) if token.raw == "and" && precedence == PRECEDENCE_AND => {
                     LessBinaryConditionOperator {
                         kind: LessBinaryConditionOperatorKind::And,
-                        span: bump!(self).span,
+                        span: self.cursor.bump()?.span,
                     }
                 }
                 Token::Ident(token) if token.raw == "or" && precedence == PRECEDENCE_OR => {
                     LessBinaryConditionOperator {
                         kind: LessBinaryConditionOperatorKind::Or,
-                        span: bump!(self).span,
+                        span: self.cursor.bump()?.span,
                     }
                 }
                 _ => break,
@@ -228,7 +227,7 @@ impl<'a> Parser<'a> {
     pub(super) fn parse_less_interpolated_ident(&mut self) -> PResult<InterpolableIdent<'a>> {
         debug_assert_eq!(self.syntax, Syntax::Less);
 
-        let (first, Span { start, mut end }) = match peek!(self) {
+        let (first, Span { start, mut end }) = match self.cursor.peek()? {
             TokenWithSpan { token: Token::Ident(..), .. } => {
                 let (ident, ident_span) = expect!(self, Ident);
                 (
@@ -292,13 +291,13 @@ impl<'a> Parser<'a> {
     ) -> PResult<oxc_allocator::Vec<'a, LessInterpolatedIdentElement<'a>>> {
         let mut elements = self.vec();
         loop {
-            if let Some((token, span)) = self.tokenizer.scan_ident_template()? {
+            if let Some((token, span)) = self.cursor.tokenizer.scan_ident_template()? {
                 *end = span.end;
                 elements.push(LessInterpolatedIdentElement::Static(
                     self.interpolable_ident_static_part(token, span),
                 ));
             } else {
-                match peek!(self) {
+                match self.cursor.peek()? {
                     TokenWithSpan { token: Token::AtLBraceVar(..), span: at_lbrace_var_span }
                         if *end == at_lbrace_var_span.start =>
                     {
@@ -328,7 +327,7 @@ impl<'a> Parser<'a> {
         &mut self,
     ) -> PResult<ComponentValue<'a>> {
         let mixin_call = self.parse::<LessMixinCall>()?;
-        if matches!(peek!(self).token, Token::LBracket(..)) {
+        if matches!(self.cursor.peek()?.token, Token::LBracket(..)) {
             let lookups = self.parse::<LessLookups>()?;
             let span = Span { start: mixin_call.span.start, end: lookups.span.end };
             Ok(ComponentValue::LessNamespaceValue(self.alloc(LessNamespaceValue {
@@ -345,10 +344,10 @@ impl<'a> Parser<'a> {
         &mut self,
     ) -> PResult<ComponentValue<'a>> {
         let variable = self.parse::<LessVariable>()?;
-        match peek!(self) {
+        match self.cursor.peek()? {
             // a detached-ruleset call in value position: `a: @a();`
             TokenWithSpan { token: Token::LParen(..), span } if variable.span.end == span.start => {
-                bump!(self);
+                self.cursor.bump()?;
                 let (_, Span { end, .. }) = expect!(self, RParen);
                 let span = Span { start: variable.span.start, end };
                 return Ok(ComponentValue::LessVariableCall(LessVariableCall { variable, span }));
@@ -381,7 +380,7 @@ impl<'a> Parser<'a> {
         precedence: u8,
     ) -> PResult<ComponentValue<'a>> {
         let mut left = if precedence >= PRECEDENCE_MULTIPLY {
-            match peek!(self).token {
+            match self.cursor.peek()?.token {
                 Token::LParen(..) => self
                     .parse_less_parenthesized_operation(allow_mixin_call)
                     .map(ComponentValue::LessParenthesizedOperation)?,
@@ -389,9 +388,9 @@ impl<'a> Parser<'a> {
                     // less.js's keyword regex also matches a bare `-`
                     // (`a:hover when (2 = true) {5:-}`); only treat it as one
                     // when a terminator follows immediately
-                    let end = peek!(self).span.end;
+                    let end = self.cursor.peek()?.span.end;
                     if matches!(self.source.as_bytes().get(end), None | Some(b';' | b'}')) {
-                        let span = bump!(self).span;
+                        let span = self.cursor.bump()?.span;
                         ComponentValue::InterpolableIdent(InterpolableIdent::Literal(Ident {
                             name: "-",
                             raw: "-",
@@ -419,13 +418,13 @@ impl<'a> Parser<'a> {
         };
 
         loop {
-            let op = match peek!(self) {
+            let op = match self.cursor.peek()? {
                 TokenWithSpan { token: Token::Asterisk(..), .. }
                     if precedence == PRECEDENCE_MULTIPLY =>
                 {
                     LessOperationOperator {
                         kind: LessOperationOperatorKind::Multiply,
-                        span: bump!(self).span,
+                        span: self.cursor.bump()?.span,
                     }
                 }
                 TokenWithSpan { token: Token::Solidus(..), .. }
@@ -435,14 +434,14 @@ impl<'a> Parser<'a> {
                 {
                     LessOperationOperator {
                         kind: LessOperationOperatorKind::Division,
-                        span: bump!(self).span,
+                        span: self.cursor.bump()?.span,
                     }
                 }
                 TokenWithSpan { token: Token::Dot(..), .. }
                     if precedence == PRECEDENCE_MULTIPLY =>
                 {
                     // `./` is also division
-                    let Span { start, .. } = bump!(self).span;
+                    let Span { start, .. } = self.cursor.bump()?.span;
                     let (_, Span { end, .. }) = expect_without_ws_or_comments!(self, Solidus);
                     LessOperationOperator {
                         kind: LessOperationOperatorKind::Division,
@@ -460,7 +459,7 @@ impl<'a> Parser<'a> {
                 {
                     LessOperationOperator {
                         kind: LessOperationOperatorKind::Plus,
-                        span: bump!(self).span,
+                        span: self.cursor.bump()?.span,
                     }
                 }
                 TokenWithSpan { token: Token::Minus(..), span }
@@ -470,7 +469,7 @@ impl<'a> Parser<'a> {
                 {
                     LessOperationOperator {
                         kind: LessOperationOperatorKind::Minus,
-                        span: bump!(self).span,
+                        span: self.cursor.bump()?.span,
                     }
                 }
                 TokenWithSpan { token: Token::Number(token), span }
@@ -540,14 +539,17 @@ impl<'a> Parser<'a> {
                     };
                     // multiplication binds tighter than the split-off sign:
                     // `(6px-1px*2)` is `6px - (1px * 2)`
-                    while matches!(&peek!(self).token, Token::Asterisk(..) | Token::Solidus(..)) {
+                    while matches!(
+                        &self.cursor.peek()?.token,
+                        Token::Asterisk(..) | Token::Solidus(..)
+                    ) {
                         let mul_op = LessOperationOperator {
-                            kind: if matches!(&peek!(self).token, Token::Asterisk(..)) {
+                            kind: if matches!(&self.cursor.peek()?.token, Token::Asterisk(..)) {
                                 LessOperationOperatorKind::Multiply
                             } else {
                                 LessOperationOperatorKind::Division
                             },
-                            span: bump!(self).span,
+                            span: self.cursor.bump()?.span,
                         };
                         let mul_rhs = self.parse_less_operation_recursively(
                             allow_mixin_call,
@@ -614,13 +616,13 @@ impl<'a> Parser<'a> {
             })
             .parse::<SelectorList>()?;
 
-        match &peek!(self).token {
+        match &self.cursor.peek()?.token {
             Token::Ident(ident) if ident.raw == "when" => {
                 // less.js: "Guards are only currently allowed on a single
                 // selector." — a guard on a selector list is rejected whether
                 // the comma comes before or after the `when`.
                 if selector_list.selectors.len() > 1 {
-                    let span = peek!(self).span.clone();
+                    let span = self.cursor.peek()?.span.clone();
                     return Err(Error {
                         kind: ErrorKind::LessGuardOnMultipleComplexSelectors,
                         span,
@@ -651,7 +653,7 @@ impl<'a> Parser<'a> {
 
         let attempt = self.try_parse(|parser| {
             let hex_color = parser.parse::<HexColor>()?;
-            match peek!(parser) {
+            match parser.cursor.peek()? {
                 TokenWithSpan { token: Token::LParen(..), span } => {
                     Err(Error { kind: ErrorKind::TryParseError, span: span.clone() })
                 }
@@ -680,7 +682,7 @@ impl<'a> Parser<'a> {
 
         let single_value = if allow_comma {
             self.parse_maybe_less_list(false)?
-        } else if let Token::Exclamation(..) = peek!(self).token {
+        } else if let Token::Exclamation(..) = self.cursor.peek()?.token {
             self.parse().map(ComponentValue::ImportantAnnotation)?
         } else {
             self.parse_less_operation(/* allow_mixin_call */ true)?
@@ -691,7 +693,7 @@ impl<'a> Parser<'a> {
         let mut separator = ListSeparatorKind::Unknown;
         let mut end = single_value.span().end;
         loop {
-            match peek!(self).token {
+            match self.cursor.peek()?.token {
                 Token::LBrace(..)
                 | Token::RBrace(..)
                 | Token::RParen(..)
@@ -709,7 +711,7 @@ impl<'a> Parser<'a> {
                         if separator == ListSeparatorKind::Unknown {
                             separator = ListSeparatorKind::Comma;
                         }
-                        let TokenWithSpan { span, .. } = bump!(self);
+                        let TokenWithSpan { span, .. } = self.cursor.bump()?;
                         end = span.end;
                         if let Some(spans) = &mut comma_spans {
                             spans.push(span);
@@ -762,7 +764,7 @@ impl<'a> Parser<'a> {
 
 impl<'a> Parse<'a> for LessConditions<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        let when_span = match bump!(input) {
+        let when_span = match input.cursor.bump()? {
             TokenWithSpan { token: Token::Ident(ident), span } if ident.raw == "when" => span,
             TokenWithSpan { span, .. } => {
                 return Err(Error { kind: ErrorKind::ExpectLessKeyword("when"), span });
@@ -777,7 +779,7 @@ impl<'a> Parse<'a> for LessConditions<'a> {
         // A comma may also separate the next guarded selector of the rule
         // (`.a when (..), .b when (..) {`), so only consume it when a
         // condition actually follows.
-        while matches!(peek!(input).token, Token::Comma(..)) {
+        while matches!(input.cursor.peek()?.token, Token::Comma(..)) {
             let Ok((comma_span, condition)) = input.try_parse(|p| {
                 let (_, comma_span) = expect!(p, Comma);
                 let condition = p.parse_less_condition(true)?;
@@ -809,7 +811,7 @@ impl<'a> Parse<'a> for LessEscapedStr<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = expect!(input, Tilde);
         let str = {
-            let (str, span) = input.tokenizer.scan_string_only()?;
+            let (str, span) = input.cursor.tokenizer.scan_string_only()?;
             input.str(str, span)
         };
         let span = Span { start, end: str.span().end };
@@ -927,10 +929,10 @@ impl<'a> Parse<'a> for LessImportOptions<'a> {
         while let Token::Ident(crate::token::Ident {
             raw: "less" | "css" | "multiple" | "once" | "inline" | "reference" | "optional",
             ..
-        }) = peek!(input).token
+        }) = input.cursor.peek()?.token
         {
             names.push(input.parse()?);
-            if !matches!(peek!(input).token, Token::RParen(..)) {
+            if !matches!(input.cursor.peek()?.token, Token::RParen(..)) {
                 comma_spans.push(expect!(input, Comma).1);
             }
         }
@@ -947,13 +949,13 @@ impl<'a> Parse<'a> for LessImportPrelude<'a> {
         let options = input.parse::<LessImportOptions>()?;
         let start = options.span.start;
 
-        let href = match &peek!(input).token {
+        let href = match &input.cursor.peek()?.token {
             Token::Str(..) | Token::StrTemplate(..) => input.parse().map(ImportPreludeHref::Str)?,
             _ => input.parse().map(ImportPreludeHref::Url)?,
         };
         let mut end = href.span().end;
 
-        let media = if matches!(peek!(input).token, Token::Semicolon(..)) {
+        let media = if matches!(input.cursor.peek()?.token, Token::Semicolon(..)) {
             None
         } else {
             let media = input.parse::<MediaQueryList>()?;
@@ -978,7 +980,7 @@ impl<'a> Parse<'a> for LessInterpolatedStr<'a> {
         let mut is_parsing_static_part = false;
         loop {
             if is_parsing_static_part {
-                let (token, str_tpl_span) = input.tokenizer.scan_string_template(quote)?;
+                let (token, str_tpl_span) = input.cursor.tokenizer.scan_string_template(quote)?;
                 let tail = token.tail;
                 let end = str_tpl_span.end;
                 elements.push(LessInterpolatedStrElement::Static(
@@ -1045,8 +1047,11 @@ impl<'a> Parse<'a> for LessLookup<'a> {
         debug_assert_eq!(input.syntax, Syntax::Less);
 
         let (_, Span { start, .. }) = expect!(input, LBracket);
-        let name =
-            if let Token::RBracket(..) = peek!(input).token { None } else { Some(input.parse()?) };
+        let name = if let Token::RBracket(..) = input.cursor.peek()?.token {
+            None
+        } else {
+            Some(input.parse()?)
+        };
         let (_, Span { end, .. }) = expect!(input, RBracket);
         Ok(LessLookup { name, span: Span { start, end } })
     }
@@ -1057,18 +1062,18 @@ impl<'a> Parse<'a> for LessLookupName<'a> {
         debug_assert_eq!(input.syntax, Syntax::Less);
 
         let is_dollar = {
-            let TokenWithSpan { token, span } = peek!(input);
+            let TokenWithSpan { token, span } = input.cursor.peek()?;
             matches!(token, Token::Unknown(..))
                 && input.source.as_bytes().get(span.start) == Some(&b'$')
         };
-        match peek!(input).token {
+        match input.cursor.peek()?.token {
             Token::AtKeyword(..) => input.parse().map(LessLookupName::LessVariable),
             Token::At(..) => input.parse().map(LessLookupName::LessVariableVariable),
             Token::DollarVar(..) => input.parse().map(LessLookupName::LessPropertyVariable),
             // `[$@var]` — a property lookup whose name is interpolated from a
             // variable; the lone `$` arrives as an <unknown-token>
             Token::Unknown(..) if is_dollar => {
-                let dollar_span = bump!(input).span;
+                let dollar_span = input.cursor.bump()?.span;
                 let variable = input.parse::<LessVariable>()?;
                 util::assert_no_ws_or_comment(&dollar_span, &variable.span)?;
                 let span = Span { start: dollar_span.start, end: variable.span.end };
@@ -1090,7 +1095,7 @@ impl<'a> Parse<'a> for LessLookups<'a> {
         let mut span = first.span.clone();
 
         let mut lookups = input.vec1(first);
-        while let Token::LBracket(..) = peek!(input).token {
+        while let Token::LBracket(..) = input.cursor.peek()?.token {
             lookups.push(input.parse()?);
         }
 
@@ -1114,9 +1119,9 @@ impl<'a> Parse<'a> for LessMixinCall<'a> {
             let mut comma_spans = input.vec();
             let mut semicolon_spans = input.vec();
             loop {
-                match peek!(input).token {
+                match input.cursor.peek()?.token {
                     Token::RParen(..) => {
-                        let TokenWithSpan { span, .. } = bump!(input);
+                        let TokenWithSpan { span, .. } = input.cursor.bump()?;
                         if semicolon_comes_at > 0 {
                             let comma_spans = mem::replace(&mut comma_spans, input.vec());
                             wrap_less_mixin_args_into_less_list(
@@ -1144,7 +1149,7 @@ impl<'a> Parse<'a> for LessMixinCall<'a> {
                     Token::Comma(..) => {
                         return Err(Error {
                             kind: ErrorKind::ExpectComponentValue,
-                            span: bump!(input).span,
+                            span: input.cursor.bump()?.span,
                         });
                     }
                     _ => 'maybe: {
@@ -1164,7 +1169,7 @@ impl<'a> Parse<'a> for LessMixinCall<'a> {
                             }
                         };
                         if let Some((_, colon_span)) = eat!(input, Colon) {
-                            let value = if matches!(peek!(input).token, Token::LBrace(..)) {
+                            let value = if matches!(input.cursor.peek()?.token, Token::LBrace(..)) {
                                 input.parse().map(ComponentValue::LessDetachedRuleset)?
                             } else {
                                 input.parse_maybe_less_list(
@@ -1200,13 +1205,13 @@ impl<'a> Parse<'a> for LessMixinCall<'a> {
                     }
                 };
 
-                match peek!(input).token {
+                match input.cursor.peek()?.token {
                     Token::RParen(..) => {}
                     Token::Comma(..) => {
-                        comma_spans.push(bump!(input).span);
+                        comma_spans.push(input.cursor.bump()?.span);
                     }
                     Token::Semicolon(..) => {
-                        let TokenWithSpan { span, .. } = bump!(input);
+                        let TokenWithSpan { span, .. } = input.cursor.bump()?;
                         let comma_spans = mem::replace(&mut comma_spans, input.vec());
                         wrap_less_mixin_args_into_less_list(
                             input.allocator(),
@@ -1219,7 +1224,7 @@ impl<'a> Parse<'a> for LessMixinCall<'a> {
                         semicolon_spans.push(span);
                     }
                     _ => {
-                        let TokenWithSpan { token, span } = bump!(input);
+                        let TokenWithSpan { token, span } = input.cursor.bump()?;
                         use crate::{token::RParen, tokenizer::TokenSymbol};
                         return Err(Error {
                             kind: ErrorKind::Unexpected(RParen::symbol(), token.symbol()),
@@ -1245,7 +1250,7 @@ impl<'a> Parse<'a> for LessMixinCall<'a> {
         let important = if !matches!(
             input.state.qualified_rule_ctx,
             Some(QualifiedRuleContext::DeclarationValue)
-        ) && matches!(peek!(input).token, Token::Exclamation(..))
+        ) && matches!(input.cursor.peek()?.token, Token::Exclamation(..))
         {
             input.parse::<ImportantAnnotation>().map(Some)?
         } else {
@@ -1269,13 +1274,13 @@ impl<'a> Parser<'a> {
         let mut comma_spans = self.vec();
         let mut semicolon_spans = self.vec();
         'params: loop {
-            match peek!(self).token {
+            match self.cursor.peek()?.token {
                 Token::RParen(..) => {
-                    rparen_span = bump!(self).span;
+                    rparen_span = self.cursor.bump()?.span;
                     break;
                 }
                 Token::DotDotDot(..) => {
-                    let TokenWithSpan { span, .. } = bump!(self);
+                    let TokenWithSpan { span, .. } = self.cursor.bump()?;
                     params.push(LessMixinParameter::Variadic(LessMixinVariadicParameter {
                         name: None,
                         span,
@@ -1287,7 +1292,7 @@ impl<'a> Parser<'a> {
                 Token::Comma(..) => {
                     return Err(Error {
                         kind: ErrorKind::ExpectComponentValue,
-                        span: bump!(self).span,
+                        span: self.cursor.bump()?.span,
                     });
                 }
                 _ => 'maybe: {
@@ -1316,7 +1321,7 @@ impl<'a> Parser<'a> {
                     };
                     let name_span = name.span();
                     if let Some((_, colon_span)) = eat!(self, Colon) {
-                        let value = if matches!(peek!(self).token, Token::LBrace(..)) {
+                        let value = if matches!(self.cursor.peek()?.token, Token::LBrace(..)) {
                             self.parse().map(ComponentValue::LessDetachedRuleset)?
                         } else {
                             self.with_state(ParserState {
@@ -1358,9 +1363,9 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            match &peek!(self).token {
+            match &self.cursor.peek()?.token {
                 Token::RParen(..) => {
-                    let span = bump!(self).span;
+                    let span = self.cursor.bump()?.span;
                     if semicolon_comes_at > 0 {
                         let comma_spans = mem::replace(&mut comma_spans, self.vec());
                         wrap_less_mixin_params_into_less_list(
@@ -1383,10 +1388,10 @@ impl<'a> Parser<'a> {
                     break;
                 }
                 Token::Comma(..) => {
-                    comma_spans.push(bump!(self).span);
+                    comma_spans.push(self.cursor.bump()?.span);
                 }
                 Token::Semicolon(..) => {
-                    let span = bump!(self).span;
+                    let span = self.cursor.bump()?.span;
                     let comma_spans = mem::replace(&mut comma_spans, self.vec());
                     wrap_less_mixin_params_into_less_list(
                         self.allocator(),
@@ -1420,9 +1425,9 @@ impl<'a> Parser<'a> {
     pub(super) fn parse_less_anonymous_mixin(&mut self) -> PResult<LessAnonymousMixin<'a>> {
         debug_assert_eq!(self.syntax, Syntax::Less);
 
-        let TokenWithSpan { token, span: head_span } = bump!(self);
+        let TokenWithSpan { token, span: head_span } = self.cursor.bump()?;
         if !matches!(token, Token::Dot(..) | Token::NumberSign(..))
-            || peek!(self).span.start != head_span.end
+            || self.cursor.peek()?.span.start != head_span.end
         {
             return Err(Error { kind: ErrorKind::TryParseError, span: head_span });
         }
@@ -1447,7 +1452,7 @@ impl<'a> Parse<'a> for LessMixinCallee<'a> {
             let combinator = eat!(input, GreaterThan)
                 .map(|(_, span)| Combinator { kind: CombinatorKind::Child, span });
             let at_name = {
-                let TokenWithSpan { token, span } = peek!(input);
+                let TokenWithSpan { token, span } = input.cursor.peek()?;
                 matches!(token, Token::Dot(..) | Token::Hash(..))
                     || (matches!(token, Token::Dimension(..))
                         && input.source.as_bytes().get(span.start) == Some(&b'.'))
@@ -1483,7 +1488,7 @@ impl<'a> Parse<'a> for LessMixinDefinition<'a> {
 
         let params = input.parse_less_mixin_parameters()?;
 
-        let guard = match &peek!(input).token {
+        let guard = match &input.cursor.peek()?.token {
             Token::Ident(ident) if ident.raw == "when" => Some(input.parse()?),
             _ => None,
         };
@@ -1503,7 +1508,7 @@ impl<'a> Parse<'a> for LessMixinDefinition<'a> {
 
 impl<'a> Parse<'a> for LessMixinName<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match bump!(input) {
+        match input.cursor.bump()? {
             // `.3D` — a digit-led name arrives as one <dimension-token>
             TokenWithSpan { token: Token::Dimension(..), span }
                 if input.source.as_bytes().get(span.start) == Some(&b'.') =>
@@ -1560,7 +1565,7 @@ impl<'a> Parse<'a> for LessMixinName<'a> {
 
 impl<'a> Parse<'a> for LessMixinParameterName<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        if matches!(peek!(input).token, Token::AtKeyword(..)) {
+        if matches!(input.cursor.peek()?.token, Token::AtKeyword(..)) {
             input.parse().map(LessMixinParameterName::Variable)
         } else {
             input.parse().map(LessMixinParameterName::PropertyVariable)
@@ -1583,7 +1588,7 @@ impl<'a> Parse<'a> for LessNamespaceValue<'a> {
 
 impl<'a> Parse<'a> for LessNamespaceValueCallee<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        if matches!(peek!(input).token, Token::AtKeyword(..)) {
+        if matches!(input.cursor.peek()?.token, Token::AtKeyword(..)) {
             input.parse().map(LessNamespaceValueCallee::LessVariable)
         } else {
             input.parse().map(LessNamespaceValueCallee::LessMixinCall)
@@ -1594,7 +1599,7 @@ impl<'a> Parse<'a> for LessNamespaceValueCallee<'a> {
 impl<'a> Parse<'a> for LessNegativeValue<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, minus_span) = expect!(input, Minus);
-        let value = match peek!(input) {
+        let value = match input.cursor.peek()? {
             TokenWithSpan {
                 token: Token::AtKeyword(..) | Token::At(..) | Token::DollarVar(..),
                 span,
@@ -1660,7 +1665,7 @@ impl<'a> Parse<'a> for LessPlugin<'a> {
 
 impl<'a> Parse<'a> for LessPluginPath<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        if let Token::Str(..) = peek!(input).token {
+        if let Token::Str(..) = input.cursor.peek()?.token {
             input.parse().map(LessPluginPath::Str)
         } else {
             input.parse().map(LessPluginPath::Url)
@@ -1683,14 +1688,14 @@ impl<'a> Parse<'a> for Option<LessPropertyMerge> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Less | Syntax::Css));
 
-        match &peek!(input).token {
+        match &input.cursor.peek()?.token {
             Token::Plus(..) => Ok(Some(LessPropertyMerge {
                 kind: LessPropertyMergeKind::Comma,
-                span: bump!(input).span,
+                span: input.cursor.bump()?.span,
             })),
             Token::PlusUnderscore(..) => Ok(Some(LessPropertyMerge {
                 kind: LessPropertyMergeKind::Space,
-                span: bump!(input).span,
+                span: input.cursor.bump()?.span,
             })),
             _ => Ok(None),
         }
@@ -1734,7 +1739,7 @@ impl<'a> Parse<'a> for LessVariableDeclaration<'a> {
 
         let name = input.parse::<LessVariable>()?;
         let (_, colon_span) = expect!(input, Colon);
-        let value = if matches!(peek!(input).token, Token::LBrace(..)) {
+        let value = if matches!(input.cursor.peek()?.token, Token::LBrace(..)) {
             ComponentValue::LessDetachedRuleset(input.parse()?)
         } else {
             let typed = input.try_parse(|p| {
@@ -1748,10 +1753,10 @@ impl<'a> Parse<'a> for LessVariableDeclaration<'a> {
                 // statement boundary — `@page :first {` is an at-rule, not a
                 // variable named `@page` with the value `first`.
                 if !matches!(
-                    &peek!(p).token,
+                    &p.cursor.peek()?.token,
                     Token::Semicolon(..) | Token::RBrace(..) | Token::Eof(..)
                 ) {
-                    let span = peek!(p).span.clone();
+                    let span = p.cursor.peek()?.span.clone();
                     return Err(Error { kind: ErrorKind::TryParseError, span });
                 }
                 Ok(value)
@@ -1763,11 +1768,11 @@ impl<'a> Parse<'a> for LessVariableDeclaration<'a> {
                     // balanced token run (`@this: () => { ... };`), but only
                     // when explicitly terminated by `;` — otherwise
                     // `@page :first { ... }` would be swallowed too.
-                    let start = peek!(input).span.start;
+                    let start = input.cursor.peek()?.span.start;
                     let values = input
                         .parse_declaration_value_tokens(/* stop_at_top_level_brace */ false)?;
                     let end = values.last().map(|v| v.span().end);
-                    if !matches!(peek!(input).token, Token::Semicolon(..)) {
+                    if !matches!(input.cursor.peek()?.token, Token::Semicolon(..)) {
                         return Err(error);
                     }
                     let Some(end) = end else {

--- a/crates/oxc_css_parser/src/parser/macros.rs
+++ b/crates/oxc_css_parser/src/parser/macros.rs
@@ -1,27 +1,12 @@
 #[doc(hidden)]
 #[macro_export]
-macro_rules! bump {
-    ($parser:expr) => {{
-        match $parser.cached_token.take() {
-            Some(token_with_span) => token_with_span,
-            None => {
-                let tokenizer = &mut $parser.tokenizer;
-                tokenizer.bump()?
-            }
-        }
-    }};
-}
-
-#[doc(hidden)]
-#[macro_export]
 macro_rules! expect {
     ($parser:expr, $variant:ident) => {{
         use $crate::{
-            bump,
             error::{Error, ErrorKind},
             tokenizer::{Token, TokenSymbol, TokenWithSpan},
         };
-        match bump!($parser) {
+        match $parser.cursor.bump()? {
             TokenWithSpan { token: Token::$variant(token), span } => (token, span),
             TokenWithSpan { token, span } => {
                 return Err(Error {
@@ -49,9 +34,9 @@ macro_rules! expect_without_ws_or_comments {
             error::{Error, ErrorKind},
             tokenizer::TokenSymbol,
         };
-        debug_assert!($parser.cached_token.is_none());
+        debug_assert!($parser.cursor.cached_token.is_none());
         let allow_leading_digit = $allow_leading_digit;
-        let tokenizer = &mut $parser.tokenizer;
+        let tokenizer = &mut $parser.cursor.tokenizer;
         if tokenizer.is_start_of_ident() || (allow_leading_digit && tokenizer.is_start_of_digit()) {
             tokenizer.scan_ident_sequence(allow_leading_digit)?
         } else {
@@ -70,8 +55,8 @@ macro_rules! expect_without_ws_or_comments {
             error::{Error, ErrorKind},
             tokenizer::{Token, TokenSymbol, TokenWithSpan},
         };
-        debug_assert!($parser.cached_token.is_none());
-        let tokenizer = &mut $parser.tokenizer;
+        debug_assert!($parser.cursor.cached_token.is_none());
+        let tokenizer = &mut $parser.cursor.tokenizer;
         let token_with_span = tokenizer.bump_without_ws_or_comments()?;
         match token_with_span {
             TokenWithSpan { token: Token::$variant(token), span } => (token, span),
@@ -92,31 +77,13 @@ macro_rules! expect_without_ws_or_comments {
 #[macro_export]
 macro_rules! eat {
     ($parser:expr, $variant:ident) => {{
-        use $crate::{
-            bump,
-            tokenizer::{Token, TokenWithSpan},
-        };
-        let token_with_span = bump!($parser);
+        use $crate::tokenizer::{Token, TokenWithSpan};
+        let token_with_span = $parser.cursor.bump()?;
         match token_with_span {
             TokenWithSpan { token: Token::$variant(token), span } => Some((token, span)),
             value => {
-                $parser.cached_token = Some(value);
+                $parser.cursor.cached_token = Some(value);
                 None
-            }
-        }
-    }};
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! peek {
-    ($parser:expr) => {{
-        match &$parser.cached_token {
-            Some(token_with_span) => token_with_span,
-            None => {
-                let tokenizer = &mut $parser.tokenizer;
-                let token = tokenizer.bump()?;
-                $parser.cached_token.insert(token)
             }
         }
     }};

--- a/crates/oxc_css_parser/src/parser/mod.rs
+++ b/crates/oxc_css_parser/src/parser/mod.rs
@@ -32,16 +32,47 @@ pub trait Parse<'a>: Sized {
     fn parse(input: &mut Parser<'a>) -> PResult<Self>;
 }
 
+pub(in crate::parser) struct ParserCursor<'a> {
+    tokenizer: Tokenizer<'a>,
+    cached_token: Option<TokenWithSpan<'a>>,
+}
+
+impl<'a> ParserCursor<'a> {
+    #[inline]
+    fn new(tokenizer: Tokenizer<'a>) -> Self {
+        Self { tokenizer, cached_token: None }
+    }
+
+    #[inline]
+    fn bump(&mut self) -> PResult<TokenWithSpan<'a>> {
+        match self.cached_token.take() {
+            Some(token_with_span) => Ok(token_with_span),
+            None => self.tokenizer.bump(),
+        }
+    }
+
+    #[inline]
+    fn peek(&mut self) -> PResult<&TokenWithSpan<'a>> {
+        if self.cached_token.is_none() {
+            let token = self.tokenizer.bump()?;
+            self.cached_token = Some(token);
+        }
+        match self.cached_token.as_ref() {
+            Some(token_with_span) => Ok(token_with_span),
+            None => unreachable!(),
+        }
+    }
+}
+
 /// Create a parser with some source code, then parse it.
 pub struct Parser<'a> {
     allocator: &'a Allocator,
     source: &'a str,
     syntax: Syntax,
     options: ParserOptions,
-    tokenizer: Tokenizer<'a>,
+    cursor: ParserCursor<'a>,
     state: ParserState,
     recoverable_errors: Vec<Error>,
-    cached_token: Option<TokenWithSpan<'a>>,
     /// Indented syntax only: `Indent` tokens consumed as mid-statement line
     /// continuations (`@for $i\n  from 1...`). The statement's own block then
     /// starts "virtually" at that depth (see [`SimpleBlock`]'s parse), and any
@@ -60,10 +91,9 @@ impl<'a> Parser<'a> {
             source,
             syntax,
             options: Default::default(),
-            tokenizer: Tokenizer::new(allocator, source, syntax, None, false),
+            cursor: ParserCursor::new(Tokenizer::new(allocator, source, syntax, None, false)),
             state: Default::default(),
             recoverable_errors: vec![],
-            cached_token: None,
             sass_pending_indents: 0,
         }
     }
@@ -85,7 +115,7 @@ impl<'a> Parser<'a> {
     /// Retrieve collected comments.
     #[inline]
     pub fn comments(&self) -> &[crate::tokenizer::token::Comment<'a>] {
-        self.tokenizer.comments()
+        self.cursor.tokenizer.comments()
     }
 
     #[inline]
@@ -200,17 +230,17 @@ impl<'a> Parser<'a> {
     }
 
     fn try_parse<R, F: FnOnce(&mut Self) -> PResult<R>>(&mut self, f: F) -> PResult<R> {
-        let tokenizer_state = self.tokenizer.state.clone();
-        let comments_count = self.tokenizer.comments_count();
+        let tokenizer_state = self.cursor.tokenizer.state.clone();
+        let comments_count = self.cursor.tokenizer.comments_count();
         let recoverable_errors_count = self.recoverable_errors.len();
-        let cached_token = self.cached_token.clone();
+        let cached_token = self.cursor.cached_token.clone();
         let sass_pending_indents = self.sass_pending_indents;
         let result = f(self);
         if result.is_err() {
-            self.tokenizer.state = tokenizer_state;
-            self.tokenizer.truncate_comments(comments_count);
+            self.cursor.tokenizer.state = tokenizer_state;
+            self.cursor.tokenizer.truncate_comments(comments_count);
             self.recoverable_errors.truncate(recoverable_errors_count);
-            self.cached_token = cached_token;
+            self.cursor.cached_token = cached_token;
             self.sass_pending_indents = sass_pending_indents;
         }
         result

--- a/crates/oxc_css_parser/src/parser/postcss_simple_vars.rs
+++ b/crates/oxc_css_parser/src/parser/postcss_simple_vars.rs
@@ -4,7 +4,7 @@ use crate::{
     ast::*,
     config::Syntax,
     error::PResult,
-    expect, peek,
+    expect,
     pos::{Span, Spanned},
     tokenizer::Token,
 };
@@ -28,7 +28,7 @@ impl<'a> Parse<'a> for PostcssSimpleVarDeclaration<'a> {
         // postcss-simple-vars is textual substitution; `!important` is just part
         // of the value, not a structural declaration modifier (unlike CSS's
         // `Declaration.important`). Keep it in the value stream.
-        if let Token::Exclamation(..) = &peek!(input).token {
+        if let Token::Exclamation(..) = &input.cursor.peek()?.token {
             let important = input.parse::<ImportantAnnotation>()?;
             value.push(ComponentValue::ImportantAnnotation(important));
         }

--- a/crates/oxc_css_parser/src/parser/sass.rs
+++ b/crates/oxc_css_parser/src/parser/sass.rs
@@ -5,11 +5,10 @@ use super::{
 use crate::{
     Parse,
     ast::*,
-    bump,
     config::Syntax,
     eat,
     error::{Error, ErrorKind, PResult},
-    expect, expect_without_ws_or_comments, peek,
+    expect, expect_without_ws_or_comments,
     pos::{Span, Spanned},
     tokenizer::{Token, TokenWithSpan},
     util,
@@ -42,13 +41,13 @@ impl<'a> Parser<'a> {
             return Ok(());
         }
         loop {
-            match &peek!(self).token {
+            match &self.cursor.peek()?.token {
                 Token::Indent(..) => {
-                    bump!(self);
+                    self.cursor.bump()?;
                     self.sass_pending_indents += 1;
                 }
                 Token::Linebreak(..) => {
-                    bump!(self);
+                    self.cursor.bump()?;
                 }
                 _ => break,
             }
@@ -60,8 +59,10 @@ impl<'a> Parser<'a> {
     /// mirror tokens). Returns whether any were drained.
     pub(super) fn drain_sass_pending_dedents(&mut self) -> PResult<bool> {
         let mut drained = false;
-        while self.sass_pending_indents > 0 && matches!(peek!(self).token, Token::Dedent(..)) {
-            bump!(self);
+        while self.sass_pending_indents > 0
+            && matches!(self.cursor.peek()?.token, Token::Dedent(..))
+        {
+            self.cursor.bump()?;
             self.sass_pending_indents -= 1;
             drained = true;
         }
@@ -76,7 +77,7 @@ impl<'a> Parser<'a> {
 
         let single_value = if allow_comma {
             self.parse_maybe_sass_list(false)?
-        } else if let Token::Exclamation(..) = peek!(self).token {
+        } else if let Token::Exclamation(..) = self.cursor.peek()?.token {
             self.parse().map(ComponentValue::ImportantAnnotation)?
         } else {
             self.parse_sass_bin_expr(/* allow_comparison */ true)?
@@ -87,7 +88,7 @@ impl<'a> Parser<'a> {
         let mut separator = ListSeparatorKind::Unknown;
         let mut end = single_value.span().end;
         loop {
-            match peek!(self).token {
+            match self.cursor.peek()?.token {
                 Token::LBrace(..)
                 | Token::RBrace(..)
                 | Token::RParen(..)
@@ -101,7 +102,7 @@ impl<'a> Parser<'a> {
                     {
                         break;
                     } else {
-                        bump!(self);
+                        self.cursor.bump()?;
                     }
                 }
                 Token::Comma(..) => {
@@ -114,7 +115,7 @@ impl<'a> Parser<'a> {
                         if separator == ListSeparatorKind::Unknown {
                             separator = ListSeparatorKind::Comma;
                         }
-                        let TokenWithSpan { span, .. } = bump!(self);
+                        let TokenWithSpan { span, .. } = self.cursor.bump()?;
                         end = span.end;
                         if let Some(spans) = &mut comma_spans {
                             spans.push(span);
@@ -186,7 +187,7 @@ impl<'a> Parser<'a> {
 
         loop {
             if PRECEDENCE_PLUS >= min_precedence {
-                match peek!(self) {
+                match self.cursor.peek()? {
                     TokenWithSpan { token: Token::Number(token), span }
                         if token.raw.starts_with('+')
                             || token.raw.starts_with('-') && span.start == left.span().end =>
@@ -266,14 +267,14 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            let (operator, precedence) = match peek!(self) {
+            let (operator, precedence) = match self.cursor.peek()? {
                 TokenWithSpan { token: Token::Asterisk(..), .. }
                     if PRECEDENCE_MULTIPLY >= min_precedence =>
                 {
                     (
                         SassBinaryOperator {
                             kind: SassBinaryOperatorKind::Multiply,
-                            span: bump!(self).span,
+                            span: self.cursor.bump()?.span,
                         },
                         PRECEDENCE_MULTIPLY,
                     )
@@ -294,7 +295,7 @@ impl<'a> Parser<'a> {
                     (
                         SassBinaryOperator {
                             kind: SassBinaryOperatorKind::Division,
-                            span: bump!(self).span,
+                            span: self.cursor.bump()?.span,
                         },
                         PRECEDENCE_MULTIPLY,
                     )
@@ -306,7 +307,7 @@ impl<'a> Parser<'a> {
                     // only take it as the modulo operator when a right operand
                     // actually follows.
                     let modulo = self.try_parse(|p| {
-                        let op_span = bump!(p).span;
+                        let op_span = p.cursor.bump()?.span;
                         p.eat_sass_line_continuation()?;
                         let right = p.parse_sass_bin_expr_with_min_precedence(
                             PRECEDENCE_MULTIPLY + 1,
@@ -337,7 +338,7 @@ impl<'a> Parser<'a> {
                     (
                         SassBinaryOperator {
                             kind: SassBinaryOperatorKind::Plus,
-                            span: bump!(self).span,
+                            span: self.cursor.bump()?.span,
                         },
                         PRECEDENCE_PLUS,
                     )
@@ -348,7 +349,7 @@ impl<'a> Parser<'a> {
                     (
                         SassBinaryOperator {
                             kind: SassBinaryOperatorKind::Minus,
-                            span: bump!(self).span,
+                            span: self.cursor.bump()?.span,
                         },
                         PRECEDENCE_PLUS,
                     )
@@ -359,7 +360,7 @@ impl<'a> Parser<'a> {
                     (
                         SassBinaryOperator {
                             kind: SassBinaryOperatorKind::GreaterThan,
-                            span: bump!(self).span,
+                            span: self.cursor.bump()?.span,
                         },
                         PRECEDENCE_RELATIONAL,
                     )
@@ -370,7 +371,7 @@ impl<'a> Parser<'a> {
                     (
                         SassBinaryOperator {
                             kind: SassBinaryOperatorKind::GreaterThanOrEqual,
-                            span: bump!(self).span,
+                            span: self.cursor.bump()?.span,
                         },
                         PRECEDENCE_RELATIONAL,
                     )
@@ -381,7 +382,7 @@ impl<'a> Parser<'a> {
                     (
                         SassBinaryOperator {
                             kind: SassBinaryOperatorKind::LessThan,
-                            span: bump!(self).span,
+                            span: self.cursor.bump()?.span,
                         },
                         PRECEDENCE_RELATIONAL,
                     )
@@ -392,7 +393,7 @@ impl<'a> Parser<'a> {
                     (
                         SassBinaryOperator {
                             kind: SassBinaryOperatorKind::LessThanOrEqual,
-                            span: bump!(self).span,
+                            span: self.cursor.bump()?.span,
                         },
                         PRECEDENCE_RELATIONAL,
                     )
@@ -403,7 +404,7 @@ impl<'a> Parser<'a> {
                     (
                         SassBinaryOperator {
                             kind: SassBinaryOperatorKind::EqualsEquals,
-                            span: bump!(self).span,
+                            span: self.cursor.bump()?.span,
                         },
                         PRECEDENCE_EQUALITY,
                     )
@@ -414,7 +415,7 @@ impl<'a> Parser<'a> {
                     (
                         SassBinaryOperator {
                             kind: SassBinaryOperatorKind::ExclamationEquals,
-                            span: bump!(self).span,
+                            span: self.cursor.bump()?.span,
                         },
                         PRECEDENCE_EQUALITY,
                     )
@@ -425,7 +426,7 @@ impl<'a> Parser<'a> {
                     (
                         SassBinaryOperator {
                             kind: SassBinaryOperatorKind::And,
-                            span: bump!(self).span,
+                            span: self.cursor.bump()?.span,
                         },
                         PRECEDENCE_AND,
                     )
@@ -436,7 +437,7 @@ impl<'a> Parser<'a> {
                     (
                         SassBinaryOperator {
                             kind: SassBinaryOperatorKind::Or,
-                            span: bump!(self).span,
+                            span: self.cursor.bump()?.span,
                         },
                         PRECEDENCE_OR,
                     )
@@ -496,7 +497,7 @@ impl<'a> Parser<'a> {
     pub(super) fn parse_sass_interpolated_ident(&mut self) -> PResult<InterpolableIdent<'a>> {
         debug_assert!(matches!(self.syntax, Syntax::Scss | Syntax::Sass));
 
-        let (first, Span { start, mut end }) = match peek!(self) {
+        let (first, Span { start, mut end }) = match self.cursor.peek()? {
             TokenWithSpan { token: Token::Ident(..), .. } => {
                 let (ident, ident_span) = expect!(self, Ident);
                 (
@@ -548,13 +549,13 @@ impl<'a> Parser<'a> {
     ) -> PResult<oxc_allocator::Vec<'a, SassInterpolatedIdentElement<'a>>> {
         let mut elements = self.vec();
         loop {
-            if let Some((token, span)) = self.tokenizer.scan_ident_template()? {
+            if let Some((token, span)) = self.cursor.tokenizer.scan_ident_template()? {
                 *end = span.end;
                 elements.push(SassInterpolatedIdentElement::Static(
                     self.interpolable_ident_static_part(token, span),
                 ));
             } else if matches!(
-                peek!(self),
+                self.cursor.peek()?,
                 TokenWithSpan { token: Token::HashLBrace(..), span } if *end == span.start
             ) {
                 let (element, span) = self.parse_sass_interpolated_ident_expr()?;
@@ -584,10 +585,10 @@ impl<'a> Parser<'a> {
 
         let mut values = self.vec_with_capacity(4);
         let mut comma_spans = self.vec();
-        while !matches!(peek!(self).token, Token::RParen(..) | Token::Eof(..)) {
-            match peek!(self).token {
+        while !matches!(self.cursor.peek()?.token, Token::RParen(..) | Token::Eof(..)) {
+            match self.cursor.peek()?.token {
                 Token::Comma(..) => {
-                    let TokenWithSpan { span, .. } = bump!(self);
+                    let TokenWithSpan { span, .. } = self.cursor.bump()?;
                     self.recoverable_errors
                         .push(Error { kind: ErrorKind::ExpectComponentValue, span });
                     continue;
@@ -618,7 +619,7 @@ impl<'a> Parser<'a> {
                     }
                 }
             }
-            if !matches!(peek!(self).token, Token::RParen(..) | Token::Eof(..)) {
+            if !matches!(self.cursor.peek()?.token, Token::RParen(..) | Token::Eof(..)) {
                 comma_spans.push(expect!(self, Comma).1);
             }
         }
@@ -630,9 +631,9 @@ impl<'a> Parser<'a> {
         &mut self,
         allow_overridable: bool,
     ) -> PResult<Option<SassModuleConfig<'a>>> {
-        match &peek!(self).token {
+        match &self.cursor.peek()?.token {
             Token::Ident(ident) if ident.name().eq_ignore_ascii_case("with") => {
-                let TokenWithSpan { span: with_span, .. } = bump!(self);
+                let TokenWithSpan { span: with_span, .. } = self.cursor.bump()?;
                 let start = with_span.start;
                 let end;
                 self.eat_sass_line_continuation()?;
@@ -706,7 +707,7 @@ impl<'a> Parser<'a> {
             }
 
             let name = self.parse::<SassVariable>()?;
-            let token_with_span = bump!(self);
+            let token_with_span = self.cursor.bump()?;
             match token_with_span.token {
                 Token::Comma(..) => {
                     let span = name.span.clone();
@@ -772,7 +773,7 @@ impl<'a> Parser<'a> {
         debug_assert!(matches!(self.syntax, Syntax::Scss | Syntax::Sass));
 
         let (_, dot_span) = expect!(self, Dot);
-        let member = if let Token::DollarVar(..) = peek!(self).token {
+        let member = if let Token::DollarVar(..) = self.cursor.peek()?.token {
             self.parse().map(SassModuleMemberName::Variable)?
         } else {
             self.parse().map(SassModuleMemberName::Ident)?
@@ -789,19 +790,22 @@ impl<'a> Parser<'a> {
         // dart-sass accepts a bare `%` in declaration values (`b: %`,
         // `b: % c`, `b: c %`) as a plain token. Calculations bypass this
         // (they parse atoms directly), so `calc(1px % 2px)` stays invalid.
-        if let Token::Percent(..) = &peek!(self).token {
-            return Ok(ComponentValue::TokenWithSpan(bump!(self)));
+        if let Token::Percent(..) = &self.cursor.peek()?.token {
+            return Ok(ComponentValue::TokenWithSpan(self.cursor.bump()?));
         }
-        let op = match &peek!(self).token {
-            Token::Plus(..) => {
-                SassUnaryOperator { kind: SassUnaryOperatorKind::Plus, span: bump!(self).span }
-            }
-            Token::Minus(..) => {
-                SassUnaryOperator { kind: SassUnaryOperatorKind::Minus, span: bump!(self).span }
-            }
-            Token::Ident(token) if token.raw == "not" => {
-                SassUnaryOperator { kind: SassUnaryOperatorKind::Not, span: bump!(self).span }
-            }
+        let op = match &self.cursor.peek()?.token {
+            Token::Plus(..) => SassUnaryOperator {
+                kind: SassUnaryOperatorKind::Plus,
+                span: self.cursor.bump()?.span,
+            },
+            Token::Minus(..) => SassUnaryOperator {
+                kind: SassUnaryOperatorKind::Minus,
+                span: self.cursor.bump()?.span,
+            },
+            Token::Ident(token) if token.raw == "not" => SassUnaryOperator {
+                kind: SassUnaryOperatorKind::Not,
+                span: self.cursor.bump()?.span,
+            },
             _ => return self.parse_component_value_atom(),
         };
 
@@ -819,7 +823,7 @@ impl<'a> Parser<'a> {
 
 impl<'a> Parse<'a> for SassAtRoot<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        let kind = if matches!(peek!(input).token, Token::LParen(..)) {
+        let kind = if matches!(input.cursor.peek()?.token, Token::LParen(..)) {
             SassAtRootKind::Query(input.parse()?)
         } else {
             SassAtRootKind::Selector(input.parse()?)
@@ -849,7 +853,7 @@ impl<'a> Parse<'a> for SassAtRootQuery<'a> {
 
         let mut rules = input.vec_with_capacity(1);
         loop {
-            match &peek!(input).token {
+            match &input.cursor.peek()?.token {
                 Token::Ident(..) | Token::HashLBrace(..) => {
                     rules.push(SassAtRootQueryRule::Ident(input.parse()?));
                 }
@@ -992,9 +996,9 @@ impl<'a> Parse<'a> for SassForward<'a> {
         let path = input.parse::<InterpolableStr>()?;
         let mut span = path.span().clone();
 
-        let prefix = match &peek!(input).token {
+        let prefix = match &input.cursor.peek()?.token {
             Token::Ident(ident) if ident.name().eq_ignore_ascii_case("as") => {
-                let TokenWithSpan { span: as_span, .. } = bump!(input);
+                let TokenWithSpan { span: as_span, .. } = input.cursor.bump()?;
                 input.eat_sass_line_continuation()?;
                 let name = input.parse()?;
                 let (_, Span { end, .. }) = expect_without_ws_or_comments!(input, Asterisk);
@@ -1005,17 +1009,17 @@ impl<'a> Parse<'a> for SassForward<'a> {
         };
 
         let visibility = if let TokenWithSpan { token: Token::Ident(keyword), span: keyword_span } =
-            peek!(input)
+            input.cursor.peek()?
         {
             let start = keyword_span.start;
             let name = keyword.name();
             if name.eq_ignore_ascii_case("hide") {
-                let keyword_span = bump!(input).span;
+                let keyword_span = input.cursor.bump()?.span;
                 let mut members = input.vec();
                 let mut comma_spans = input.vec();
                 loop {
                     input.eat_sass_line_continuation()?;
-                    match &peek!(input).token {
+                    match &input.cursor.peek()?.token {
                         Token::Ident(..) => {
                             members.push(input.parse().map(SassForwardMember::Ident)?)
                         }
@@ -1034,15 +1038,15 @@ impl<'a> Parse<'a> for SassForward<'a> {
                     },
                     members,
                     comma_spans,
-                    span: Span { start, end: input.tokenizer.current_offset() },
+                    span: Span { start, end: input.cursor.tokenizer.current_offset() },
                 })
             } else if name.eq_ignore_ascii_case("show") {
-                let keyword_span = bump!(input).span;
+                let keyword_span = input.cursor.bump()?.span;
                 let mut members = input.vec();
                 let mut comma_spans = input.vec();
                 loop {
                     input.eat_sass_line_continuation()?;
-                    match &peek!(input).token {
+                    match &input.cursor.peek()?.token {
                         Token::Ident(..) => {
                             members.push(input.parse().map(SassForwardMember::Ident)?)
                         }
@@ -1061,7 +1065,7 @@ impl<'a> Parse<'a> for SassForward<'a> {
                     },
                     members,
                     comma_spans,
-                    span: Span { start, end: input.tokenizer.current_offset() },
+                    span: Span { start, end: input.cursor.tokenizer.current_offset() },
                 })
             } else {
                 None
@@ -1114,24 +1118,24 @@ impl<'a> Parse<'a> for SassIfAtRule<'a> {
             // rollback snapshot is needed only when one is present.)
             fn else_keyword<'a>(p: &mut Parser<'a>) -> PResult<(Span, bool)> {
                 while eat!(p, Linebreak).is_some() {}
-                let is_else = match &peek!(p).token {
+                let is_else = match &p.cursor.peek()?.token {
                     Token::AtKeyword(at_keyword) => match &*at_keyword.ident.name() {
                         "else" => true,
                         // `elseif` is deprecated by Sass
                         "elseif" => false,
                         _ => {
-                            let span = peek!(p).span.clone();
+                            let span = p.cursor.peek()?.span.clone();
                             return Err(Error { kind: ErrorKind::TryParseError, span });
                         }
                     },
                     _ => {
-                        let span = peek!(p).span.clone();
+                        let span = p.cursor.peek()?.span.clone();
                         return Err(Error { kind: ErrorKind::TryParseError, span });
                     }
                 };
-                Ok((bump!(p).span, is_else))
+                Ok((p.cursor.bump()?.span, is_else))
             }
-            let else_keyword = if matches!(peek!(input).token, Token::Linebreak(..)) {
+            let else_keyword = if matches!(input.cursor.peek()?.token, Token::Linebreak(..)) {
                 input.try_parse(else_keyword)
             } else {
                 else_keyword(input)
@@ -1140,9 +1144,9 @@ impl<'a> Parse<'a> for SassIfAtRule<'a> {
             else_spans.push(else_span);
             if is_else {
                 input.eat_sass_line_continuation()?;
-                match &peek!(input).token {
+                match &input.cursor.peek()?.token {
                     Token::Ident(ident) if ident.name() == "if" => {
-                        bump!(input);
+                        input.cursor.bump()?;
                         else_if_clauses.push(input.parse()?);
                     }
                     _ => {
@@ -1196,7 +1200,7 @@ impl<'a> Parse<'a> for SassInclude<'a> {
         let name = input.parse::<FunctionName>()?;
         let mut span = name.span().clone();
 
-        let arguments = if matches!(peek!(input).token, Token::LParen(..)) {
+        let arguments = if matches!(input.cursor.peek()?.token, Token::LParen(..)) {
             let arguments = input.parse::<SassIncludeArgs>()?;
             span.end = arguments.span.end;
             Some(arguments)
@@ -1204,7 +1208,7 @@ impl<'a> Parse<'a> for SassInclude<'a> {
             None
         };
 
-        let content_block_params = match &peek!(input).token {
+        let content_block_params = match &input.cursor.peek()?.token {
             Token::Ident(ident) if ident.name().eq_ignore_ascii_case("using") => {
                 let content_block_params = input.parse::<SassIncludeContentBlockParams>()?;
                 span.end = content_block_params.span.end;
@@ -1228,7 +1232,7 @@ impl<'a> Parse<'a> for SassIncludeArgs<'a> {
 
 impl<'a> Parse<'a> for SassIncludeContentBlockParams<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match bump!(input) {
+        match input.cursor.bump()? {
             TokenWithSpan { token: Token::Ident(ident), span: using_span }
                 if ident.name().eq_ignore_ascii_case("using") =>
             {
@@ -1256,7 +1260,7 @@ impl<'a> Parse<'a> for SassInterpolatedStr<'a> {
         let mut is_parsing_static_part = false;
         loop {
             if is_parsing_static_part {
-                let (token, str_tpl_span) = input.tokenizer.scan_string_template(quote)?;
+                let (token, str_tpl_span) = input.cursor.tokenizer.scan_string_template(quote)?;
                 let tail = token.tail;
                 let end = str_tpl_span.end;
                 elements.push(SassInterpolatedStrElement::Static(
@@ -1285,7 +1289,7 @@ impl<'a> Parse<'a> for SassInterpolatedUrl<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
 
-        let (first, first_span) = match input.tokenizer.scan_url_raw_or_template()? {
+        let (first, first_span) = match input.cursor.tokenizer.scan_url_raw_or_template()? {
             TokenWithSpan { token: Token::UrlTemplate(template), span } => (template, span),
             TokenWithSpan { token, span } => {
                 return Err(Error {
@@ -1302,7 +1306,7 @@ impl<'a> Parse<'a> for SassInterpolatedUrl<'a> {
         loop {
             if is_parsing_static_part {
                 let (token, url_tpl_span @ Span { end, .. }) =
-                    input.tokenizer.scan_url_template()?;
+                    input.cursor.tokenizer.scan_url_template()?;
                 let tail = token.tail;
                 elements.push(SassInterpolatedUrlElement::Static(
                     input.interpolable_url_static_part(token, url_tpl_span),
@@ -1334,7 +1338,7 @@ impl<'a> Parse<'a> for SassList<'a> {
             Ok(list)
         } else {
             use crate::{token::Comma, tokenizer::TokenSymbol};
-            let TokenWithSpan { token, span } = bump!(input);
+            let TokenWithSpan { token, span } = input.cursor.bump()?;
             Err(Error { kind: ErrorKind::Unexpected(Comma::symbol(), token.symbol()), span })
         }
     }
@@ -1347,20 +1351,20 @@ impl<'a> Parse<'a> for SassMap<'a> {
         let mut items = input.vec();
         let mut comma_spans = input.vec();
         loop {
-            match peek!(input).token {
+            match input.cursor.peek()?.token {
                 Token::RParen(..) => break,
                 Token::Indent(..) | Token::Dedent(..) | Token::Linebreak(..) => {
-                    bump!(input);
+                    input.cursor.bump()?;
                 }
                 _ => {
                     items.push(input.parse()?);
                     if matches!(
-                        peek!(input).token,
+                        input.cursor.peek()?.token,
                         Token::Indent(..) | Token::Dedent(..) | Token::Linebreak(..)
                     ) {
-                        bump!(input);
+                        input.cursor.bump()?;
                     }
-                    if !matches!(&peek!(input).token, Token::RParen(..)) {
+                    if !matches!(&input.cursor.peek()?.token, Token::RParen(..)) {
                         comma_spans.push(expect!(input, Comma).1);
                     }
                 }
@@ -1392,7 +1396,7 @@ impl<'a> Parse<'a> for SassMixin<'a> {
         let start = name.span.start;
         let mut end = name.span.end;
 
-        let parameters = if matches!(peek!(input).token, Token::LParen(..)) {
+        let parameters = if matches!(input.cursor.peek()?.token, Token::LParen(..)) {
             let parameters = input.parse::<SassParameters>()?;
             end = parameters.span.end;
             Some(parameters)
@@ -1454,7 +1458,7 @@ impl<'a> Parse<'a> for SassUse<'a> {
         let path = input.parse::<InterpolableStr>()?;
         let mut span = path.span().clone();
 
-        let namespace = match &peek!(input).token {
+        let namespace = match &input.cursor.peek()?.token {
             Token::Ident(ident) if ident.name().eq_ignore_ascii_case("as") => {
                 let namespace = input.parse::<SassUseNamespace>()?;
                 span.end = namespace.span.end;
@@ -1474,18 +1478,18 @@ impl<'a> Parse<'a> for SassUse<'a> {
 
 impl<'a> Parse<'a> for SassUseNamespace<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        let as_span = match peek!(input) {
+        let as_span = match input.cursor.peek()? {
             TokenWithSpan { token: Token::Ident(ident), .. }
                 if ident.name().eq_ignore_ascii_case("as") =>
             {
-                bump!(input).span
+                input.cursor.bump()?.span
             }
             TokenWithSpan { span, .. } => {
                 return Err(Error { kind: ErrorKind::ExpectSassKeyword("as"), span: span.clone() });
             }
         };
         input.eat_sass_line_continuation()?;
-        match bump!(input) {
+        match input.cursor.bump()? {
             TokenWithSpan { token: Token::Asterisk(..), span: asterisk_span } => {
                 let span = Span { start: as_span.start, end: asterisk_span.end };
                 Ok(SassUseNamespace {
@@ -1527,7 +1531,7 @@ impl<'a> Parse<'a> for SassVariableDeclaration<'a> {
         let namespace = if let Some((ident_token, span)) = eat!(input, Ident) {
             let (_, dot_span) = expect!(input, Dot);
             util::assert_no_ws_or_comment(&span, &dot_span)?;
-            let TokenWithSpan { span: next_span, .. } = peek!(input);
+            let TokenWithSpan { span: next_span, .. } = input.cursor.peek()?;
             util::assert_no_ws_or_comment(&dot_span, next_span)?;
             Some(input.ident(ident_token, span))
         } else {

--- a/crates/oxc_css_parser/src/parser/selector.rs
+++ b/crates/oxc_css_parser/src/parser/selector.rs
@@ -2,9 +2,9 @@ use super::Parser;
 use crate::{
     Parse, Syntax,
     ast::*,
-    bump, eat,
+    eat,
     error::{Error, ErrorKind, PResult},
-    expect, expect_without_ws_or_comments, peek,
+    expect, expect_without_ws_or_comments,
     pos::{Span, Spanned},
     tokenizer::{Token, TokenWithSpan, token},
     util,
@@ -13,18 +13,18 @@ use crate::{
 // https://www.w3.org/TR/css-syntax-3/#the-anb-type
 impl<'a> Parse<'a> for AnPlusB {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match peek!(input) {
+        match input.cursor.peek()? {
             TokenWithSpan { token: Token::Dimension(..), .. } => {
                 let (token::Dimension { value, unit }, span) = expect!(input, Dimension);
                 let value_span = Span { start: span.start, end: span.start + value.raw.len() };
                 let unit_name = unit.name();
                 if unit_name.eq_ignore_ascii_case("n") {
-                    match &peek!(input).token {
+                    match &input.cursor.peek()?.token {
                         // syntax: <n-dimension> ['+' | '-'] <signless-integer>
                         // examples: '1n + 1', '1n - 1', '1n+ 1'
                         sign @ Token::Plus(..) | sign @ Token::Minus(..) => {
                             let sign = if let Token::Plus(..) = sign { 1 } else { -1 };
-                            bump!(input);
+                            input.cursor.bump()?;
                             let (number, number_span) = expect_unsigned_int(input)?;
                             let span = Span { start: span.start, end: number_span.end };
                             Ok(AnPlusB {
@@ -97,16 +97,16 @@ impl<'a> Parse<'a> for AnPlusB {
             }
 
             TokenWithSpan { token: Token::Plus(..), .. } => {
-                let plus_span = bump!(input).span;
+                let plus_span = input.cursor.bump()?.span;
                 let (ident, ident_span) = expect_without_ws_or_comments!(input, Ident);
                 let ident_name = ident.name();
                 if ident_name.eq_ignore_ascii_case("n") {
-                    match &peek!(input).token {
+                    match &input.cursor.peek()?.token {
                         // syntax: +n ['+' | '-'] <signless-integer>
                         // examples: '+n + 1', '+n - 1', '+n+ 1'
                         sign @ Token::Plus(..) | sign @ Token::Minus(..) => {
                             let sign = if let Token::Plus(..) = sign { 1 } else { -1 };
-                            bump!(input);
+                            input.cursor.bump()?;
                             let (number, number_span) = expect_unsigned_int(input)?;
                             let span = Span { start: plus_span.start, end: number_span.end };
                             Ok(AnPlusB {
@@ -180,12 +180,12 @@ impl<'a> Parse<'a> for AnPlusB {
                 let (ident, ident_span) = expect!(input, Ident);
                 let ident_name = ident.name();
                 if ident_name.eq_ignore_ascii_case("n") {
-                    match &peek!(input).token {
+                    match &input.cursor.peek()?.token {
                         // syntax: n ['+' | '-'] <signless-integer>
                         // examples: 'n + 1', 'n - 1', 'n+ 1'
                         sign @ Token::Plus(..) | sign @ Token::Minus(..) => {
                             let sign = if let Token::Plus(..) = sign { 1 } else { -1 };
-                            bump!(input);
+                            input.cursor.bump()?;
                             let (number, number_span) = expect_unsigned_int(input)?;
                             let span = Span { start: ident_span.start, end: number_span.end };
                             Ok(AnPlusB {
@@ -240,12 +240,12 @@ impl<'a> Parse<'a> for AnPlusB {
                     })?;
                     Ok(AnPlusB { a: 1, b: -b, span: ident_span })
                 } else if ident_name.eq_ignore_ascii_case("-n") {
-                    match &peek!(input).token {
+                    match &input.cursor.peek()?.token {
                         // syntax: -n ['+' | '-'] <signless-integer>
                         // examples: '-n + 1', '-n - 1', '-n+ 1'
                         sign @ Token::Plus(..) | sign @ Token::Minus(..) => {
                             let sign = if let Token::Plus(..) = sign { 1 } else { -1 };
-                            bump!(input);
+                            input.cursor.bump()?;
                             let (number, number_span) = expect_unsigned_int(input)?;
                             let span = Span { start: ident_span.start, end: number_span.end };
                             Ok(AnPlusB {
@@ -315,7 +315,7 @@ impl<'a> Parse<'a> for AttributeSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let start = expect!(input, LBracket).1.start;
 
-        let name = match peek!(input) {
+        let name = match input.cursor.peek()? {
             TokenWithSpan {
                 token: Token::Ident(..) | Token::HashLBrace(..) | Token::AtLBraceVar(..),
                 ..
@@ -342,7 +342,7 @@ impl<'a> Parse<'a> for AttributeSelector<'a> {
                 }
             }
             TokenWithSpan { token: Token::Asterisk(..), .. } => {
-                let asterisk_span = bump!(input).span;
+                let asterisk_span = input.cursor.bump()?.span;
                 let bar_token_span = expect!(input, Bar).1;
                 let name = input.parse::<InterpolableIdent>()?;
 
@@ -360,7 +360,7 @@ impl<'a> Parse<'a> for AttributeSelector<'a> {
                 }
             }
             TokenWithSpan { token: Token::Bar(..), .. } => {
-                let bar_token_span = bump!(input).span;
+                let bar_token_span = input.cursor.bump()?.span;
                 let name = input.parse::<InterpolableIdent>()?;
 
                 let start = bar_token_span.start;
@@ -379,32 +379,32 @@ impl<'a> Parse<'a> for AttributeSelector<'a> {
             }
         };
 
-        let matcher = match peek!(input) {
+        let matcher = match input.cursor.peek()? {
             TokenWithSpan { token: Token::RBracket(..), .. } => None,
             TokenWithSpan { token: Token::Equal(..), .. } => Some(AttributeSelectorMatcher {
                 kind: AttributeSelectorMatcherKind::Exact,
-                span: bump!(input).span,
+                span: input.cursor.bump()?.span,
             }),
             TokenWithSpan { token: Token::TildeEqual(..), .. } => Some(AttributeSelectorMatcher {
                 kind: AttributeSelectorMatcherKind::MatchWord,
-                span: bump!(input).span,
+                span: input.cursor.bump()?.span,
             }),
             TokenWithSpan { token: Token::BarEqual(..), .. } => Some(AttributeSelectorMatcher {
                 kind: AttributeSelectorMatcherKind::ExactOrPrefixThenHyphen,
-                span: bump!(input).span,
+                span: input.cursor.bump()?.span,
             }),
             TokenWithSpan { token: Token::CaretEqual(..), .. } => Some(AttributeSelectorMatcher {
                 kind: AttributeSelectorMatcherKind::Prefix,
-                span: bump!(input).span,
+                span: input.cursor.bump()?.span,
             }),
             TokenWithSpan { token: Token::DollarEqual(..), .. } => Some(AttributeSelectorMatcher {
                 kind: AttributeSelectorMatcherKind::Suffix,
-                span: bump!(input).span,
+                span: input.cursor.bump()?.span,
             }),
             TokenWithSpan { token: Token::AsteriskEqual(..), .. } => {
                 Some(AttributeSelectorMatcher {
                     kind: AttributeSelectorMatcherKind::Substring,
-                    span: bump!(input).span,
+                    span: input.cursor.bump()?.span,
                 })
             }
             TokenWithSpan { span, .. } => {
@@ -416,7 +416,7 @@ impl<'a> Parse<'a> for AttributeSelector<'a> {
         };
 
         let value = if matcher.is_some() {
-            match peek!(input) {
+            match input.cursor.peek()? {
                 TokenWithSpan {
                     token:
                         Token::Ident(..)
@@ -458,8 +458,11 @@ impl<'a> Parse<'a> for AttributeSelector<'a> {
                 TokenWithSpan { span, .. } if input.syntax == Syntax::Css => {
                     let start = span.start;
                     let mut tokens = input.vec();
-                    while !matches!(peek!(input).token, Token::RBracket(..) | Token::Eof(..)) {
-                        tokens.push(bump!(input));
+                    while !matches!(
+                        input.cursor.peek()?.token,
+                        Token::RBracket(..) | Token::Eof(..)
+                    ) {
+                        tokens.push(input.cursor.bump()?);
                     }
                     let end = tokens.last().map_or(start, |t| t.span.end);
                     Some(AttributeSelectorValue::TokenSeq(TokenSeq {
@@ -479,7 +482,7 @@ impl<'a> Parse<'a> for AttributeSelector<'a> {
         };
 
         let modifier = if value.is_some() {
-            match &peek!(input).token {
+            match &input.cursor.peek()?.token {
                 Token::Ident(..) | Token::HashLBrace(..) => {
                     let ident = input.parse::<InterpolableIdent>()?;
                     let span = ident.span().clone();
@@ -501,14 +504,14 @@ impl<'a> Parse<'a> for ClassSelector<'a> {
         let (_, dot_span) = expect!(input, Dot);
         let start = dot_span.start;
         let end;
-        // Detect an adjacent placeholder without `peek!`: `peek!` skips
+        // Detect an adjacent placeholder without `peek()`: `peek()` skips
         // whitespace and caches a token, which would both break the no-ws rule
         // (the name must immediately follow the dot) and trip the empty-cache
         // assertion in the `expect_without_ws_or_comments!` fallback. `scan_placeholder`
         // returns `None` (leaving the tokenizer untouched) unless a placeholder
         // begins exactly here, so the fallback paths run with an empty cache.
         let placeholder = if input.options.template_placeholder.is_some() {
-            input.tokenizer.scan_placeholder()
+            input.cursor.tokenizer.scan_placeholder()
         } else {
             None
         };
@@ -540,15 +543,16 @@ impl<'a> Parse<'a> for ComplexSelector<'a> {
         let (span, first, mut is_previous_combinator) = if let Token::GreaterThan(..)
         | Token::Plus(..)
         | Token::Tilde(..)
-        | Token::BarBar(..) = peek!(input).token
+        | Token::BarBar(..) =
+            input.cursor.peek()?.token
         {
-            let end = input.tokenizer.current_offset();
+            let end = input.cursor.tokenizer.current_offset();
             if let Some(combinator) = input.parse_combinator(end)? {
                 (combinator.span.clone(), ComplexSelectorChild::Combinator(combinator), true)
             } else {
                 return Err(Error {
                     kind: ErrorKind::ExpectSimpleSelector,
-                    span: bump!(input).span,
+                    span: input.cursor.bump()?.span,
                 });
             }
         } else {
@@ -564,7 +568,7 @@ impl<'a> Parse<'a> for ComplexSelector<'a> {
         children.push(first);
         let is_less = input.syntax == Syntax::Less;
         while !matches!(
-            peek!(input).token,
+            input.cursor.peek()?.token,
             Token::LBrace(..) | Token::Indent(..) | Token::Linebreak(..)
         ) {
             if is_previous_combinator {
@@ -574,7 +578,7 @@ impl<'a> Parse<'a> for ComplexSelector<'a> {
                 // compound selector. CSS keeps the strict alternation.
                 if matches!(input.syntax, Syntax::Scss | Syntax::Sass) {
                     if matches!(
-                        peek!(input).token,
+                        input.cursor.peek()?.token,
                         Token::GreaterThan(..)
                             | Token::Plus(..)
                             | Token::Tilde(..)
@@ -585,7 +589,7 @@ impl<'a> Parse<'a> for ComplexSelector<'a> {
                         children.push(ComplexSelectorChild::Combinator(combinator));
                         continue;
                     } else if matches!(
-                        peek!(input).token,
+                        input.cursor.peek()?.token,
                         Token::RParen(..) | Token::Comma(..) | Token::RBrace(..) | Token::Eof(..)
                     ) {
                         break;
@@ -596,7 +600,7 @@ impl<'a> Parse<'a> for ComplexSelector<'a> {
                 children.push(ComplexSelectorChild::CompoundSelector(compound_selector));
             } else if let Some(combinator) = input.parse_combinator(end)? {
                 if is_less && combinator.kind == CombinatorKind::Descendant {
-                    match &peek!(input).token {
+                    match &input.cursor.peek()?.token {
                         Token::Ident(ident) if ident.raw == "when" => break,
                         _ => {}
                     }
@@ -623,7 +627,7 @@ impl<'a> Parse<'a> for CompoundSelector<'a> {
         children.push(first);
         loop {
             use token::*;
-            match peek!(input) {
+            match input.cursor.peek()? {
                 TokenWithSpan {
                     token:
                         Token::Dot(..)
@@ -691,7 +695,7 @@ impl<'a> Parse<'a> for CompoundSelectorList<'a> {
 
 impl<'a> Parse<'a> for IdSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match bump!(input) {
+        match input.cursor.bump()? {
             TokenWithSpan { token: Token::Hash(token), span } => {
                 let first_span = Span { start: span.start + 1, end: span.end };
                 let raw = token.raw;
@@ -708,7 +712,7 @@ impl<'a> Parse<'a> for IdSelector<'a> {
                     raw
                 };
                 let first = Ident { name: value, raw: token.raw, span: first_span };
-                let name = match peek!(input) {
+                let name = match input.cursor.peek()? {
                     TokenWithSpan { token: Token::HashLBrace(..), span }
                         if matches!(input.syntax, Syntax::Scss | Syntax::Sass)
                             && first.span.end == span.start =>
@@ -747,7 +751,7 @@ impl<'a> Parse<'a> for IdSelector<'a> {
 
 impl<'a> Parse<'a> for LanguageRange<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match &peek!(input).token {
+        match &input.cursor.peek()?.token {
             Token::Str(..) | Token::StrTemplate(..) => input.parse().map(LanguageRange::Str),
             _ => input.parse().map(LanguageRange::Ident),
         }
@@ -779,7 +783,7 @@ impl<'a> Parse<'a> for NestingSelector<'a> {
         let (_, mut span) = expect!(input, Ampersand);
         let suffix = match input.syntax {
             Syntax::Css => {
-                if let Some((ident, ident_span)) = input.tokenizer.scan_ident_template()? {
+                if let Some((ident, ident_span)) = input.cursor.tokenizer.scan_ident_template()? {
                     span.end = ident_span.end;
                     Some(InterpolableIdent::Literal(input.ident(ident, ident_span)))
                 } else {
@@ -820,7 +824,7 @@ impl<'a> Parse<'a> for Nth<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let index = input.parse::<NthIndex>()?;
         let mut span = index.span().clone();
-        let matcher = match &peek!(input).token {
+        let matcher = match &input.cursor.peek()?.token {
             Token::Ident(ident) if ident.name().eq_ignore_ascii_case("of") => {
                 let matcher = input.parse::<NthMatcher>()?;
                 span.end = matcher.span.end;
@@ -835,7 +839,7 @@ impl<'a> Parse<'a> for Nth<'a> {
 
 impl<'a> Parse<'a> for NthIndex<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match &peek!(input).token {
+        match &input.cursor.peek()?.token {
             Token::Ident(ident) => {
                 let name = ident.name();
                 if name.eq_ignore_ascii_case("odd") {
@@ -866,7 +870,7 @@ impl<'a> Parse<'a> for NthMatcher<'a> {
             return Err(Error { kind: ErrorKind::ExpectNthOf, span });
         }
 
-        let selector = if matches!(&peek!(input).token, Token::RParen(..)) {
+        let selector = if matches!(&input.cursor.peek()?.token, Token::RParen(..)) {
             None
         } else {
             let selector = input.parse::<SelectorList>()?;
@@ -887,10 +891,10 @@ impl<'a> Parse<'a> for PseudoClassSelector<'a> {
 
         let mut end = name_span.end;
 
-        let arg = match peek!(input) {
+        let arg = match input.cursor.peek()? {
             TokenWithSpan { token: Token::LParen(..), span: l_paren } if l_paren.start == end => {
                 let l_paren = l_paren.clone();
-                bump!(input);
+                input.cursor.bump()?;
                 let kind = match &name {
                     InterpolableIdent::Literal(Ident { name, .. })
                         if name.eq_ignore_ascii_case("nth-child")
@@ -1015,10 +1019,10 @@ impl<'a> Parse<'a> for PseudoElementSelector<'a> {
             name
         };
 
-        let arg = match peek!(input) {
+        let arg = match input.cursor.peek()? {
             TokenWithSpan { token: Token::LParen(..), span: l_paren } if l_paren.start == end => {
                 let l_paren = l_paren.clone();
-                bump!(input);
+                input.cursor.bump()?;
                 let kind = match &name {
                     InterpolableIdent::Literal(Ident { name, .. })
                         if name.eq_ignore_ascii_case("part") =>
@@ -1058,7 +1062,7 @@ impl<'a> Parse<'a> for PseudoElementSelector<'a> {
 
 impl<'a> Parse<'a> for RelativeSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        let pos = input.tokenizer.current_offset();
+        let pos = input.cursor.tokenizer.current_offset();
         let combinator = match input.parse_combinator(pos)? {
             Some(Combinator { kind: CombinatorKind::Descendant, .. }) => None,
             combinator => combinator,
@@ -1117,11 +1121,13 @@ impl<'a> Parse<'a> for SelectorList<'a> {
             // In the indented syntax a deeper line after the comma continues
             // the selector list (`a,\n    b\n  c: d`); a same-level line or
             // `{` means the comma was trailing.
-            if input.syntax == Syntax::Sass && matches!(peek!(input).token, Token::Indent(..)) {
+            if input.syntax == Syntax::Sass
+                && matches!(input.cursor.peek()?.token, Token::Indent(..))
+            {
                 input.eat_sass_line_continuation()?;
             } else if !is_css
                 && matches!(
-                    peek!(input).token,
+                    input.cursor.peek()?.token,
                     Token::LBrace(..) | Token::Indent(..) | Token::Linebreak(..)
                 )
             {
@@ -1148,7 +1154,7 @@ impl<'a> Parse<'a> for SelectorList<'a> {
 // https://www.w3.org/TR/selectors-4/#ref-for-typedef-simple-selector
 impl<'a> Parse<'a> for SimpleSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match peek!(input) {
+        match input.cursor.peek()? {
             TokenWithSpan { token: Token::Dot(..), .. } => input.parse().map(SimpleSelector::Class),
             TokenWithSpan { token: Token::Hash(..) | Token::NumberSign(..), .. } => {
                 input.parse().map(SimpleSelector::Id)
@@ -1202,16 +1208,16 @@ impl<'a> Parse<'a> for TypeSelector<'a> {
             Asterisk(Span),
         }
 
-        let ident_or_asterisk = match &peek!(input).token {
+        let ident_or_asterisk = match &input.cursor.peek()?.token {
             Token::Ident(..) | Token::HashLBrace(..) | Token::AtLBraceVar(..) => {
                 input.parse().map(IdentOrAsterisk::Ident).map(Some)?
             }
-            Token::Asterisk(..) => Some(IdentOrAsterisk::Asterisk(bump!(input).span)),
+            Token::Asterisk(..) => Some(IdentOrAsterisk::Asterisk(input.cursor.bump()?.span)),
             Token::Bar(..) => None,
             _ => unreachable!(),
         };
 
-        match peek!(input) {
+        match input.cursor.peek()? {
             TokenWithSpan { token: Token::Bar(..), span }
                 if ident_or_asterisk
                     .as_ref()
@@ -1225,7 +1231,7 @@ impl<'a> Parse<'a> for TypeSelector<'a> {
                     })
                     .unwrap_or(true) =>
             {
-                let bar_token_span = bump!(input).span;
+                let bar_token_span = input.cursor.bump()?.span;
 
                 let prefix = match ident_or_asterisk {
                     Some(IdentOrAsterisk::Ident(ident)) => {
@@ -1246,7 +1252,7 @@ impl<'a> Parse<'a> for TypeSelector<'a> {
                     None => NsPrefix { kind: None, span: bar_token_span },
                 };
 
-                match peek!(input) {
+                match input.cursor.peek()? {
                     TokenWithSpan { token: Token::Ident(..) | Token::HashLBrace(..), .. } => {
                         let name = input.parse::<InterpolableIdent>()?;
                         let name_span = name.span();
@@ -1258,7 +1264,7 @@ impl<'a> Parse<'a> for TypeSelector<'a> {
                         }))
                     }
                     TokenWithSpan { token: Token::Asterisk(..), .. } => {
-                        let asterisk_span = bump!(input).span;
+                        let asterisk_span = input.cursor.bump()?.span;
                         util::assert_no_ws(input.source, &prefix.span, &asterisk_span)?;
                         let span = Span { start: prefix.span.start, end: asterisk_span.end };
                         Ok(TypeSelector::Universal(UniversalSelector {
@@ -1291,7 +1297,7 @@ impl<'a> Parse<'a> for TypeSelector<'a> {
 
 impl<'a> Parser<'a> {
     fn parse_combinator(&mut self, pos: usize) -> PResult<Option<Combinator>> {
-        match peek!(self) {
+        match self.cursor.peek()? {
             TokenWithSpan {
                 token:
                     Token::Ident(..)
@@ -1321,28 +1327,28 @@ impl<'a> Parser<'a> {
                 ..
             } => Ok(Some(Combinator {
                 kind: CombinatorKind::Child,
-                span: bump!(self).span,
+                span: self.cursor.bump()?.span,
             })),
             TokenWithSpan {
                 token: Token::Plus(..),
                 ..
             } => Ok(Some(Combinator {
                 kind: CombinatorKind::NextSibling,
-                span: bump!(self).span,
+                span: self.cursor.bump()?.span,
             })),
             TokenWithSpan {
                 token: Token::Tilde(..),
                 ..
             } => Ok(Some(Combinator {
                 kind: CombinatorKind::LaterSibling,
-                span: bump!(self).span,
+                span: self.cursor.bump()?.span,
             })),
             TokenWithSpan {
                 token: Token::BarBar(..),
                 ..
             } => Ok(Some(Combinator {
                 kind: CombinatorKind::Column,
-                span: bump!(self).span,
+                span: self.cursor.bump()?.span,
             })),
             // deprecated shadow-piercing `/deep/` and less.js's arbitrary
             // slashed combinators (`.container /shadow/ .content`) — but not
@@ -1351,12 +1357,12 @@ impl<'a> Parser<'a> {
                 if !matches!(self.syntax, Syntax::Scss | Syntax::Sass) =>
             {
                 let deep = self.try_parse(|p| {
-                    let start = bump!(p).span; // `/`
-                    let ident_end = match peek!(p) {
+                    let start = p.cursor.bump()?.span; // `/`
+                    let ident_end = match p.cursor.peek()? {
                         TokenWithSpan { token: Token::Ident(..), span }
                             if span.start == start.end =>
                         {
-                            bump!(p).span.end
+                            p.cursor.bump()?.span.end
                         }
                         TokenWithSpan { span, .. } => {
                             return Err(Error {
@@ -1365,11 +1371,11 @@ impl<'a> Parser<'a> {
                             });
                         }
                     };
-                    match peek!(p) {
+                    match p.cursor.peek()? {
                         TokenWithSpan { token: Token::Solidus(..), span }
                             if span.start == ident_end =>
                         {
-                            let end = bump!(p).span.end;
+                            let end = p.cursor.bump()?.span.end;
                             Ok(Span { start: start.start, end })
                         }
                         TokenWithSpan { span, .. } => Err(Error {
@@ -1391,12 +1397,12 @@ impl<'a> Parser<'a> {
             } if !matches!(self.syntax, Syntax::Scss | Syntax::Sass)
                 && self.source.as_bytes().get(span.start) == Some(&b'^') =>
             {
-                let start = bump!(self).span.start;
-                if matches!(&peek!(self).token, Token::Unknown(..))
-                    && peek!(self).span.start == start + 1
+                let start = self.cursor.bump()?.span.start;
+                if matches!(&self.cursor.peek()?.token, Token::Unknown(..))
+                    && self.cursor.peek()?.span.start == start + 1
                     && self.source.as_bytes().get(start + 1) == Some(&b'^')
                 {
-                    let end = bump!(self).span.end;
+                    let end = self.cursor.bump()?.span.end;
                     Ok(Some(Combinator {
                         kind: CombinatorKind::ShadowDescendant,
                         span: Span { start, end },

--- a/crates/oxc_css_parser/src/parser/stmt.rs
+++ b/crates/oxc_css_parser/src/parser/stmt.rs
@@ -5,9 +5,9 @@ use super::{
 use crate::{
     Parse, Syntax,
     ast::*,
-    bump, eat,
+    eat,
     error::{Error, ErrorKind, PResult},
-    expect, peek,
+    expect,
     pos::{Span, Spanned},
     tokenizer::{Token, TokenWithSpan},
 };
@@ -20,7 +20,7 @@ impl<'a> Parse<'a> for Declaration<'a> {
         // when glued: `* color` (whitespace or a comment after the sigil) is
         // not the hack, so leave the token for the normal (failing) parse.
         let mut name_prefix = if input.state.allow_ie_star_hack
-            && let TokenWithSpan { token, span } = peek!(input)
+            && let TokenWithSpan { token, span } = input.cursor.peek()?
             && let Some(prefix) = match token {
                 Token::Asterisk(..) => Some('*'),
                 Token::Dot(..) if input.syntax == Syntax::Css => Some('.'),
@@ -34,32 +34,32 @@ impl<'a> Parse<'a> for Declaration<'a> {
                 .is_some_and(|b| !b.is_ascii_whitespace() && *b != b'/')
         {
             let start = span.start;
-            bump!(input);
+            input.cursor.bump()?;
             Some((start, prefix))
         } else {
             None
         };
         // A css-in-js `${}` placeholder may stand in for the property name
         // (`${foo}: ${bar}`); it is not a real ident, so accept it directly.
-        let name = if let Token::Placeholder(..) = peek!(input).token {
+        let name = if let Token::Placeholder(..) = input.cursor.peek()?.token {
             let (placeholder, span) = expect!(input, Placeholder);
             InterpolableIdent::Placeholder((placeholder, span).into())
         } else if input.state.allow_ie_star_hack
             && input.syntax == Syntax::Less
-            && let TokenWithSpan { token: Token::Number(number), span } = peek!(input)
+            && let TokenWithSpan { token: Token::Number(number), span } = input.cursor.peek()?
             && number.raw.bytes().all(|b| b.is_ascii_digit())
         {
             let raw = number.raw;
             let span = span.clone();
-            bump!(input);
+            input.cursor.bump()?;
             InterpolableIdent::Literal(Ident { name: raw, raw, span })
         } else if name_prefix.is_none()
             && input.state.allow_ie_star_hack
             && input.syntax == Syntax::Css
-            && matches!(peek!(input).token, Token::Hash(..))
+            && matches!(input.cursor.peek()?.token, Token::Hash(..))
         {
             // `#x: y` — the `#` and the name arrive as one <hash-token>.
-            let TokenWithSpan { token: Token::Hash(hash), span } = bump!(input) else {
+            let TokenWithSpan { token: Token::Hash(hash), span } = input.cursor.bump()? else {
                 unreachable!()
             };
             name_prefix = Some((span.start, '#'));
@@ -83,10 +83,11 @@ impl<'a> Parse<'a> for Declaration<'a> {
         };
 
         // https://tailwindcss.com/docs/theme#overriding-the-default-theme
-        let name_suffix = if let TokenWithSpan { token: Token::Asterisk(..), span } = peek!(input)
+        let name_suffix = if let TokenWithSpan { token: Token::Asterisk(..), span } =
+            input.cursor.peek()?
             && name.span().end == span.start
         {
-            bump!(input);
+            input.cursor.bump()?;
             Some('*')
         } else {
             None
@@ -107,7 +108,7 @@ impl<'a> Parse<'a> for Declaration<'a> {
                 InterpolableIdent::Literal(ident)
                     if ident.name.starts_with("--")
                         || matches!(
-                            &peek!(parser).token,
+                            &parser.cursor.peek()?.token,
                             // for IE-compatibility, regardless of the property
                             // name (`filter`, `-ms-filter`, vendor variants...):
                             // filter: progid:DXImageTransform.Microsoft...
@@ -137,11 +138,11 @@ impl<'a> Parse<'a> for Declaration<'a> {
                 {
                     let typed = parser.try_parse(|p| {
                         let values = p.parse_declaration_value()?;
-                        let important = match &peek!(p).token {
+                        let important = match &p.cursor.peek()?.token {
                             Token::Exclamation(..) => Some(p.parse::<ImportantAnnotation>()?),
                             _ => None,
                         };
-                        let next = peek!(p);
+                        let next = p.cursor.peek()?;
                         if at_declaration_value_end(&next.token) {
                             Ok((values, important))
                         } else {
@@ -161,7 +162,7 @@ impl<'a> Parse<'a> for Declaration<'a> {
                             // disambiguation) and the declaration is rejected.
                             let in_fn_body = parser.state.in_css_function_body;
                             let values = parser.parse_declaration_value_tokens(!in_fn_body)?;
-                            if !in_fn_body && let Token::LBrace(..) = &peek!(parser).token {
+                            if !in_fn_body && let Token::LBrace(..) = &parser.cursor.peek()?.token {
                                 return Err(error);
                             }
                             (values, None)
@@ -173,7 +174,7 @@ impl<'a> Parse<'a> for Declaration<'a> {
         };
 
         if important.is_none()
-            && let Token::Exclamation(..) = &peek!(input).token
+            && let Token::Exclamation(..) = &input.cursor.peek()?.token
         {
             important = Some(input.parse::<ImportantAnnotation>()?);
         }
@@ -182,7 +183,7 @@ impl<'a> Parse<'a> for Declaration<'a> {
         // another component, and only a trailing one is structural.
         while matches!(input.syntax, Syntax::Scss | Syntax::Sass)
             && important.is_some()
-            && !at_declaration_value_end(&peek!(input).token)
+            && !at_declaration_value_end(&input.cursor.peek()?.token)
         {
             if let Some(annotation) = important.take() {
                 value.push(ComponentValue::ImportantAnnotation(annotation));
@@ -196,7 +197,7 @@ impl<'a> Parse<'a> for Declaration<'a> {
             for component in more {
                 value.push(component);
             }
-            if let Token::Exclamation(..) = &peek!(input).token {
+            if let Token::Exclamation(..) = &input.cursor.peek()?.token {
                 important = Some(input.parse::<ImportantAnnotation>()?);
             }
         }
@@ -277,19 +278,19 @@ impl<'a> Parse<'a> for SimpleBlock<'a> {
                 span.end
             } else if drained
                 && input.sass_pending_indents == 0
-                && input.tokenizer.reopen_indent_level()
+                && input.cursor.tokenizer.reopen_indent_level()
             {
                 // The block's level sat between two known indents, so its
                 // `Indent` was never emitted; re-open it directly.
-                peek!(input).span.start
+                input.cursor.peek()?.span.start
             } else if input.sass_pending_indents > 0 {
                 // The statement's clause consumed this block's `Indent` as a
                 // line continuation (`@each $a in\n  b, c\n  .x\n    ...`);
                 // enter the block "virtually" at that depth.
                 input.sass_pending_indents -= 1;
-                peek!(input).span.start
+                input.cursor.peek()?.span.start
             } else {
-                let offset = peek!(input).span.start;
+                let offset = input.cursor.peek()?.span.start;
                 return Ok(SimpleBlock {
                     statements: input.vec(),
                     span: Span { start: offset, end: offset },
@@ -304,13 +305,13 @@ impl<'a> Parse<'a> for SimpleBlock<'a> {
         // CSS Syntax: EOF closes all open constructs (a parse error, but the
         // tree is valid — browsers accept unclosed blocks at EOF). The
         // dialects' reference compilers reject them.
-        if input.syntax == Syntax::Css && matches!(peek!(input).token, Token::Eof(..)) {
-            let end = peek!(input).span.start;
+        if input.syntax == Syntax::Css && matches!(input.cursor.peek()?.token, Token::Eof(..)) {
+            let end = input.cursor.peek()?.span.start;
             return Ok(SimpleBlock { statements, span: Span { start, end } });
         }
 
         if is_sass {
-            match bump!(input) {
+            match input.cursor.bump()? {
                 TokenWithSpan { token: Token::Dedent(..) | Token::Eof(..), span } => {
                     let end = statements.last().map_or(span.start, |last| last.span().end);
                     Ok(SimpleBlock { statements, span: Span { start, end } })
@@ -351,7 +352,7 @@ impl<'a> Parser<'a> {
         let mut values = self.vec_with_capacity(3);
         let mut pairs = Vec::with_capacity(1);
         loop {
-            match &peek!(self).token {
+            match &self.cursor.peek()?.token {
                 Token::Dedent(..) | Token::Linebreak(..) | Token::Eof(..) => break,
                 Token::Semicolon(..) if pairs.is_empty() => {
                     break;
@@ -374,7 +375,7 @@ impl<'a> Parser<'a> {
                     }
                 }
             }
-            values.push(ComponentValue::TokenWithSpan(bump!(self)));
+            values.push(ComponentValue::TokenWithSpan(self.cursor.bump()?));
         }
         Ok(values)
     }
@@ -384,7 +385,7 @@ impl<'a> Parser<'a> {
     ) -> PResult<oxc_allocator::Vec<'a, ComponentValue<'a>>> {
         let mut values = self.vec_with_capacity(3);
         loop {
-            match &peek!(self).token {
+            match &self.cursor.peek()?.token {
                 Token::RBrace(..)
                 | Token::RParen(..)
                 | Token::Semicolon(..)
@@ -468,7 +469,7 @@ impl<'a> Parser<'a> {
             // next statement may follow directly (`${mixin}\n@media {...}`,
             // `${a} ${b}`, `${foo}: ${bar}`).
             let mut is_block_element = false;
-            let TokenWithSpan { token, span } = peek!(self);
+            let TokenWithSpan { token, span } = self.cursor.peek()?;
             match token {
                 Token::Ident(..) | Token::HashLBrace(..) | Token::AtLBraceVar(..) => {
                     match self.syntax {
@@ -576,7 +577,7 @@ impl<'a> Parser<'a> {
                 | Token::NumberSign(..)
                     if !self.state.in_keyframes_at_rule =>
                 {
-                    if matches!(peek!(self).token, Token::Asterisk(..)) {
+                    if matches!(self.cursor.peek()?.token, Token::Asterisk(..)) {
                         // `*color: red` / `*zoom: 1` (an IE<=7 hack) looks like a `*`
                         // universal selector but is a declaration; try the rule, then
                         // fall back to a declaration. (A `*` never starts a
@@ -608,7 +609,7 @@ impl<'a> Parser<'a> {
                             is_block_element = true;
                         }
                     } else if self.syntax == Syntax::Css
-                        && matches!(peek!(self).token, Token::Colon(..))
+                        && matches!(self.cursor.peek()?.token, Token::Colon(..))
                     {
                         let (stmt, is_block) = self.parse_rule_or_declaration(is_top_level)?;
                         is_block_element = is_block;
@@ -636,7 +637,7 @@ impl<'a> Parser<'a> {
                             "else" => {
                                 return Err(Error {
                                     kind: ErrorKind::UnexpectedSassElseAtRule,
-                                    span: bump!(self).span,
+                                    span: self.cursor.bump()?.span,
                                 });
                             }
                             _ => {
@@ -680,7 +681,7 @@ impl<'a> Parser<'a> {
                     // A placeholder may also be a declaration property name
                     // (`${foo}: ${bar}`), so try a declaration before falling back
                     // to a bare placeholder statement.
-                    let ph_end = peek!(self).span.end;
+                    let ph_end = self.cursor.peek()?.span.end;
                     if self.placeholder_starts_qualified_rule(ph_end)
                         && let Ok(rule) = self.try_parse(QualifiedRule::parse)
                     {
@@ -717,7 +718,7 @@ impl<'a> Parser<'a> {
                 // A spaced `+ b` stays a sibling-combinator selector: `+` is
                 // an include only when glued to an identifier.
                 Token::Equal(..) if self.syntax == Syntax::Sass => {
-                    let eq_span = bump!(self).span;
+                    let eq_span = self.cursor.bump()?.span;
                     self.eat_sass_line_continuation()?;
                     let prelude = self.parse::<SassMixin>()?;
                     let block = self
@@ -740,21 +741,23 @@ impl<'a> Parser<'a> {
                     if self.syntax == Syntax::Sass
                         && crate::tokenizer::ident_starts_at(self.source, span.end) =>
                 {
-                    let plus_span = bump!(self).span;
+                    let plus_span = self.cursor.bump()?.span;
                     let prelude = self.parse::<SassInclude>()?;
-                    let block =
-                        if matches!(peek!(self).token, Token::LBrace(..) | Token::Indent(..)) {
-                            Some(
-                                self.with_state(ParserState {
-                                    sass_ctx: self.state.sass_ctx
-                                        | super::state::SASS_CTX_ALLOW_KEYFRAME_BLOCK,
-                                    ..self.state.clone()
-                                })
-                                .parse::<SimpleBlock>()?,
-                            )
-                        } else {
-                            None
-                        };
+                    let block = if matches!(
+                        self.cursor.peek()?.token,
+                        Token::LBrace(..) | Token::Indent(..)
+                    ) {
+                        Some(
+                            self.with_state(ParserState {
+                                sass_ctx: self.state.sass_ctx
+                                    | super::state::SASS_CTX_ALLOW_KEYFRAME_BLOCK,
+                                ..self.state.clone()
+                            })
+                            .parse::<SimpleBlock>()?,
+                        )
+                    } else {
+                        None
+                    };
                     let end = block.as_ref().map_or(prelude.span.end, |block| block.span.end);
                     let span = Span { start: plus_span.start, end };
                     is_block_element = block.is_some();
@@ -777,7 +780,7 @@ impl<'a> Parser<'a> {
                     statements.push(self.parse().map(Statement::Declaration)?);
                 }
                 Token::Cdo(..) | Token::Cdc(..) => {
-                    bump!(self);
+                    self.cursor.bump()?;
                     continue;
                 }
                 Token::At(..) if matches!(self.syntax, Syntax::Scss | Syntax::Sass) => {
@@ -797,7 +800,7 @@ impl<'a> Parser<'a> {
                 }
                 Token::RBrace(..) | Token::Eof(..) | Token::Dedent(..) => break,
                 Token::Semicolon(..) | Token::Linebreak(..) => {
-                    bump!(self);
+                    self.cursor.bump()?;
                     continue;
                 }
                 Token::LBrace(..) if self.syntax == Syntax::Css => {
@@ -837,7 +840,7 @@ impl<'a> Parser<'a> {
             if self.drain_sass_pending_dedents()? {
                 continue;
             }
-            match &peek!(self).token {
+            match &self.cursor.peek()?.token {
                 Token::RBrace(..) | Token::Eof(..) | Token::Dedent(..) => break,
                 _ => {
                     if self.syntax == Syntax::Sass {

--- a/crates/oxc_css_parser/src/parser/token_seq.rs
+++ b/crates/oxc_css_parser/src/parser/token_seq.rs
@@ -2,25 +2,23 @@ use super::Parser;
 use crate::{
     Syntax,
     ast::*,
-    bump,
     error::{Error, ErrorKind, PResult},
-    peek,
     pos::Span,
     tokenizer::{Token, TokenWithSpan},
 };
 
 impl<'a> Parser<'a> {
     pub(super) fn parse_tokens_in_parens(&mut self) -> PResult<TokenSeq<'a>> {
-        let start = self.tokenizer.current_offset();
+        let start = self.cursor.tokenizer.current_offset();
         let mut tokens = self.vec_with_capacity(1);
         let mut pairs = Vec::with_capacity(1);
         loop {
-            match &peek!(self).token {
+            match &self.cursor.peek()?.token {
                 // A stray delimiter is a plain token in CSS, but the
                 // preprocessor dialects give it real syntax (`$var`, Less
                 // `^`), and their reference compilers reject it here.
                 Token::Unknown(..) if self.syntax != Syntax::Css => {
-                    let span = peek!(self).span.clone();
+                    let span = self.cursor.peek()?.span.clone();
                     return Err(Error { kind: ErrorKind::UnknownToken, span });
                 }
                 // An interpolated string (`("min-width:#{$foo}")`) must be
@@ -37,14 +35,14 @@ impl<'a> Parser<'a> {
                     }
                 }
             }
-            tokens.push(bump!(self));
+            tokens.push(self.cursor.bump()?);
         }
         let span = Span {
             start: tokens.first().map(|token| token.span.start).unwrap_or(start),
             end: if let Some(last) = tokens.last() {
                 last.span.end
             } else {
-                peek!(self).span.start
+                self.cursor.peek()?.span.start
             },
         };
         Ok(TokenSeq { tokens, span })
@@ -58,7 +56,7 @@ impl<'a> Parser<'a> {
         &mut self,
         tokens: &mut oxc_allocator::Vec<'a, TokenWithSpan<'a>>,
     ) -> PResult<()> {
-        let head = bump!(self);
+        let head = self.cursor.bump()?;
         let quote = head.span.start;
         let quote = self.source[quote..].chars().next().unwrap_or('"');
         let mut tail = matches!(&head.token, Token::StrTemplate(template) if template.tail);
@@ -66,13 +64,13 @@ impl<'a> Parser<'a> {
         while !tail {
             // Each non-tail part ends at `#{` with the `#` consumed, so the
             // interpolation opens with a bare `{` (like `SassInterpolatedStr`).
-            let lbrace = bump!(self);
+            let lbrace = self.cursor.bump()?;
             debug_assert!(matches!(lbrace.token, Token::LBrace(..)));
             tokens.push(lbrace);
             // the expression's tokens, balanced to the interpolation's `}`
             let mut depth = 0u32;
             loop {
-                match &peek!(self).token {
+                match &self.cursor.peek()?.token {
                     Token::Eof(..) => return Ok(()),
                     Token::StrTemplate(..) => {
                         self.consume_str_template_tokens_into(tokens)?;
@@ -81,16 +79,16 @@ impl<'a> Parser<'a> {
                     Token::LBrace(..) | Token::HashLBrace(..) => depth += 1,
                     Token::RBrace(..) => {
                         if depth == 0 {
-                            tokens.push(bump!(self));
+                            tokens.push(self.cursor.bump()?);
                             break;
                         }
                         depth -= 1;
                     }
                     _ => {}
                 }
-                tokens.push(bump!(self));
+                tokens.push(self.cursor.bump()?);
             }
-            let (template, span) = self.tokenizer.scan_string_template(quote)?;
+            let (template, span) = self.cursor.tokenizer.scan_string_template(quote)?;
             tail = template.tail;
             tokens.push(TokenWithSpan { token: Token::StrTemplate(template), span });
         }

--- a/crates/oxc_css_parser/src/parser/value.rs
+++ b/crates/oxc_css_parser/src/parser/value.rs
@@ -2,9 +2,9 @@ use super::{Parser, state::QualifiedRuleContext};
 use crate::{
     Parse, Syntax,
     ast::*,
-    bump, eat,
+    eat,
     error::{Error, ErrorKind, PResult},
-    expect, peek,
+    expect,
     pos::{Span, Spanned},
     tokenizer::{Token, TokenWithSpan},
     util,
@@ -52,23 +52,23 @@ impl<'a> Parser<'a> {
                 expect!(self, RParen);
                 expr
             } else if matches!(self.syntax, Syntax::Scss | Syntax::Sass)
-                && matches!(&peek!(self).token, Token::Minus(..) | Token::Plus(..))
+                && matches!(&self.cursor.peek()?.token, Token::Minus(..) | Token::Plus(..))
                 && {
-                    let span = &peek!(self).span;
+                    let span = &self.cursor.peek()?.span;
                     self.source.as_bytes().get(span.end) == Some(&b'(')
                 }
             {
                 // SassScript allows a unary sign glued to a parenthesized
                 // operand inside a calculation (`round(-(1) + 2)`); a spaced
                 // `calc(+ 1px)` stays invalid, as in dart-sass.
-                let op = match &peek!(self).token {
+                let op = match &self.cursor.peek()?.token {
                     Token::Minus(..) => SassUnaryOperator {
                         kind: SassUnaryOperatorKind::Minus,
-                        span: bump!(self).span,
+                        span: self.cursor.bump()?.span,
                     },
                     _ => SassUnaryOperator {
                         kind: SassUnaryOperatorKind::Plus,
-                        span: bump!(self).span,
+                        span: self.cursor.bump()?.span,
                     },
                 };
                 let expr = self.parse_calc_expr_recursively(PRECEDENCE_MULTIPLY, allow_modulo)?;
@@ -79,7 +79,7 @@ impl<'a> Parser<'a> {
                     span,
                 })
             } else if self.syntax == Syntax::Less {
-                if matches!(peek!(self).token, Token::Minus(..)) {
+                if matches!(self.cursor.peek()?.token, Token::Minus(..)) {
                     ComponentValue::LessNegativeValue(self.parse()?)
                 } else {
                     self.parse_component_value_atom()?
@@ -92,24 +92,26 @@ impl<'a> Parser<'a> {
         };
 
         loop {
-            let operator = match &peek!(self).token {
-                Token::Asterisk(..) if precedence == PRECEDENCE_MULTIPLY => {
-                    CalcOperator { kind: CalcOperatorKind::Multiply, span: bump!(self).span }
-                }
-                Token::Solidus(..) if precedence == PRECEDENCE_MULTIPLY => {
-                    CalcOperator { kind: CalcOperatorKind::Division, span: bump!(self).span }
-                }
+            let operator = match &self.cursor.peek()?.token {
+                Token::Asterisk(..) if precedence == PRECEDENCE_MULTIPLY => CalcOperator {
+                    kind: CalcOperatorKind::Multiply,
+                    span: self.cursor.bump()?.span,
+                },
+                Token::Solidus(..) if precedence == PRECEDENCE_MULTIPLY => CalcOperator {
+                    kind: CalcOperatorKind::Division,
+                    span: self.cursor.bump()?.span,
+                },
                 // Sass modulo (`%`) shares multiplicative precedence, but only the
                 // legacy SassScript `min`/`max` accept it (`allow_modulo`); true
                 // calculations (`calc`, `clamp`, `sin`, ...) reject it, as does CSS.
                 Token::Percent(..) if precedence == PRECEDENCE_MULTIPLY && allow_modulo => {
-                    CalcOperator { kind: CalcOperatorKind::Modulo, span: bump!(self).span }
+                    CalcOperator { kind: CalcOperatorKind::Modulo, span: self.cursor.bump()?.span }
                 }
                 Token::Plus(..) if precedence == PRECEDENCE_PLUS => {
-                    CalcOperator { kind: CalcOperatorKind::Plus, span: bump!(self).span }
+                    CalcOperator { kind: CalcOperatorKind::Plus, span: self.cursor.bump()?.span }
                 }
                 Token::Minus(..) if precedence == PRECEDENCE_PLUS => {
-                    CalcOperator { kind: CalcOperatorKind::Minus, span: bump!(self).span }
+                    CalcOperator { kind: CalcOperatorKind::Minus, span: self.cursor.bump()?.span }
                 }
                 _ => break,
             };
@@ -128,7 +130,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn parse_component_value_atom(&mut self) -> PResult<ComponentValue<'a>> {
-        let token_with_span = peek!(self);
+        let token_with_span = self.cursor.peek()?;
         match &token_with_span.token {
             Token::Ident(token) => {
                 if unvendored(&token.name()).eq_ignore_ascii_case("url") {
@@ -153,7 +155,7 @@ impl<'a> Parser<'a> {
                 }
                 let ident = self.parse::<InterpolableIdent>()?;
                 let ident_end = ident.span().end;
-                match peek!(self) {
+                match self.cursor.peek()? {
                     TokenWithSpan { token: Token::LParen(..), span } if span.start == ident_end => {
                         return match ident {
                             InterpolableIdent::Literal(ident)
@@ -226,7 +228,7 @@ impl<'a> Parser<'a> {
                 }
                 match ident {
                     InterpolableIdent::Literal(ident) if ident.raw.eq_ignore_ascii_case("u") => {
-                        match peek!(self) {
+                        match self.cursor.peek()? {
                             TokenWithSpan { token: Token::Plus(..), span }
                                 if span.start == ident_end =>
                             {
@@ -281,7 +283,7 @@ impl<'a> Parser<'a> {
             }
             Token::HashLBrace(..) if matches!(self.syntax, Syntax::Scss | Syntax::Sass) => {
                 let ident = self.parse_sass_interpolated_ident()?;
-                match peek!(self) {
+                match self.cursor.peek()? {
                     TokenWithSpan { token: Token::LParen(..), span }
                         if span.start == ident.span().end =>
                     {
@@ -372,7 +374,7 @@ impl<'a> Parser<'a> {
 
     pub(super) fn parse_function(&mut self, name: InterpolableIdent<'a>) -> PResult<Function<'a>> {
         expect!(self, LParen);
-        let args = if let Token::RParen(..) = &peek!(self).token {
+        let args = if let Token::RParen(..) = &self.cursor.peek()?.token {
             self.vec()
         } else {
             match &name {
@@ -417,10 +419,10 @@ impl<'a> Parser<'a> {
                     } else {
                         let typed = self.try_parse(|p| {
                             let values = p.parse_calc_args(allow_modulo)?;
-                            if matches!(&peek!(p).token, Token::RParen(..)) {
+                            if matches!(&p.cursor.peek()?.token, Token::RParen(..)) {
                                 Ok(values)
                             } else {
-                                let span = peek!(p).span.clone();
+                                let span = p.cursor.peek()?.span.clone();
                                 Err(Error { kind: ErrorKind::TryParseError, span })
                             }
                         });
@@ -485,7 +487,7 @@ impl<'a> Parser<'a> {
     ) -> PResult<oxc_allocator::Vec<'a, ComponentValue<'a>>> {
         let mut values = self.vec_with_capacity(1);
         loop {
-            match peek!(self) {
+            match self.cursor.peek()? {
                 TokenWithSpan { token: Token::RParen(..), .. } => break,
                 TokenWithSpan { token: Token::Comma(..), .. } => {
                     values.push(ComponentValue::Delimiter(self.parse()?));
@@ -500,7 +502,7 @@ impl<'a> Parser<'a> {
                             .iter()
                             .any(|v| matches!(v, ComponentValue::SassArbitraryArgument(..))) =>
                 {
-                    let TokenWithSpan { span: Span { end, .. }, .. } = bump!(self);
+                    let TokenWithSpan { span: Span { end, .. }, .. } = self.cursor.bump()?;
                     let value = values.pop().unwrap();
                     let span = Span { start: value.span().start, end };
                     values.push(ComponentValue::SassArbitraryArgument(SassArbitraryArgument {
@@ -546,7 +548,7 @@ impl<'a> Parser<'a> {
     fn parse_progid_function(&mut self, name: Ident<'a>) -> PResult<Function<'a>> {
         let mut args = self.vec_with_capacity(4);
         loop {
-            match &peek!(self).token {
+            match &self.cursor.peek()?.token {
                 Token::LParen(..)
                 | Token::Semicolon(..)
                 | Token::RBrace(..)
@@ -555,7 +557,7 @@ impl<'a> Parser<'a> {
                 | Token::Indent(..)
                 | Token::Dedent(..)
                 | Token::Linebreak(..) => break,
-                _ => args.push(ComponentValue::TokenWithSpan(bump!(self))),
+                _ => args.push(ComponentValue::TokenWithSpan(self.cursor.bump()?)),
             }
         }
         expect!(self, LParen);
@@ -574,7 +576,7 @@ impl<'a> Parser<'a> {
     ) -> PResult<()> {
         let mut pairs: Vec<util::PairedToken> = Vec::with_capacity(1);
         loop {
-            match &peek!(self).token {
+            match &self.cursor.peek()?.token {
                 Token::Eof(..) => break,
                 // Interpolated strings must be parsed structurally so the
                 // tokenizer resumes the string after each `#{...}`.
@@ -588,7 +590,7 @@ impl<'a> Parser<'a> {
                     }
                 }
             }
-            values.push(ComponentValue::TokenWithSpan(bump!(self)));
+            values.push(ComponentValue::TokenWithSpan(self.cursor.bump()?));
         }
         Ok(())
     }
@@ -598,7 +600,7 @@ impl<'a> Parser<'a> {
     ) -> PResult<oxc_allocator::Vec<'a, ComponentValue<'a>>> {
         let mut values = self.vec_with_capacity(4);
         loop {
-            match &peek!(self).token {
+            match &self.cursor.peek()?.token {
                 Token::RParen(..) | Token::Eof(..) => break,
                 Token::Semicolon(..) => {
                     values.push(self.parse().map(ComponentValue::Delimiter)?);
@@ -616,24 +618,24 @@ impl<'a> Parser<'a> {
                     } else if let Ok(value) = self.try_parse(ComponentValue::parse) {
                         values.push(value);
                     } else {
-                        values.push(ComponentValue::TokenWithSpan(bump!(self)));
+                        values.push(ComponentValue::TokenWithSpan(self.cursor.bump()?));
                     }
                 }
                 Token::Indent(..) | Token::Dedent(..) | Token::Linebreak(..) => {
-                    bump!(self);
+                    self.cursor.bump()?;
                 }
                 // A stray delimiter is a plain token in CSS, but the
                 // preprocessor dialects give it real syntax and their
                 // reference compilers reject it in function arguments.
                 Token::Unknown(..) if self.syntax != Syntax::Css => {
-                    let span = peek!(self).span.clone();
+                    let span = self.cursor.peek()?.span.clone();
                     return Err(Error { kind: ErrorKind::UnknownToken, span });
                 }
                 _ => {
                     let value = if let Ok(value) = self.try_parse(ComponentValue::parse) {
                         value
                     } else {
-                        values.push(ComponentValue::TokenWithSpan(bump!(self)));
+                        values.push(ComponentValue::TokenWithSpan(self.cursor.bump()?));
                         continue;
                     };
                     if matches!(self.syntax, Syntax::Scss | Syntax::Sass) {
@@ -687,18 +689,18 @@ impl<'a> Parser<'a> {
     fn parse_src_url(&mut self, name: Ident<'a>) -> PResult<Url<'a>> {
         // caller of `parse_src_url` should make sure there're no whitespaces before paren
         expect!(self, LParen);
-        let value = match &peek!(self).token {
+        let value = match &self.cursor.peek()?.token {
             Token::Str(..) | Token::StrTemplate(..) => {
                 Some(UrlValue::Str(self.parse::<InterpolableStr>()?))
             }
             _ => None,
         };
-        let modifiers = match &peek!(self).token {
+        let modifiers = match &self.cursor.peek()?.token {
             Token::Ident(..) | Token::HashLBrace(..) | Token::AtLBraceVar(..) => {
                 let mut modifiers = self.vec_with_capacity(1);
                 loop {
                     modifiers.push(self.parse()?);
-                    if let Token::RParen(..) = &peek!(self).token {
+                    if let Token::RParen(..) = &self.cursor.peek()?.token {
                         break;
                     }
                 }
@@ -713,10 +715,10 @@ impl<'a> Parser<'a> {
 
     fn parse_unicode_range(&mut self, prefix_ident: Ident<'a>) -> PResult<UnicodeRange<'a>> {
         let prefix = prefix_ident.raw.chars().next().unwrap();
-        let (span_start, span_end) = match bump!(self) {
+        let (span_start, span_end) = match self.cursor.bump()? {
             TokenWithSpan { token: Token::Plus(..), span: plus_token_span } => {
                 let start = plus_token_span.start;
-                let mut end = match self.tokenizer.bump_without_ws_or_comments()? {
+                let mut end = match self.cursor.tokenizer.bump_without_ws_or_comments()? {
                     TokenWithSpan { token: Token::Ident(..) | Token::Question(..), span } => {
                         span.end
                     }
@@ -728,9 +730,9 @@ impl<'a> Parser<'a> {
                     }
                 };
                 loop {
-                    match peek!(self) {
+                    match self.cursor.peek()? {
                         TokenWithSpan { token: Token::Question(..), span } if span.start == end => {
-                            end = bump!(self).span.end;
+                            end = self.cursor.bump()?.span.end;
                         }
                         _ => break,
                     }
@@ -741,9 +743,9 @@ impl<'a> Parser<'a> {
                 let start = dimension_token_span.start;
                 let mut end = dimension_token_span.end;
                 loop {
-                    match peek!(self) {
+                    match self.cursor.peek()? {
                         TokenWithSpan { token: Token::Question(..), span } if span.start == end => {
-                            end = bump!(self).span.end;
+                            end = self.cursor.bump()?.span.end;
                         }
                         _ => break,
                     }
@@ -753,22 +755,22 @@ impl<'a> Parser<'a> {
             TokenWithSpan { token: Token::Number(..), span: number_token_span } => {
                 let start = number_token_span.start;
                 let mut end = number_token_span.end;
-                match &peek!(self).token {
+                match &self.cursor.peek()?.token {
                     Token::Question(..) => {
-                        end = bump!(self).span.end;
+                        end = self.cursor.bump()?.span.end;
                         loop {
-                            match peek!(self) {
+                            match self.cursor.peek()? {
                                 TokenWithSpan { token: Token::Question(..), span }
                                     if span.start == end =>
                                 {
-                                    end = bump!(self).span.end;
+                                    end = self.cursor.bump()?.span.end;
                                 }
                                 _ => break,
                             }
                         }
                     }
                     Token::Dimension(..) | Token::Number(..) => {
-                        end = bump!(self).span.end;
+                        end = self.cursor.bump()?.span.end;
                     }
                     _ => {}
                 }
@@ -827,7 +829,7 @@ impl<'a> Parse<'a> for BracketBlock<'a> {
         let start = expect!(input, LBracket).1.start;
         let mut value = input.vec_with_capacity(3);
         loop {
-            match &peek!(input).token {
+            match &input.cursor.peek()?.token {
                 Token::RBracket(..) => break,
                 _ => value.push(input.parse()?),
             }
@@ -858,7 +860,7 @@ impl<'a> Parse<'a> for ComponentValues<'a> {
         let mut values = input.vec_with_capacity(4);
         values.push(first);
         loop {
-            match &peek!(input).token {
+            match &input.cursor.peek()?.token {
                 Token::Eof(..) => break,
                 Token::Semicolon(..) => {
                     values.push(input.parse().map(ComponentValue::Delimiter)?);
@@ -877,7 +879,7 @@ impl<'a> Parse<'a> for ComponentValues<'a> {
 impl<'a> Parse<'a> for Delimiter {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         use crate::tokenizer::token::*;
-        match bump!(input) {
+        match input.cursor.bump()? {
             TokenWithSpan { token: Token::Solidus(..), span } => {
                 Ok(Delimiter { kind: DelimiterKind::Solidus, span })
             }
@@ -902,13 +904,13 @@ impl<'a> Parse<'a> for Dimension<'a> {
 impl<'a> Parse<'a> for Function<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let name = input.parse::<FunctionName>()?;
-        match peek!(input) {
+        match input.cursor.peek()? {
             TokenWithSpan { token: Token::LParen(..), span } => {
                 util::assert_no_ws_or_comment(name.span(), span)?;
                 match name {
                     FunctionName::Ident(name) => input.parse_function(name),
                     name => {
-                        bump!(input);
+                        input.cursor.bump()?;
                         let args = input.parse_function_args()?;
                         let (_, Span { end, .. }) = expect!(input, RParen);
                         let span = Span { start: name.span().start, end };
@@ -929,12 +931,12 @@ impl<'a> Parse<'a> for Function<'a> {
 
 impl<'a> Parse<'a> for FunctionName<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match peek!(input).token {
+        match input.cursor.peek()?.token {
             Token::Ident(..) => {
                 let ident = input.parse::<Ident>()?;
-                match (&peek!(input).token, input.syntax) {
+                match (&input.cursor.peek()?.token, input.syntax) {
                     (Token::Dot(..), Syntax::Scss | Syntax::Sass) => {
-                        bump!(input);
+                        input.cursor.bump()?;
                         let member = input.parse::<Ident>()?;
                         let span = Span { start: ident.span.start, end: member.span.end };
                         Ok(FunctionName::SassQualifiedName(input.alloc(SassQualifiedName {
@@ -954,7 +956,7 @@ impl<'a> Parse<'a> for FunctionName<'a> {
             }
             _ => {
                 use crate::{token::Ident, tokenizer::TokenSymbol};
-                let TokenWithSpan { token, span } = bump!(input);
+                let TokenWithSpan { token, span } = input.cursor.bump()?;
                 Err(Error { kind: ErrorKind::Unexpected(Ident::symbol(), token.symbol()), span })
             }
         }
@@ -982,7 +984,7 @@ impl<'a> Parse<'a> for InterpolableIdent<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         // A css-in-js placeholder stands in for an interpolated ident anywhere one
         // is expected (id selector `#${x}`, attribute value `[a=${x}]`, ...).
-        if let Token::Placeholder(..) = peek!(input).token {
+        if let Token::Placeholder(..) = input.cursor.peek()?.token {
             let (placeholder, span) = expect!(input, Placeholder);
             return Ok(InterpolableIdent::Placeholder((placeholder, span).into()));
         }
@@ -1006,7 +1008,7 @@ impl<'a> Parse<'a> for InterpolableIdent<'a> {
 
 impl<'a> Parse<'a> for InterpolableStr<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match peek!(input) {
+        match input.cursor.peek()? {
             TokenWithSpan { token: Token::Str(..), .. } => {
                 input.parse().map(InterpolableStr::Literal)
             }
@@ -1069,23 +1071,23 @@ impl<'a> Parse<'a> for Url<'a> {
         let prefix_start = prefix_span.start;
         let name = input.ident(prefix, prefix_span.clone());
 
-        match peek!(input) {
+        match input.cursor.peek()? {
             TokenWithSpan { token: Token::LParen(..), span } if prefix_span.end == span.start => {
-                bump!(input);
+                input.cursor.bump()?;
             }
             TokenWithSpan { span, .. } => {
                 return Err(Error { kind: ErrorKind::TryParseError, span: span.clone() });
             }
         }
 
-        if input.tokenizer.is_start_of_url_string() {
+        if input.cursor.tokenizer.is_start_of_url_string() {
             let value = input.parse()?;
-            let modifiers = match &peek!(input).token {
+            let modifiers = match &input.cursor.peek()?.token {
                 Token::Ident(..) | Token::HashLBrace(..) | Token::AtLBraceVar(..) => {
                     let mut modifiers = input.vec_with_capacity(1);
                     loop {
                         modifiers.push(input.parse()?);
-                        if let Token::RParen(..) = &peek!(input).token {
+                        if let Token::RParen(..) = &input.cursor.peek()?.token {
                             break;
                         }
                     }
@@ -1104,7 +1106,9 @@ impl<'a> Parse<'a> for Url<'a> {
             Ok(Url { name, value: Some(UrlValue::Raw(value)), modifiers: input.vec(), span })
         } else {
             match input.syntax {
-                Syntax::Css => Err(Error { kind: ErrorKind::InvalidUrl, span: bump!(input).span }),
+                Syntax::Css => {
+                    Err(Error { kind: ErrorKind::InvalidUrl, span: input.cursor.bump()?.span })
+                }
                 Syntax::Scss | Syntax::Sass => {
                     let value = input.parse::<SassInterpolatedUrl>()?;
                     let span = Span {
@@ -1132,7 +1136,7 @@ impl<'a> Parse<'a> for Url<'a> {
 impl<'a> Parse<'a> for UrlModifier<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let ident = input.parse::<InterpolableIdent>()?;
-        match peek!(input) {
+        match input.cursor.peek()? {
             TokenWithSpan { token: Token::LParen(..), span } if ident.span().end == span.start => {
                 input.parse_function(ident).map(UrlModifier::Function)
             }
@@ -1143,7 +1147,7 @@ impl<'a> Parse<'a> for UrlModifier<'a> {
 
 impl<'a> Parse<'a> for UrlRaw<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match input.tokenizer.scan_url_raw_or_template()? {
+        match input.cursor.tokenizer.scan_url_raw_or_template()? {
             TokenWithSpan { token: Token::UrlRaw(url), span } => {
                 let value = if url.escaped {
                     util::handle_escape_in(url.raw, input.allocator())


### PR DESCRIPTION
Replace the parser `peek!` and `bump!` macros with a cursor field that owns lookahead state.

Validation:
- `cargo check -p oxc-css-parser`
- `cargo test -p oxc-css-parser --lib --tests`