### PR TITLE
refactor(parser): replace arena macros with helpers

### DIFF
--- a/crates/oxc_css_parser/src/parser/at_rule/container.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/container.rs
@@ -1,6 +1,6 @@
 use super::Parser;
 use crate::{
-    Parse, arena_box, arena_vec,
+    Parse,
     ast::*,
     eat,
     error::{Error, ErrorKind, PResult},
@@ -16,15 +16,14 @@ impl<'a> Parse<'a> for ContainerCondition<'a> {
                 let container_condition_not = input.parse::<ContainerConditionNot>()?;
                 let span = container_condition_not.span.clone();
                 Ok(ContainerCondition {
-                    conditions: arena_vec!(input; ContainerConditionKind::Not(container_condition_not)),
+                    conditions: input.vec1(ContainerConditionKind::Not(container_condition_not)),
                     span,
                 })
             }
             _ => {
                 let first = input.parse::<QueryInParens>()?;
                 let mut span = first.span.clone();
-                let mut conditions =
-                    arena_vec!(input; ContainerConditionKind::QueryInParens(first));
+                let mut conditions = input.vec1(ContainerConditionKind::QueryInParens(first));
                 // formally `and`/`or` may not mix without parens and `not`
                 // is leading-only, but real-world code (less.js) chains them
                 // freely: `(a) or (b) and (c)`, `(a) not (b)`.
@@ -98,7 +97,8 @@ impl<'a> Parse<'a> for QueryInParens<'a> {
             let kind = if let Ok(container_condition) = input.try_parse(ContainerCondition::parse) {
                 QueryInParensKind::ContainerCondition(container_condition)
             } else {
-                QueryInParensKind::SizeFeature(arena_box!(input, input.parse()?))
+                let size_feature = input.parse()?;
+                QueryInParensKind::SizeFeature(input.alloc(size_feature))
             };
             let (_, Span { end, .. }) = expect!(input, RParen);
             Ok(QueryInParens { kind, span: Span { start, end } })
@@ -114,7 +114,7 @@ impl<'a> Parse<'a> for QueryInParens<'a> {
                 // https://drafts.csswg.org/css-conditional-5/#scroll-state-container
                 expect_without_ws_or_comments!(input, LParen);
                 let media = input.parse()?;
-                let kind = QueryInParensKind::ScrollState(arena_box!(input, media));
+                let kind = QueryInParensKind::ScrollState(input.alloc(media));
                 let (_, Span { end, .. }) = expect!(input, RParen);
                 Ok(QueryInParens { kind, span: Span { start: ident_span.start, end } })
             } else {
@@ -131,14 +131,14 @@ impl<'a> Parse<'a> for StyleCondition<'a> {
                 let style_condition_not = input.parse::<StyleConditionNot>()?;
                 let span = style_condition_not.span.clone();
                 Ok(StyleCondition {
-                    conditions: arena_vec!(input; StyleConditionKind::Not(style_condition_not)),
+                    conditions: input.vec1(StyleConditionKind::Not(style_condition_not)),
                     span,
                 })
             }
             _ => {
                 let first = input.parse::<StyleInParens>()?;
                 let mut span = first.span.clone();
-                let mut conditions = arena_vec!(input; StyleConditionKind::StyleInParens(first));
+                let mut conditions = input.vec1(StyleConditionKind::StyleInParens(first));
                 if let Token::Ident(ident) = &peek!(input).token {
                     let name = ident.name();
                     if name.eq_ignore_ascii_case("and") {

--- a/crates/oxc_css_parser/src/parser/at_rule/custom_selector.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/custom_selector.rs
@@ -1,7 +1,5 @@
 use super::Parser;
-use crate::{
-    Parse, arena_vec, ast::*, error::PResult, expect, peek, pos::Span, tokenizer::Token, util,
-};
+use crate::{Parse, ast::*, error::PResult, expect, peek, pos::Span, tokenizer::Token, util};
 
 impl<'a> Parse<'a> for CustomSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
@@ -52,8 +50,8 @@ impl<'a> Parse<'a> for CustomSelectorArgs<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = expect!(input, LParen);
 
-        let mut args = arena_vec!(input);
-        let mut comma_spans = arena_vec!(input);
+        let mut args = input.vec();
+        let mut comma_spans = input.vec();
         while !matches!(peek!(input).token, Token::RParen(..)) {
             args.push(input.parse()?);
             if !matches!(peek!(input).token, Token::RParen(..)) {

--- a/crates/oxc_css_parser/src/parser/at_rule/document.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/document.rs
@@ -1,5 +1,5 @@
 use super::Parser;
-use crate::{Parse, Spanned, arena_vec, ast::*, eat, error::PResult};
+use crate::{Parse, Spanned, ast::*, eat, error::PResult};
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/@document
 impl<'a> Parse<'a> for DocumentPrelude<'a> {
@@ -7,8 +7,8 @@ impl<'a> Parse<'a> for DocumentPrelude<'a> {
         let first = input.parse::<DocumentPreludeMatcher>()?;
         let mut span = first.span().clone();
 
-        let mut matchers = arena_vec!(input; first);
-        let mut comma_spans = arena_vec!(input);
+        let mut matchers = input.vec1(first);
+        let mut comma_spans = input.vec();
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             matchers.push(input.parse()?);

--- a/crates/oxc_css_parser/src/parser/at_rule/font_feature_values.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/font_feature_values.rs
@@ -1,5 +1,5 @@
 use super::Parser;
-use crate::{Parse, Spanned, arena_vec, ast::*, error::PResult, peek, tokenizer::Token};
+use crate::{Parse, Spanned, ast::*, error::PResult, peek, tokenizer::Token};
 
 // https://drafts.csswg.org/css-fonts/Overview.bs
 impl<'a> Parse<'a> for FontFamilyName<'a> {
@@ -10,7 +10,7 @@ impl<'a> Parse<'a> for FontFamilyName<'a> {
                 let first = input.parse::<InterpolableIdent>()?;
                 let mut span = first.span().clone();
 
-                let mut idents = arena_vec!(input; first);
+                let mut idents = input.vec1(first);
                 while let Token::Ident(..) | Token::HashLBrace(..) | Token::AtLBraceVar(..) =
                     &peek!(input).token
                 {

--- a/crates/oxc_css_parser/src/parser/at_rule/import.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/import.rs
@@ -1,6 +1,6 @@
 use super::Parser;
 use crate::{
-    Parse, Syntax, arena_vec,
+    Parse, Syntax,
     ast::*,
     bump,
     error::{Error, ErrorKind, PResult},
@@ -116,7 +116,8 @@ impl<'a> ImportPrelude<'a> {
                         if span.start == ident.span.end =>
                     {
                         bump!(input);
-                        let args = arena_vec!(input; input.parse().map(ComponentValue::LayerName)?);
+                        let layer_name = input.parse().map(ComponentValue::LayerName)?;
+                        let args = input.vec1(layer_name);
                         let end = expect!(input, RParen).1.end;
                         let span = Span { start: ident.span.start, end };
                         ImportPreludeLayer::WithName(Function {

--- a/crates/oxc_css_parser/src/parser/at_rule/keyframes.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/keyframes.rs
@@ -1,6 +1,6 @@
 use super::Parser;
 use crate::{
-    Parse, arena_vec,
+    Parse,
     ast::*,
     eat,
     error::{Error, ErrorKind, PResult},
@@ -19,7 +19,7 @@ impl<'a> Parse<'a> for KeyframeBlock<'a> {
 
         let mut selectors = input.vec_with_capacity(2);
         selectors.push(first_selector);
-        let mut comma_spans = arena_vec!(input);
+        let mut comma_spans = input.vec();
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             selectors.push(input.parse()?);

--- a/crates/oxc_css_parser/src/parser/at_rule/layer.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/layer.rs
@@ -1,6 +1,6 @@
 use super::Parser;
 use crate::{
-    Parse, arena_vec,
+    Parse,
     ast::*,
     bump, eat,
     error::{Error, PResult},
@@ -16,8 +16,8 @@ impl<'a> Parse<'a> for LayerNames<'a> {
         let first = input.parse::<LayerName>()?;
         let mut span = first.span.clone();
 
-        let mut names = arena_vec!(input; first);
-        let mut comma_spans = arena_vec!(input);
+        let mut names = input.vec1(first);
+        let mut comma_spans = input.vec();
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             names.push(input.parse()?);
@@ -37,7 +37,7 @@ impl<'a> Parse<'a> for LayerName<'a> {
         let start = first.span().start;
         let mut end = first.span().end;
 
-        let mut idents = arena_vec!(input; first);
+        let mut idents = input.vec1(first);
         while let TokenWithSpan { token: Token::Dot(..), span } = peek!(input) {
             if span.start == end {
                 let span = bump!(input).span;

--- a/crates/oxc_css_parser/src/parser/at_rule/media.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/media.rs
@@ -1,6 +1,6 @@
 use super::Parser;
 use crate::{
-    Parse, Syntax, arena_box, arena_vec,
+    Parse, Syntax,
     ast::*,
     bump, eat,
     error::{Error, ErrorKind, PResult},
@@ -161,7 +161,7 @@ impl<'a> Parse<'a> for MediaInParensKind<'a> {
                 Err(Error { kind: ErrorKind::ExpectMediaFeatureName, span })
             }
         }) {
-            Ok(MediaInParensKind::MediaFeature(arena_box!(input, media_feature)))
+            Ok(MediaInParensKind::MediaFeature(input.alloc(media_feature)))
         } else {
             // <general-enclosed>: MQ L4 forward-compat catch-all, evaluates false at runtime.
             let tokens = input.parse_tokens_in_parens()?;
@@ -219,7 +219,7 @@ impl<'a> Parse<'a> for MediaQuery<'a> {
                 }
                 Token::Dot(..) | Token::Hash(..) => {
                     let less_namespace_value = input.parse()?;
-                    Ok(MediaQuery::LessNamespaceValue(arena_box!(input, less_namespace_value)))
+                    Ok(MediaQuery::LessNamespaceValue(input.alloc(less_namespace_value)))
                 }
                 _ => input.parse_media_query_with_type_or_function(),
             }
@@ -235,8 +235,8 @@ impl<'a> Parse<'a> for MediaQueryList<'a> {
         let first = input.parse::<MediaQuery>()?;
         let mut span = first.span().clone();
 
-        let mut queries = arena_vec!(input; first);
-        let mut comma_spans = arena_vec!(input);
+        let mut queries = input.vec1(first);
+        let mut comma_spans = input.vec();
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             queries.push(input.parse()?);
@@ -311,7 +311,7 @@ impl<'a> Parser<'a> {
             let span = token.span.clone();
             return Ok(MediaInParens {
                 kind: MediaInParensKind::GeneralEnclosed(TokenSeq {
-                    tokens: arena_vec!(self; token),
+                    tokens: self.vec1(token),
                     span: span.clone(),
                 }),
                 span,
@@ -330,7 +330,7 @@ impl<'a> Parser<'a> {
                 let media_not = self.parse::<MediaNot>()?;
                 let span = media_not.span.clone();
                 Ok(MediaCondition {
-                    conditions: arena_vec!(self; MediaConditionKind::Not(media_not)),
+                    conditions: self.vec1(MediaConditionKind::Not(media_not)),
                     span,
                 })
             }
@@ -341,7 +341,7 @@ impl<'a> Parser<'a> {
                     self.parse::<MediaInParens>()?
                 };
                 let mut span = first.span.clone();
-                let mut conditions = arena_vec!(self; MediaConditionKind::MediaInParens(first));
+                let mut conditions = self.vec1(MediaConditionKind::MediaInParens(first));
                 if let Token::Ident(ident) = &peek!(self).token {
                     let name = ident.name();
                     if name.eq_ignore_ascii_case("and") {

--- a/crates/oxc_css_parser/src/parser/at_rule/mod.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/mod.rs
@@ -1,6 +1,6 @@
 use super::{Parser, state::ParserState};
 use crate::{
-    Parse, Syntax, arena_box,
+    Parse, Syntax,
     ast::*,
     bump,
     error::{Error, ErrorKind, PResult},
@@ -78,7 +78,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
                         })
                     };
                     match raw {
-                        Ok(raw) => Some(AtRulePrelude::Unknown(arena_box!(input, raw))),
+                        Ok(raw) => Some(AtRulePrelude::Unknown(input.alloc(raw))),
                         Err(_) => Some(AtRulePrelude::Media(input.parse()?)),
                     }
                 }
@@ -107,7 +107,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
                         Ok(name) => Some(AtRulePrelude::Keyframes(name)),
                         Err(_) => input
                             .parse_unknown_at_rule_prelude()?
-                            .map(|prelude| AtRulePrelude::Unknown(arena_box!(input, prelude))),
+                            .map(|prelude| AtRulePrelude::Unknown(input.alloc(prelude))),
                     }
                 }
             };
@@ -120,11 +120,11 @@ impl<'a> Parse<'a> for AtRule<'a> {
             let (end, prelude) = match input.syntax {
                 Syntax::Css => {
                     let prelude = input.parse::<ImportPrelude>()?;
-                    (prelude.span.end, AtRulePrelude::Import(arena_box!(input, prelude)))
+                    (prelude.span.end, AtRulePrelude::Import(input.alloc(prelude)))
                 }
                 Syntax::Scss | Syntax::Sass => {
                     if let Ok(prelude) = input.try_parse(ImportPrelude::parse) {
-                        (prelude.span.end, AtRulePrelude::Import(arena_box!(input, prelude)))
+                        (prelude.span.end, AtRulePrelude::Import(input.alloc(prelude)))
                     } else {
                         let prelude = input.parse::<SassImportPrelude>()?;
                         (prelude.span.end, AtRulePrelude::SassImport(prelude))
@@ -132,10 +132,10 @@ impl<'a> Parse<'a> for AtRule<'a> {
                 }
                 Syntax::Less => {
                     if let Ok(prelude) = input.try_parse(ImportPrelude::parse) {
-                        (prelude.span.end, AtRulePrelude::Import(arena_box!(input, prelude)))
+                        (prelude.span.end, AtRulePrelude::Import(input.alloc(prelude)))
                     } else {
                         let prelude = input.parse::<LessImportPrelude>()?;
-                        (prelude.span.end, AtRulePrelude::LessImport(arena_box!(input, prelude)))
+                        (prelude.span.end, AtRulePrelude::LessImport(input.alloc(prelude)))
                     }
                 }
             };
@@ -148,11 +148,10 @@ impl<'a> Parse<'a> for AtRule<'a> {
                 let prelude = input.parse::<InterpolableStr>()?;
                 let end = prelude.span().end;
                 (
-                    Some(AtRulePrelude::Unknown(arena_box!(
-                        input,
+                    Some(AtRulePrelude::Unknown(input.alloc(
                         UnknownAtRulePrelude::ComponentValue(ComponentValue::InterpolableStr(
-                            prelude
-                        ))
+                            prelude,
+                        )),
                     ))),
                     None,
                     end,
@@ -180,7 +179,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
                         && matches!(peek!(input).token, Token::AtKeyword(..)) =>
                 {
                     let raw = input.parse_raw_at_rule_prelude()?;
-                    Some(AtRulePrelude::Unknown(arena_box!(input, raw)))
+                    Some(AtRulePrelude::Unknown(input.alloc(raw)))
                 }
                 Err(_) => None,
             };
@@ -208,32 +207,32 @@ impl<'a> Parse<'a> for AtRule<'a> {
             // (`@container card (w > 400px), style(--x: y) {`); those — and
             // only those — are kept as raw tokens. A malformed single query
             // still errors.
-            let prelude = match input
-                .try_parse_full_prelude(|p| p.parse().map(AtRulePrelude::Container))
-            {
-                Ok(prelude) => prelude,
-                Err(error) => {
-                    let is_query_list = input
-                        .try_parse(|p| {
-                            p.parse::<ContainerPrelude>()?;
-                            if matches!(peek!(p).token, Token::Comma(..)) {
-                                Ok(())
-                            } else {
-                                let span = peek!(p).span.clone();
-                                Err(Error { kind: ErrorKind::TryParseError, span })
-                            }
-                        })
-                        .is_ok();
-                    // a Less variable may stand for the container name:
-                    // `@container @varfoo (min-width: @threshold) {`
-                    let less_variable_name = input.syntax == Syntax::Less
-                        && matches!(peek!(input).token, Token::AtKeyword(..));
-                    if !is_query_list && !less_variable_name {
-                        return Err(error);
+            let prelude =
+                match input.try_parse_full_prelude(|p| p.parse().map(AtRulePrelude::Container)) {
+                    Ok(prelude) => prelude,
+                    Err(error) => {
+                        let is_query_list = input
+                            .try_parse(|p| {
+                                p.parse::<ContainerPrelude>()?;
+                                if matches!(peek!(p).token, Token::Comma(..)) {
+                                    Ok(())
+                                } else {
+                                    let span = peek!(p).span.clone();
+                                    Err(Error { kind: ErrorKind::TryParseError, span })
+                                }
+                            })
+                            .is_ok();
+                        // a Less variable may stand for the container name:
+                        // `@container @varfoo (min-width: @threshold) {`
+                        let less_variable_name = input.syntax == Syntax::Less
+                            && matches!(peek!(input).token, Token::AtKeyword(..));
+                        if !is_query_list && !less_variable_name {
+                            return Err(error);
+                        }
+                        let prelude = input.parse_raw_at_rule_prelude()?;
+                        AtRulePrelude::Unknown(input.alloc(prelude))
                     }
-                    AtRulePrelude::Unknown(arena_box!(input, input.parse_raw_at_rule_prelude()?))
-                }
-            };
+                };
             let block = input.parse::<SimpleBlock>()?;
             let end = block.span.end;
             (Some(prelude), Some(block), end)
@@ -253,11 +252,11 @@ impl<'a> Parse<'a> for AtRule<'a> {
             // `@namespace @ns "http://...";` — a Less variable prefix
             let raw = input.parse_raw_at_rule_prelude()?;
             let end = raw.span().end;
-            (Some(AtRulePrelude::Unknown(arena_box!(input, raw))), None, end)
+            (Some(AtRulePrelude::Unknown(input.alloc(raw))), None, end)
         } else if at_rule_name.eq_ignore_ascii_case("namespace") {
             let namespace = input.parse::<NamespacePrelude>()?;
             let end = namespace.span.end;
-            (Some(AtRulePrelude::Namespace(arena_box!(input, namespace))), None, end)
+            (Some(AtRulePrelude::Namespace(input.alloc(namespace))), None, end)
         } else if at_rule_name.eq_ignore_ascii_case("color-profile") {
             let prelude = Some(AtRulePrelude::ColorProfile(input.parse()?));
             let block = input.parse::<SimpleBlock>()?;
@@ -282,15 +281,11 @@ impl<'a> Parse<'a> for AtRule<'a> {
         } else if at_rule_name.eq_ignore_ascii_case("custom-media") {
             let custom_media = input.parse::<CustomMedia>()?;
             let end = custom_media.span.end;
-            (Some(AtRulePrelude::CustomMedia(arena_box!(input, custom_media))), None, end)
+            (Some(AtRulePrelude::CustomMedia(input.alloc(custom_media))), None, end)
         } else if at_rule_name.eq_ignore_ascii_case("custom-selector") {
             let custom_selector_prelude = input.parse::<CustomSelectorPrelude>()?;
             let end = custom_selector_prelude.span.end;
-            (
-                Some(AtRulePrelude::CustomSelector(arena_box!(input, custom_selector_prelude))),
-                None,
-                end,
-            )
+            (Some(AtRulePrelude::CustomSelector(input.alloc(custom_selector_prelude))), None, end)
         } else if at_rule_name.eq_ignore_ascii_case("position-try") {
             // https://drafts.csswg.org/css-anchor-position-1/#fallback-rule
             let prelude = Some(AtRulePrelude::PositionTry(input.parse_dashed_ident()?));
@@ -311,7 +306,8 @@ impl<'a> Parse<'a> for AtRule<'a> {
             (prelude, Some(block), end)
         } else if at_rule_name.eq_ignore_ascii_case("scope") {
             let prelude = if let Token::LParen(..) | Token::Ident(..) = peek!(input).token {
-                Some(AtRulePrelude::Scope(arena_box!(input, input.parse()?)))
+                let scope = input.parse()?;
+                Some(AtRulePrelude::Scope(input.alloc(scope)))
             } else {
                 None
             };
@@ -332,7 +328,8 @@ impl<'a> Parse<'a> for AtRule<'a> {
                     ) {
                         return Err(error);
                     }
-                    AtRulePrelude::Unknown(arena_box!(input, input.parse_raw_at_rule_prelude()?))
+                    let prelude = input.parse_raw_at_rule_prelude()?;
+                    AtRulePrelude::Unknown(input.alloc(prelude))
                 }
             };
             // real-world code also writes a block-less `@document ...;`
@@ -376,7 +373,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
         } else if at_rule_name == "plugin" && input.syntax == Syntax::Less {
             let prelude = input.parse::<LessPlugin>()?;
             let end = prelude.span.end;
-            (Some(AtRulePrelude::LessPlugin(arena_box!(input, prelude))), None, end)
+            (Some(AtRulePrelude::LessPlugin(input.alloc(prelude))), None, end)
         } else if at_rule_name.eq_ignore_ascii_case("function")
             && matches!(&peek!(input).token, Token::Ident(ident) if ident.raw.starts_with("--"))
         {
@@ -390,7 +387,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
                 .with_state(ParserState { in_css_function_body: true, ..input.state.clone() })
                 .parse::<SimpleBlock>()?;
             let end = block.span.end;
-            (Some(AtRulePrelude::Unknown(arena_box!(input, prelude))), Some(block), end)
+            (Some(AtRulePrelude::Unknown(input.alloc(prelude))), Some(block), end)
         } else if matches!(input.syntax, Syntax::Scss | Syntax::Sass) {
             use super::state::{
                 SASS_CTX_ALLOW_DIV, SASS_CTX_ALLOW_KEYFRAME_BLOCK, SASS_CTX_IN_FUNCTION,
@@ -400,20 +397,20 @@ impl<'a> Parse<'a> for AtRule<'a> {
                     let prelude = input.parse()?;
                     let block = input.parse::<SimpleBlock>()?;
                     let end = block.span.end;
-                    (Some(AtRulePrelude::SassEach(arena_box!(input, prelude))), Some(block), end)
+                    (Some(AtRulePrelude::SassEach(input.alloc(prelude))), Some(block), end)
                 }
                 "while" => {
                     input.eat_sass_line_continuation()?;
                     let prelude = input.parse()?;
                     let block = input.parse::<SimpleBlock>()?;
                     let end = block.span.end;
-                    (Some(AtRulePrelude::SassExpr(arena_box!(input, prelude))), Some(block), end)
+                    (Some(AtRulePrelude::SassExpr(input.alloc(prelude))), Some(block), end)
                 }
                 "for" => {
                     let prelude = input.parse()?;
                     let block = input.parse::<SimpleBlock>()?;
                     let end = block.span.end;
-                    (Some(AtRulePrelude::SassFor(arena_box!(input, prelude))), Some(block), end)
+                    (Some(AtRulePrelude::SassFor(input.alloc(prelude))), Some(block), end)
                 }
                 "mixin" => {
                     let prelude = input.parse()?;
@@ -424,7 +421,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
                         })
                         .parse::<SimpleBlock>()?;
                     let end = block.span.end;
-                    (Some(AtRulePrelude::SassMixin(arena_box!(input, prelude))), Some(block), end)
+                    (Some(AtRulePrelude::SassMixin(input.alloc(prelude))), Some(block), end)
                 }
                 "include" => {
                     let prelude = input.parse::<SassInclude>()?;
@@ -444,7 +441,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
                         };
                     let end =
                         block.as_ref().map(|block| block.span.end).unwrap_or(prelude.span.end);
-                    (Some(AtRulePrelude::SassInclude(arena_box!(input, prelude))), block, end)
+                    (Some(AtRulePrelude::SassInclude(input.alloc(prelude))), block, end)
                 }
                 "content" => {
                     if matches!(peek!(input).token, Token::LParen(..)) {
@@ -458,7 +455,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
                 "use" => {
                     let prelude = input.parse::<SassUse>()?;
                     let end = prelude.span.end;
-                    (Some(AtRulePrelude::SassUse(arena_box!(input, prelude))), None, end)
+                    (Some(AtRulePrelude::SassUse(input.alloc(prelude))), None, end)
                 }
                 "function" => {
                     let prelude = input.parse::<SassFunction>()?;
@@ -469,11 +466,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
                         })
                         .parse::<SimpleBlock>()?;
                     let end = block.span.end;
-                    (
-                        Some(AtRulePrelude::SassFunction(arena_box!(input, prelude))),
-                        Some(block),
-                        end,
-                    )
+                    (Some(AtRulePrelude::SassFunction(input.alloc(prelude))), Some(block), end)
                 }
                 "return" => {
                     input.eat_sass_line_continuation()?;
@@ -490,23 +483,23 @@ impl<'a> Parse<'a> for AtRule<'a> {
                             span: Span { start: at_keyword_span.start, end },
                         });
                     }
-                    (Some(AtRulePrelude::SassExpr(arena_box!(input, expr))), None, end)
+                    (Some(AtRulePrelude::SassExpr(input.alloc(expr))), None, end)
                 }
                 "extend" => {
                     let prelude = input.parse::<SassExtend>()?;
                     let end = prelude.span.end;
-                    (Some(AtRulePrelude::SassExtend(arena_box!(input, prelude))), None, end)
+                    (Some(AtRulePrelude::SassExtend(input.alloc(prelude))), None, end)
                 }
                 "warn" | "error" | "debug" => {
                     input.eat_sass_line_continuation()?;
                     let expr = input.parse_maybe_sass_list(/* allow_comma */ true)?;
                     let end = expr.span().end;
-                    (Some(AtRulePrelude::SassExpr(arena_box!(input, expr))), None, end)
+                    (Some(AtRulePrelude::SassExpr(input.alloc(expr))), None, end)
                 }
                 "forward" => {
                     let prelude = input.parse::<SassForward>()?;
                     let end = prelude.span.end;
-                    (Some(AtRulePrelude::SassForward(arena_box!(input, prelude))), None, end)
+                    (Some(AtRulePrelude::SassForward(input.alloc(prelude))), None, end)
                 }
                 "at-root" => {
                     let prelude = if !matches!(
@@ -535,7 +528,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
                 _ => {
                     let (prelude, block, end) = input.parse_unknown_at_rule()?;
                     (
-                        prelude.map(|prelude| AtRulePrelude::Unknown(arena_box!(input, prelude))),
+                        prelude.map(|prelude| AtRulePrelude::Unknown(input.alloc(prelude))),
                         block,
                         end.unwrap_or(at_keyword_span.end),
                     )
@@ -544,7 +537,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
         } else {
             let (prelude, block, end) = input.parse_unknown_at_rule()?;
             (
-                prelude.map(|prelude| AtRulePrelude::Unknown(arena_box!(input, prelude))),
+                prelude.map(|prelude| AtRulePrelude::Unknown(input.alloc(prelude))),
                 block,
                 end.unwrap_or(at_keyword_span.end),
             )

--- a/crates/oxc_css_parser/src/parser/at_rule/page.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/page.rs
@@ -1,6 +1,6 @@
 use super::Parser;
 use crate::{
-    Parse, arena_vec,
+    Parse,
     ast::*,
     eat,
     error::PResult,
@@ -14,7 +14,7 @@ use crate::{
 impl<'a> Parse<'a> for PageSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let mut name = None;
-        let mut pseudo = arena_vec!(input);
+        let mut pseudo = input.vec();
         let start;
         let mut end;
 
@@ -51,8 +51,8 @@ impl<'a> Parse<'a> for PageSelectorList<'a> {
         let first = input.parse::<PageSelector>()?;
         let mut span = first.span.clone();
 
-        let mut selectors = arena_vec!(input; first);
-        let mut comma_spans = arena_vec!(input);
+        let mut selectors = input.vec1(first);
+        let mut comma_spans = input.vec();
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             selectors.push(input.parse()?);

--- a/crates/oxc_css_parser/src/parser/at_rule/supports.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/supports.rs
@@ -1,6 +1,6 @@
 use super::Parser;
 use crate::{
-    Parse, arena_box, arena_vec,
+    Parse,
     ast::*,
     error::{Error, ErrorKind, PResult},
     expect, peek,
@@ -17,7 +17,7 @@ impl<'a> Parse<'a> for SupportsCondition<'a> {
                 let condition = input.parse::<SupportsInParens>()?;
                 let span = Span { start: keyword.span.start, end: condition.span().end };
                 Ok(SupportsCondition {
-                    conditions: arena_vec!(input; SupportsConditionKind::Not(SupportsNot {
+                    conditions: input.vec1(SupportsConditionKind::Not(SupportsNot {
                         keyword,
                         condition,
                         span: span.clone(),
@@ -28,8 +28,7 @@ impl<'a> Parse<'a> for SupportsCondition<'a> {
             _ => {
                 let first = input.parse::<SupportsInParens>()?;
                 let mut span = first.span().clone();
-                let mut conditions =
-                    arena_vec!(input; SupportsConditionKind::SupportsInParens(first));
+                let mut conditions = input.vec1(SupportsConditionKind::SupportsInParens(first));
                 while let Token::Ident(ident) = &peek!(input).token {
                     let name = ident.name();
                     if name.eq_ignore_ascii_case("and") {
@@ -71,7 +70,7 @@ impl<'a> Parse<'a> for SupportsInParens<'a> {
                     parser.parse::<SupportsDecl>().map(|supports_decl| {
                         let span = supports_decl.span.clone();
                         SupportsInParens {
-                            kind: SupportsInParensKind::Feature(arena_box!(parser, supports_decl)),
+                            kind: SupportsInParensKind::Feature(parser.alloc(supports_decl)),
                             span,
                         }
                     })

--- a/crates/oxc_css_parser/src/parser/less.rs
+++ b/crates/oxc_css_parser/src/parser/less.rs
@@ -3,7 +3,7 @@ use super::{
     state::{LESS_CTX_ALLOW_DIV, LESS_CTX_ALLOW_KEYFRAME_BLOCK, ParserState, QualifiedRuleContext},
 };
 use crate::{
-    Parse, arena_box, arena_vec,
+    Parse,
     ast::*,
     bump,
     config::Syntax,
@@ -84,9 +84,9 @@ impl<'a> Parser<'a> {
 
         let span = Span { start: left.span().start, end: right.span().end };
         Ok(LessCondition::Binary(LessBinaryCondition {
-            left: arena_box!(self, left),
+            left: self.alloc(left),
             op,
-            right: arena_box!(self, right),
+            right: self.alloc(right),
             span,
         }))
     }
@@ -157,7 +157,7 @@ impl<'a> Parser<'a> {
                     let Span { start, .. } = bump!(self).span;
                     let (condition, end) = self.parse_less_guard_paren_condition(needs_parens)?;
                     LessCondition::Parenthesized(LessParenthesizedCondition {
-                        condition: arena_box!(self, condition),
+                        condition: self.alloc(condition),
                         span: Span { start, end },
                     })
                 }
@@ -172,7 +172,7 @@ impl<'a> Parser<'a> {
                         (condition, end)
                     };
                     LessCondition::Negated(LessNegatedCondition {
-                        condition: arena_box!(self, condition),
+                        condition: self.alloc(condition),
                         span: Span { start, end },
                     })
                 }
@@ -215,9 +215,9 @@ impl<'a> Parser<'a> {
 
             let span = Span { start: left.span().start, end: right.span().end };
             left = LessCondition::Binary(LessBinaryCondition {
-                left: arena_box!(self, left),
+                left: self.alloc(left),
                 op,
-                right: arena_box!(self, right),
+                right: self.alloc(right),
                 span,
             });
         }
@@ -290,7 +290,7 @@ impl<'a> Parser<'a> {
         &mut self,
         end: &mut usize,
     ) -> PResult<oxc_allocator::Vec<'a, LessInterpolatedIdentElement<'a>>> {
-        let mut elements = arena_vec!(self);
+        let mut elements = self.vec();
         loop {
             if let Some((token, span)) = self.tokenizer.scan_ident_template()? {
                 *end = span.end;
@@ -331,16 +331,13 @@ impl<'a> Parser<'a> {
         if matches!(peek!(self).token, Token::LBracket(..)) {
             let lookups = self.parse::<LessLookups>()?;
             let span = Span { start: mixin_call.span.start, end: lookups.span.end };
-            Ok(ComponentValue::LessNamespaceValue(arena_box!(
-                self,
-                LessNamespaceValue {
-                    callee: LessNamespaceValueCallee::LessMixinCall(mixin_call),
-                    lookups,
-                    span,
-                }
-            )))
+            Ok(ComponentValue::LessNamespaceValue(self.alloc(LessNamespaceValue {
+                callee: LessNamespaceValueCallee::LessMixinCall(mixin_call),
+                lookups,
+                span,
+            })))
         } else {
-            Ok(ComponentValue::LessMixinCall(arena_box!(self, mixin_call)))
+            Ok(ComponentValue::LessMixinCall(self.alloc(mixin_call)))
         }
     }
 
@@ -361,14 +358,11 @@ impl<'a> Parser<'a> {
             {
                 let lookups = self.parse::<LessLookups>()?;
                 let span = Span { start: variable.span.start, end: lookups.span.end };
-                Ok(ComponentValue::LessNamespaceValue(arena_box!(
-                    self,
-                    LessNamespaceValue {
-                        callee: LessNamespaceValueCallee::LessVariable(variable),
-                        lookups,
-                        span,
-                    }
-                )))
+                Ok(ComponentValue::LessNamespaceValue(self.alloc(LessNamespaceValue {
+                    callee: LessNamespaceValueCallee::LessVariable(variable),
+                    lookups,
+                    span,
+                })))
             }
             _ => Ok(ComponentValue::LessVariable(variable)),
         }
@@ -505,9 +499,9 @@ impl<'a> Parser<'a> {
                             .map(|value| ComponentValue::Number(Number { value, raw, span }))?
                     };
                     left = ComponentValue::LessBinaryOperation(LessBinaryOperation {
-                        left: arena_box!(self, left),
+                        left: self.alloc(left),
                         op,
-                        right: arena_box!(self, right),
+                        right: self.alloc(right),
                         span,
                     });
                     continue;
@@ -561,17 +555,17 @@ impl<'a> Parser<'a> {
                         )?;
                         let span = Span { start: right.span().start, end: mul_rhs.span().end };
                         right = ComponentValue::LessBinaryOperation(LessBinaryOperation {
-                            left: arena_box!(self, right),
+                            left: self.alloc(right),
                             op: mul_op,
-                            right: arena_box!(self, mul_rhs),
+                            right: self.alloc(mul_rhs),
                             span,
                         });
                     }
                     let span = Span { start: left.span().start, end: right.span().end };
                     left = ComponentValue::LessBinaryOperation(LessBinaryOperation {
-                        left: arena_box!(self, left),
+                        left: self.alloc(left),
                         op,
-                        right: arena_box!(self, right),
+                        right: self.alloc(right),
                         span,
                     });
                     continue;
@@ -582,9 +576,9 @@ impl<'a> Parser<'a> {
             let right = self.parse_less_operation_recursively(allow_mixin_call, precedence + 1)?;
             let span = Span { start: left.span().start, end: right.span().end };
             left = ComponentValue::LessBinaryOperation(LessBinaryOperation {
-                left: arena_box!(self, left),
+                left: self.alloc(left),
                 op,
-                right: arena_box!(self, right),
+                right: self.alloc(right),
                 span,
             });
         }
@@ -605,7 +599,7 @@ impl<'a> Parser<'a> {
             .parse_less_operation(allow_mixin_call)?;
         let (_, Span { end, .. }) = expect!(self, RParen);
         Ok(LessParenthesizedOperation {
-            operation: arena_box!(self, operation),
+            operation: self.alloc(operation),
             span: Span { start, end },
         })
     }
@@ -692,7 +686,7 @@ impl<'a> Parser<'a> {
             self.parse_less_operation(/* allow_mixin_call */ true)?
         };
 
-        let mut elements = arena_vec!(self);
+        let mut elements = self.vec();
         let mut comma_spans: Option<oxc_allocator::Vec<'a, Span>> = None;
         let mut separator = ListSeparatorKind::Unknown;
         let mut end = single_value.span().end;
@@ -720,7 +714,7 @@ impl<'a> Parser<'a> {
                         if let Some(spans) = &mut comma_spans {
                             spans.push(span);
                         } else {
-                            comma_spans = Some(arena_vec!(self; span));
+                            comma_spans = Some(self.vec1(span));
                         }
                     }
                 }
@@ -778,8 +772,8 @@ impl<'a> Parse<'a> for LessConditions<'a> {
         let first = input.parse_less_condition(true)?;
         let mut span = first.span().clone();
 
-        let mut conditions = arena_vec!(input; first);
-        let mut comma_spans = arena_vec!(input);
+        let mut conditions = input.vec1(first);
+        let mut comma_spans = input.vec();
         // A comma may also separate the next guarded selector of the rule
         // (`.a when (..), .b when (..) {`), so only consume it when a
         // condition actually follows.
@@ -871,8 +865,8 @@ impl<'a> Parse<'a> for LessExtendList<'a> {
         let first = input.parse::<LessExtend>()?;
         let mut span = first.span.clone();
 
-        let mut elements = arena_vec!(input; first);
-        let mut comma_spans = arena_vec!(input);
+        let mut elements = input.vec1(first);
+        let mut comma_spans = input.vec();
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             elements.push(input.parse()?);
@@ -929,7 +923,7 @@ impl<'a> Parse<'a> for LessImportOptions<'a> {
         let (_, Span { start, .. }) = expect!(input, LParen);
 
         let mut names = input.vec_with_capacity(1);
-        let mut comma_spans = arena_vec!(input);
+        let mut comma_spans = input.vec();
         while let Token::Ident(crate::token::Ident {
             raw: "less" | "css" | "multiple" | "once" | "inline" | "reference" | "optional",
             ..
@@ -977,12 +971,9 @@ impl<'a> Parse<'a> for LessInterpolatedStr<'a> {
         let quote = first.raw.chars().next().unwrap();
         debug_assert!(quote == '\'' || quote == '"');
         let mut span = first_span.clone();
-        let mut elements = arena_vec!(
-            input;
-            LessInterpolatedStrElement::Static(
-                input.interpolable_str_static_part(first, first_span)
-            )
-        );
+        let mut elements = input.vec1(LessInterpolatedStrElement::Static(
+            input.interpolable_str_static_part(first, first_span),
+        ));
 
         let mut is_parsing_static_part = false;
         loop {
@@ -1098,7 +1089,7 @@ impl<'a> Parse<'a> for LessLookups<'a> {
         let first = input.parse::<LessLookup>()?;
         let mut span = first.span.clone();
 
-        let mut lookups = arena_vec!(input; first);
+        let mut lookups = input.vec1(first);
         while let Token::LBracket(..) = peek!(input).token {
             lookups.push(input.parse()?);
         }
@@ -1119,15 +1110,15 @@ impl<'a> Parse<'a> for LessMixinCall<'a> {
         let mut end = callee.span.end;
         let args = if let Some((_, lparen_span)) = eat!(input, LParen) {
             let mut semicolon_comes_at = 0;
-            let mut args = arena_vec!(input);
-            let mut comma_spans = arena_vec!(input);
-            let mut semicolon_spans = arena_vec!(input);
+            let mut args = input.vec();
+            let mut comma_spans = input.vec();
+            let mut semicolon_spans = input.vec();
             loop {
                 match peek!(input).token {
                     Token::RParen(..) => {
                         let TokenWithSpan { span, .. } = bump!(input);
                         if semicolon_comes_at > 0 {
-                            let comma_spans = mem::replace(&mut comma_spans, arena_vec!(input));
+                            let comma_spans = mem::replace(&mut comma_spans, input.vec());
                             wrap_less_mixin_args_into_less_list(
                                 input.allocator(),
                                 &mut args,
@@ -1216,7 +1207,7 @@ impl<'a> Parse<'a> for LessMixinCall<'a> {
                     }
                     Token::Semicolon(..) => {
                         let TokenWithSpan { span, .. } = bump!(input);
-                        let comma_spans = mem::replace(&mut comma_spans, arena_vec!(input));
+                        let comma_spans = mem::replace(&mut comma_spans, input.vec());
                         wrap_less_mixin_args_into_less_list(
                             input.allocator(),
                             &mut args,
@@ -1274,9 +1265,9 @@ impl<'a> Parser<'a> {
         let (_, lparen_span) = expect!(self, LParen);
         let rparen_span;
         let mut semicolon_comes_at = 0;
-        let mut params = arena_vec!(self);
-        let mut comma_spans = arena_vec!(self);
-        let mut semicolon_spans = arena_vec!(self);
+        let mut params = self.vec();
+        let mut comma_spans = self.vec();
+        let mut semicolon_spans = self.vec();
         'params: loop {
             match peek!(self).token {
                 Token::RParen(..) => {
@@ -1371,7 +1362,7 @@ impl<'a> Parser<'a> {
                 Token::RParen(..) => {
                     let span = bump!(self).span;
                     if semicolon_comes_at > 0 {
-                        let comma_spans = mem::replace(&mut comma_spans, arena_vec!(self));
+                        let comma_spans = mem::replace(&mut comma_spans, self.vec());
                         wrap_less_mixin_params_into_less_list(
                             self.allocator(),
                             &mut params,
@@ -1396,7 +1387,7 @@ impl<'a> Parser<'a> {
                 }
                 Token::Semicolon(..) => {
                     let span = bump!(self).span;
-                    let comma_spans = mem::replace(&mut comma_spans, arena_vec!(self));
+                    let comma_spans = mem::replace(&mut comma_spans, self.vec());
                     wrap_less_mixin_params_into_less_list(
                         self.allocator(),
                         &mut params,
@@ -1447,10 +1438,11 @@ impl<'a> Parse<'a> for LessMixinCallee<'a> {
         let first_name = input.parse::<LessMixinName>()?;
         let mut span = first_name.span().clone();
 
-        let mut children = arena_vec!(
-            input;
-            LessMixinCalleeChild { name: first_name, combinator: None, span: span.clone() }
-        );
+        let mut children = input.vec1(LessMixinCalleeChild {
+            name: first_name,
+            combinator: None,
+            span: span.clone(),
+        });
         loop {
             let combinator = eat!(input, GreaterThan)
                 .map(|(_, span)| Combinator { kind: CombinatorKind::Child, span });
@@ -1608,13 +1600,13 @@ impl<'a> Parse<'a> for LessNegativeValue<'a> {
                 span,
             } if minus_span.end == span.start => {
                 let value = input.parse_component_value_atom()?;
-                arena_box!(input, value)
+                input.alloc(value)
             }
             TokenWithSpan { token: Token::LParen(..), span } if minus_span.end == span.start => {
                 let value = ComponentValue::LessParenthesizedOperation(
                     input.parse_less_parenthesized_operation(/* allow_mixin_call */ true)?,
                 );
-                arena_box!(input, value)
+                input.alloc(value)
             }
             TokenWithSpan { token, span } => {
                 use crate::{

--- a/crates/oxc_css_parser/src/parser/macros.rs
+++ b/crates/oxc_css_parser/src/parser/macros.rs
@@ -121,28 +121,3 @@ macro_rules! peek {
         }
     }};
 }
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! arena_box {
-    ($parser:expr, $value:expr) => {{ oxc_allocator::Box::new_in($value, &$parser.allocator()) }};
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! arena_vec {
-    ($parser:expr) => {{
-        oxc_allocator::Vec::new_in(&$parser.allocator())
-    }};
-    ($parser:expr; $($value:expr),+ $(,)?) => {{
-        let mut vec = oxc_allocator::Vec::with_capacity_in(
-            <[()]>::len(&[$($crate::arena_vec!(@unit $value)),+]),
-            &$parser.allocator(),
-        );
-        $(vec.push($value);)+
-        vec
-    }};
-    (@unit $value:expr) => {
-        ()
-    };
-}

--- a/crates/oxc_css_parser/src/parser/mod.rs
+++ b/crates/oxc_css_parser/src/parser/mod.rs
@@ -94,8 +94,20 @@ impl<'a> Parser<'a> {
     }
 
     #[inline]
+    pub(crate) fn alloc<T>(&self, value: T) -> oxc_allocator::Box<'a, T> {
+        oxc_allocator::Box::new_in(value, &self.allocator)
+    }
+
+    #[inline]
     pub(crate) fn vec<T>(&self) -> ArenaVec<'a, T> {
         ArenaVec::new_in(&self.allocator)
+    }
+
+    #[inline]
+    pub(crate) fn vec1<T>(&self, value: T) -> ArenaVec<'a, T> {
+        let mut vec = self.vec_with_capacity(1);
+        vec.push(value);
+        vec
     }
 
     #[inline]

--- a/crates/oxc_css_parser/src/parser/sass.rs
+++ b/crates/oxc_css_parser/src/parser/sass.rs
@@ -3,7 +3,7 @@ use super::{
     state::{ParserState, SASS_CTX_ALLOW_DIV, SASS_CTX_IN_PARENS},
 };
 use crate::{
-    Parse, arena_box, arena_vec,
+    Parse,
     ast::*,
     bump,
     config::Syntax,
@@ -82,7 +82,7 @@ impl<'a> Parser<'a> {
             self.parse_sass_bin_expr(/* allow_comparison */ true)?
         };
 
-        let mut elements = arena_vec!(self);
+        let mut elements = self.vec();
         let mut comma_spans: Option<oxc_allocator::Vec<'a, Span>> = None;
         let mut separator = ListSeparatorKind::Unknown;
         let mut end = single_value.span().end;
@@ -119,7 +119,7 @@ impl<'a> Parser<'a> {
                         if let Some(spans) = &mut comma_spans {
                             spans.push(span);
                         } else {
-                            comma_spans = Some(arena_vec!(self; span));
+                            comma_spans = Some(self.vec1(span));
                         }
                     }
                 }
@@ -212,9 +212,9 @@ impl<'a> Parser<'a> {
                                 .map(|value| ComponentValue::Number(Number { value, raw, span }))?
                         };
                         left = ComponentValue::SassBinaryExpression(SassBinaryExpression {
-                            left: arena_box!(self, left),
+                            left: self.alloc(left),
                             op,
-                            right: arena_box!(self, right),
+                            right: self.alloc(right),
                             span,
                         });
                         continue;
@@ -255,9 +255,9 @@ impl<'a> Parser<'a> {
                             .map(ComponentValue::Dimension)?
                         };
                         left = ComponentValue::SassBinaryExpression(SassBinaryExpression {
-                            left: arena_box!(self, left),
+                            left: self.alloc(left),
                             op,
-                            right: arena_box!(self, right),
+                            right: self.alloc(right),
                             span,
                         });
                         continue;
@@ -318,12 +318,12 @@ impl<'a> Parser<'a> {
                         Ok((op_span, right)) => {
                             let span = Span { start: left.span().start, end: right.span().end };
                             left = ComponentValue::SassBinaryExpression(SassBinaryExpression {
-                                left: arena_box!(self, left),
+                                left: self.alloc(left),
                                 op: SassBinaryOperator {
                                     kind: SassBinaryOperatorKind::Modulo,
                                     span: op_span,
                                 },
-                                right: arena_box!(self, right),
+                                right: self.alloc(right),
                                 span,
                             });
                             continue;
@@ -455,9 +455,9 @@ impl<'a> Parser<'a> {
 
             let span = Span { start: left.span().start, end: right.span().end };
             left = ComponentValue::SassBinaryExpression(SassBinaryExpression {
-                left: arena_box!(self, left),
+                left: self.alloc(left),
                 op: operator,
-                right: arena_box!(self, right),
+                right: self.alloc(right),
                 span,
             });
         }
@@ -546,7 +546,7 @@ impl<'a> Parser<'a> {
         &mut self,
         end: &mut usize,
     ) -> PResult<oxc_allocator::Vec<'a, SassInterpolatedIdentElement<'a>>> {
-        let mut elements = arena_vec!(self);
+        let mut elements = self.vec();
         loop {
             if let Some((token, span)) = self.tokenizer.scan_ident_template()? {
                 *end = span.end;
@@ -583,7 +583,7 @@ impl<'a> Parser<'a> {
         debug_assert!(matches!(self.syntax, Syntax::Scss | Syntax::Sass));
 
         let mut values = self.vec_with_capacity(4);
-        let mut comma_spans = arena_vec!(self);
+        let mut comma_spans = self.vec();
         while !matches!(peek!(self).token, Token::RParen(..) | Token::Eof(..)) {
             match peek!(self).token {
                 Token::Comma(..) => {
@@ -597,7 +597,7 @@ impl<'a> Parser<'a> {
                     if let Some((_, span)) = eat!(self, DotDotDot) {
                         let span = Span { start: value.span().start, end: span.end };
                         values.push(ComponentValue::SassArbitraryArgument(SassArbitraryArgument {
-                            value: arena_box!(self, value),
+                            value: self.alloc(value),
                             span,
                         }));
                     } else if let ComponentValue::SassVariable(sass_var) = value {
@@ -607,7 +607,7 @@ impl<'a> Parser<'a> {
                             values.push(ComponentValue::SassKeywordArgument(SassKeywordArgument {
                                 name: sass_var,
                                 colon_span,
-                                value: arena_box!(self, value),
+                                value: self.alloc(value),
                                 span,
                             }));
                         } else {
@@ -638,9 +638,9 @@ impl<'a> Parser<'a> {
                 self.eat_sass_line_continuation()?;
                 let (_, lparen_span) = expect!(self, LParen);
 
-                let mut items =
-                    arena_vec!(self; self.parse_sass_module_config_item(allow_overridable)?);
-                let mut comma_spans = arena_vec!(self);
+                let item = self.parse_sass_module_config_item(allow_overridable)?;
+                let mut items = self.vec1(item);
+                let mut comma_spans = self.vec();
                 if let Some((_, span)) = eat!(self, RParen) {
                     end = span.end;
                 } else {
@@ -686,7 +686,7 @@ impl<'a> Parser<'a> {
             self.parse_sass_flags()
                 .map(|(flags, end)| (flags, end.unwrap_or_else(|| value.span().end)))?
         } else {
-            (arena_vec!(self), value.span().end)
+            (self.vec(), value.span().end)
         };
 
         let span = Span { start: variable.span.start, end };
@@ -695,9 +695,9 @@ impl<'a> Parser<'a> {
 
     /// This method will consume `)` token.
     fn parse_sass_params(&mut self) -> PResult<SassParams<'a>> {
-        let mut parameters = arena_vec!(self);
+        let mut parameters = self.vec();
         let mut arbitrary_parameter = None;
-        let mut comma_spans = arena_vec!(self);
+        let mut comma_spans = self.vec();
         let end;
         loop {
             if let Some((_, span)) = eat!(self, RParen) {
@@ -810,7 +810,7 @@ impl<'a> Parser<'a> {
         let expr = self.parse_sass_unary_expression()?;
         let span = Span { start: op.span.start, end: expr.span().end };
         Ok(ComponentValue::SassUnaryExpression(SassUnaryExpression {
-            expr: arena_box!(self, expr),
+            expr: self.alloc(expr),
             op,
             span,
         }))
@@ -892,8 +892,8 @@ impl<'a> Parse<'a> for SassEach<'a> {
         let first_binding = input.parse::<SassVariable>()?;
         let start = first_binding.span().start;
 
-        let mut bindings = arena_vec!(input; first_binding);
-        let mut comma_spans = arena_vec!(input);
+        let mut bindings = input.vec1(first_binding);
+        let mut comma_spans = input.vec();
         loop {
             // the comma may sit on a continuation line (`@each $a\n  , $b in ...`)
             input.eat_sass_line_continuation()?;
@@ -1011,8 +1011,8 @@ impl<'a> Parse<'a> for SassForward<'a> {
             let name = keyword.name();
             if name.eq_ignore_ascii_case("hide") {
                 let keyword_span = bump!(input).span;
-                let mut members = arena_vec!(input);
-                let mut comma_spans = arena_vec!(input);
+                let mut members = input.vec();
+                let mut comma_spans = input.vec();
                 loop {
                     input.eat_sass_line_continuation()?;
                     match &peek!(input).token {
@@ -1038,8 +1038,8 @@ impl<'a> Parse<'a> for SassForward<'a> {
                 })
             } else if name.eq_ignore_ascii_case("show") {
                 let keyword_span = bump!(input).span;
-                let mut members = arena_vec!(input);
-                let mut comma_spans = arena_vec!(input);
+                let mut members = input.vec();
+                let mut comma_spans = input.vec();
                 loop {
                     input.eat_sass_line_continuation()?;
                     match &peek!(input).token {
@@ -1104,7 +1104,7 @@ impl<'a> Parse<'a> for SassIfAtRule<'a> {
         let if_clause = input.parse::<SassConditionalClause>()?;
         let mut else_if_clauses: oxc_allocator::Vec<'a, SassConditionalClause<'a>> = input.vec();
         let mut else_clause: Option<SimpleBlock> = None;
-        let mut else_spans = arena_vec!(input);
+        let mut else_spans = input.vec();
 
         loop {
             // In the indented syntax `@else` sits on the line after the
@@ -1173,8 +1173,8 @@ impl<'a> Parse<'a> for SassImportPrelude<'a> {
         let first = input.parse::<Str>()?;
         let mut span = first.span.clone();
 
-        let mut paths = arena_vec!(input; first);
-        let mut comma_spans = arena_vec!(input);
+        let mut paths = input.vec1(first);
+        let mut comma_spans = input.vec();
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             paths.push(input.parse()?);
@@ -1251,7 +1251,7 @@ impl<'a> Parse<'a> for SassInterpolatedStr<'a> {
         debug_assert!(quote == '\'' || quote == '"');
         let mut span = first_span.clone();
         let first = input.interpolable_str_static_part(first, first_span);
-        let mut elements = arena_vec!(input; SassInterpolatedStrElement::Static(first));
+        let mut elements = input.vec1(SassInterpolatedStrElement::Static(first));
 
         let mut is_parsing_static_part = false;
         loop {
@@ -1296,7 +1296,7 @@ impl<'a> Parse<'a> for SassInterpolatedUrl<'a> {
         };
         let mut span = first_span.clone();
         let first = input.interpolable_url_static_part(first, first_span);
-        let mut elements = arena_vec!(input; SassInterpolatedUrlElement::Static(first));
+        let mut elements = input.vec1(SassInterpolatedUrlElement::Static(first));
 
         let mut is_parsing_static_part = false;
         loop {
@@ -1344,8 +1344,8 @@ impl<'a> Parse<'a> for SassMap<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let start = expect!(input, LParen).1.start;
 
-        let mut items = arena_vec!(input);
-        let mut comma_spans = arena_vec!(input);
+        let mut items = input.vec();
+        let mut comma_spans = input.vec();
         loop {
             match peek!(input).token {
                 Token::RParen(..) => break,
@@ -1431,7 +1431,7 @@ impl<'a> Parse<'a> for SassParenthesizedExpression<'a> {
                 ..input.state.clone()
             })
             .parse_maybe_sass_list(/* allow_comma */ true)?;
-        let expr = arena_box!(input, expr);
+        let expr = input.alloc(expr);
         let end = expect!(input, RParen).1.end;
         Ok(SassParenthesizedExpression { expr, span: Span { start, end } })
     }

--- a/crates/oxc_css_parser/src/parser/selector.rs
+++ b/crates/oxc_css_parser/src/parser/selector.rs
@@ -1,6 +1,6 @@
 use super::Parser;
 use crate::{
-    Parse, Syntax, arena_vec,
+    Parse, Syntax,
     ast::*,
     bump, eat,
     error::{Error, ErrorKind, PResult},
@@ -457,7 +457,7 @@ impl<'a> Parse<'a> for AttributeSelector<'a> {
                 // tokens up to the closing `]`.
                 TokenWithSpan { span, .. } if input.syntax == Syntax::Css => {
                     let start = span.start;
-                    let mut tokens = arena_vec!(input);
+                    let mut tokens = input.vec();
                     while !matches!(peek!(input).token, Token::RBracket(..) | Token::Eof(..)) {
                         tokens.push(bump!(input));
                     }
@@ -672,8 +672,8 @@ impl<'a> Parse<'a> for CompoundSelectorList<'a> {
         let first = input.parse::<CompoundSelector>()?;
         let mut span = first.span.clone();
 
-        let mut selectors = arena_vec!(input; first);
-        let mut comma_spans = arena_vec!(input);
+        let mut selectors = input.vec1(first);
+        let mut comma_spans = input.vec();
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             input.eat_sass_line_continuation()?;
@@ -759,8 +759,8 @@ impl<'a> Parse<'a> for LanguageRangeList<'a> {
         let first = input.parse::<LanguageRange>()?;
         let mut span = first.span().clone();
 
-        let mut ranges = arena_vec!(input; first);
-        let mut comma_spans = arena_vec!(input);
+        let mut ranges = input.vec1(first);
+        let mut comma_spans = input.vec();
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             ranges.push(input.parse()?);
@@ -1077,8 +1077,8 @@ impl<'a> Parse<'a> for RelativeSelectorList<'a> {
         let first = input.parse::<RelativeSelector>()?;
         let mut span = first.span.clone();
 
-        let mut selectors = arena_vec!(input; first);
-        let mut comma_spans = arena_vec!(input);
+        let mut selectors = input.vec1(first);
+        let mut comma_spans = input.vec();
         while let Some((_, comma_span)) = eat!(input, Comma) {
             comma_spans.push(comma_span);
             selectors.push(input.parse()?);
@@ -1100,7 +1100,7 @@ impl<'a> Parse<'a> for SelectorList<'a> {
 
         let mut selectors = input.vec_with_capacity(2);
         selectors.push(first);
-        let mut comma_spans = arena_vec!(input);
+        let mut comma_spans = input.vec();
 
         let is_css = input.syntax == Syntax::Css;
         while let Some((_, comma_span)) = eat!(input, Comma) {

--- a/crates/oxc_css_parser/src/parser/stmt.rs
+++ b/crates/oxc_css_parser/src/parser/stmt.rs
@@ -3,7 +3,7 @@ use super::{
     state::{ParserState, QualifiedRuleContext},
 };
 use crate::{
-    Parse, Syntax, arena_box, arena_vec,
+    Parse, Syntax,
     ast::*,
     bump, eat,
     error::{Error, ErrorKind, PResult},
@@ -291,7 +291,7 @@ impl<'a> Parse<'a> for SimpleBlock<'a> {
             } else {
                 let offset = peek!(input).span.start;
                 return Ok(SimpleBlock {
-                    statements: arena_vec!(input),
+                    statements: input.vec(),
                     span: Span { start: offset, end: offset },
                 });
             }
@@ -489,10 +489,9 @@ impl<'a> Parser<'a> {
                             if let Ok(sass_var_decl) =
                                 self.try_parse(SassVariableDeclaration::parse)
                             {
-                                statements.push(Statement::SassVariableDeclaration(arena_box!(
-                                    self,
-                                    sass_var_decl
-                                )));
+                                statements.push(Statement::SassVariableDeclaration(
+                                    self.alloc(sass_var_decl),
+                                ));
                             } else if self.state.in_keyframes_at_rule {
                                 let (stmt, is_block) =
                                     self.parse_keyframe_block_or_declaration()?;
@@ -552,7 +551,7 @@ impl<'a> Parser<'a> {
                         stmt
                     } else if let Ok(mixin_def) = self.try_parse(LessMixinDefinition::parse) {
                         is_block_element = true;
-                        Statement::LessMixinDefinition(arena_box!(self, mixin_def))
+                        Statement::LessMixinDefinition(self.alloc(mixin_def))
                     } else {
                         self.parse().map(Statement::LessMixinCall)?
                     };
@@ -629,8 +628,9 @@ impl<'a> Parser<'a> {
                         let at_keyword_name = at_keyword.ident.name();
                         match &*at_keyword_name {
                             "if" => {
+                                let sass_if_at_rule = self.parse()?;
                                 statements
-                                    .push(Statement::SassIfAtRule(arena_box!(self, self.parse()?)));
+                                    .push(Statement::SassIfAtRule(self.alloc(sass_if_at_rule)));
                                 is_block_element = true;
                             }
                             "else" => {
@@ -654,10 +654,9 @@ impl<'a> Parser<'a> {
                                 less_variable_declaration.value,
                                 ComponentValue::LessDetachedRuleset(..)
                             );
-                            statements.push(Statement::LessVariableDeclaration(arena_box!(
-                                self,
-                                less_variable_declaration
-                            )));
+                            statements.push(Statement::LessVariableDeclaration(
+                                self.alloc(less_variable_declaration),
+                            ));
                         } else if let Ok(variable_call) = self.try_parse(LessVariableCall::parse) {
                             statements.push(Statement::LessVariableCall(variable_call));
                         } else {
@@ -703,16 +702,15 @@ impl<'a> Parser<'a> {
                     is_block_element = true;
                 }
                 Token::DollarVar(..) if matches!(self.syntax, Syntax::Scss | Syntax::Sass) => {
-                    statements
-                        .push(Statement::SassVariableDeclaration(arena_box!(self, self.parse()?)));
+                    let declaration = self.parse()?;
+                    statements.push(Statement::SassVariableDeclaration(self.alloc(declaration)));
                 }
                 Token::DollarVar(..)
                     if self.syntax == Syntax::Css && self.options.allow_postcss_simple_vars =>
                 {
-                    statements.push(Statement::PostcssSimpleVarDeclaration(arena_box!(
-                        self,
-                        self.parse()?
-                    )));
+                    let declaration = self.parse()?;
+                    statements
+                        .push(Statement::PostcssSimpleVarDeclaration(self.alloc(declaration)));
                 }
                 // Indented-syntax shorthands: `=name` defines a mixin
                 // (`@mixin name`) and `+name` includes one (`@include name`).
@@ -732,7 +730,7 @@ impl<'a> Parser<'a> {
                     let span = Span { start: eq_span.start, end: block.span.end };
                     statements.push(Statement::AtRule(AtRule {
                         name: Ident { name: "mixin", raw: "=", span: eq_span },
-                        prelude: Some(AtRulePrelude::SassMixin(arena_box!(self, prelude))),
+                        prelude: Some(AtRulePrelude::SassMixin(self.alloc(prelude))),
                         block: Some(block),
                         span,
                     }));
@@ -762,7 +760,7 @@ impl<'a> Parser<'a> {
                     is_block_element = block.is_some();
                     statements.push(Statement::AtRule(AtRule {
                         name: Ident { name: "include", raw: "+", span: plus_span },
-                        prelude: Some(AtRulePrelude::SassInclude(arena_box!(self, prelude))),
+                        prelude: Some(AtRulePrelude::SassInclude(self.alloc(prelude))),
                         block,
                         span,
                     }));
@@ -785,8 +783,7 @@ impl<'a> Parser<'a> {
                 Token::At(..) if matches!(self.syntax, Syntax::Scss | Syntax::Sass) => {
                     let unknown_sass_at_rule = self.parse::<UnknownSassAtRule>()?;
                     is_block_element = unknown_sass_at_rule.block.is_some();
-                    statements
-                        .push(Statement::UnknownSassAtRule(arena_box!(self, unknown_sass_at_rule)));
+                    statements.push(Statement::UnknownSassAtRule(self.alloc(unknown_sass_at_rule)));
                 }
                 Token::Percentage(..)
                     if self.state.in_keyframes_at_rule
@@ -809,8 +806,8 @@ impl<'a> Parser<'a> {
                     let start = span.start;
                     let block = self.parse::<SimpleBlock>()?;
                     let selector = SelectorList {
-                        selectors: arena_vec!(self),
-                        comma_spans: arena_vec!(self),
+                        selectors: self.vec(),
+                        comma_spans: self.vec(),
                         span: Span { start, end: start },
                     };
                     let span = Span { start, end: block.span.end };

--- a/crates/oxc_css_parser/src/parser/value.rs
+++ b/crates/oxc_css_parser/src/parser/value.rs
@@ -1,6 +1,6 @@
 use super::{Parser, state::QualifiedRuleContext};
 use crate::{
-    Parse, Syntax, arena_box, arena_vec,
+    Parse, Syntax,
     ast::*,
     bump, eat,
     error::{Error, ErrorKind, PResult},
@@ -74,7 +74,7 @@ impl<'a> Parser<'a> {
                 let expr = self.parse_calc_expr_recursively(PRECEDENCE_MULTIPLY, allow_modulo)?;
                 let span = Span { start: op.span.start, end: expr.span().end };
                 ComponentValue::SassUnaryExpression(SassUnaryExpression {
-                    expr: arena_box!(self, expr),
+                    expr: self.alloc(expr),
                     op,
                     span,
                 })
@@ -117,9 +117,9 @@ impl<'a> Parser<'a> {
             let right = self.parse_calc_expr_recursively(precedence + 1, allow_modulo)?;
             let span = Span { start: left.span().start, end: right.span().end };
             left = ComponentValue::Calc(Calc {
-                left: arena_box!(self, left),
+                left: self.alloc(left),
                 op: operator,
-                right: arena_box!(self, right),
+                right: self.alloc(right),
                 span,
             });
         }
@@ -133,7 +133,7 @@ impl<'a> Parser<'a> {
             Token::Ident(token) => {
                 if unvendored(&token.name()).eq_ignore_ascii_case("url") {
                     match self.try_parse(Url::parse) {
-                        Ok(url) => return Ok(ComponentValue::Url(arena_box!(self, url))),
+                        Ok(url) => return Ok(ComponentValue::Url(self.alloc(url))),
                         Err(Error { kind: ErrorKind::TryParseError, .. }) => {}
                         Err(error) => {
                             // Not a `<url-token>` (quotes, parens, or raw
@@ -160,7 +160,7 @@ impl<'a> Parser<'a> {
                                 if ident.name.eq_ignore_ascii_case("src") =>
                             {
                                 self.parse_src_url(ident)
-                                    .map(|url| ComponentValue::Url(arena_box!(self, url)))
+                                    .map(|url| ComponentValue::Url(self.alloc(url)))
                             }
                             InterpolableIdent::Literal(ident)
                                 if unvendored(ident.name).eq_ignore_ascii_case("expression") =>
@@ -213,12 +213,12 @@ impl<'a> Parser<'a> {
                                 let (_, Span { end, .. }) = expect!(self, RParen);
                                 let span = Span { start: name.span.start, end };
                                 Ok(ComponentValue::Function(Function {
-                                    name: FunctionName::SassQualifiedName(arena_box!(self, name)),
+                                    name: FunctionName::SassQualifiedName(self.alloc(name)),
                                     args,
                                     span,
                                 }))
                             } else {
-                                Ok(ComponentValue::SassQualifiedName(arena_box!(self, name)))
+                                Ok(ComponentValue::SassQualifiedName(self.alloc(name)))
                             };
                         }
                     }
@@ -373,7 +373,7 @@ impl<'a> Parser<'a> {
     pub(super) fn parse_function(&mut self, name: InterpolableIdent<'a>) -> PResult<Function<'a>> {
         expect!(self, LParen);
         let args = if let Token::RParen(..) = &peek!(self).token {
-            arena_vec!(self)
+            self.vec()
         } else {
             match &name {
                 InterpolableIdent::Literal(ident)
@@ -456,15 +456,14 @@ impl<'a> Parser<'a> {
                     }
                 }
                 InterpolableIdent::Literal(ident) if ident.name.eq_ignore_ascii_case("element") => {
-                    arena_vec!(self; self.parse().map(ComponentValue::IdSelector)?)
+                    let id_selector = self.parse().map(ComponentValue::IdSelector)?;
+                    self.vec1(id_selector)
                 }
                 InterpolableIdent::Literal(Ident { raw: "boolean" | "if", .. })
                     if self.syntax == Syntax::Less =>
                 {
-                    let condition = ComponentValue::LessCondition(arena_box!(
-                        self,
-                        self.parse_less_condition(false)?
-                    ));
+                    let less_condition = self.parse_less_condition(false)?;
+                    let condition = ComponentValue::LessCondition(self.alloc(less_condition));
                     let mut args = self.parse_function_args()?;
                     args.insert(0, condition);
                     args
@@ -505,7 +504,7 @@ impl<'a> Parser<'a> {
                     let value = values.pop().unwrap();
                     let span = Span { start: value.span().start, end };
                     values.push(ComponentValue::SassArbitraryArgument(SassArbitraryArgument {
-                        value: arena_box!(self, value),
+                        value: self.alloc(value),
                         span,
                     }));
                 }
@@ -641,7 +640,7 @@ impl<'a> Parser<'a> {
                         if let Some((_, mut span)) = eat!(self, DotDotDot) {
                             span.start = value.span().start;
                             values.push(ComponentValue::SassArbitraryArgument(
-                                SassArbitraryArgument { value: arena_box!(self, value), span },
+                                SassArbitraryArgument { value: self.alloc(value), span },
                             ));
                         } else if let ComponentValue::SassVariable(sass_var) = value {
                             if let Some((_, colon_span)) = eat!(self, Colon) {
@@ -652,7 +651,7 @@ impl<'a> Parser<'a> {
                                     SassKeywordArgument {
                                         name: sass_var,
                                         colon_span,
-                                        value: arena_box!(self, value),
+                                        value: self.alloc(value),
                                         span,
                                     },
                                 ));
@@ -705,7 +704,7 @@ impl<'a> Parser<'a> {
                 }
                 modifiers
             }
-            _ => arena_vec!(self),
+            _ => self.vec(),
         };
         let end = expect!(self, RParen).1.end;
         let span = Span { start: name.span.start, end };
@@ -938,14 +937,11 @@ impl<'a> Parse<'a> for FunctionName<'a> {
                         bump!(input);
                         let member = input.parse::<Ident>()?;
                         let span = Span { start: ident.span.start, end: member.span.end };
-                        Ok(FunctionName::SassQualifiedName(arena_box!(
-                            input,
-                            SassQualifiedName {
-                                module: ident,
-                                member: SassModuleMemberName::Ident(member),
-                                span,
-                            }
-                        )))
+                        Ok(FunctionName::SassQualifiedName(input.alloc(SassQualifiedName {
+                            module: ident,
+                            member: SassModuleMemberName::Ident(member),
+                            span,
+                        })))
                     }
                     _ => Ok(FunctionName::Ident(InterpolableIdent::Literal(ident))),
                 }
@@ -1095,7 +1091,7 @@ impl<'a> Parse<'a> for Url<'a> {
                     }
                     modifiers
                 }
-                _ => arena_vec!(input),
+                _ => input.vec(),
             };
             let end = expect!(input, RParen).1.end;
             let span = Span { start: prefix_start, end };
@@ -1105,7 +1101,7 @@ impl<'a> Parse<'a> for Url<'a> {
                 start: prefix_start,
                 end: value.span.end + 1, // `)` is consumed, but span excludes it
             };
-            Ok(Url { name, value: Some(UrlValue::Raw(value)), modifiers: arena_vec!(input), span })
+            Ok(Url { name, value: Some(UrlValue::Raw(value)), modifiers: input.vec(), span })
         } else {
             match input.syntax {
                 Syntax::Css => Err(Error { kind: ErrorKind::InvalidUrl, span: bump!(input).span }),
@@ -1118,7 +1114,7 @@ impl<'a> Parse<'a> for Url<'a> {
                     Ok(Url {
                         name,
                         value: Some(UrlValue::SassInterpolated(value)),
-                        modifiers: arena_vec!(input),
+                        modifiers: input.vec(),
                         span,
                     })
                 }
@@ -1126,7 +1122,7 @@ impl<'a> Parse<'a> for Url<'a> {
                     let value = UrlValue::LessEscapedStr(input.parse()?);
                     let (_, Span { end, .. }) = expect!(input, RParen);
                     let span = Span { start: prefix_start, end };
-                    Ok(Url { name, value: Some(value), modifiers: arena_vec!(input), span })
+                    Ok(Url { name, value: Some(value), modifiers: input.vec(), span })
                 }
             }
         }


### PR DESCRIPTION
Replace `arena_box!` and `arena_vec!` with parser allocator helper methods.

Validation:
- `cargo check -p oxc-css-parser`
- `cargo test -p oxc-css-parser --lib --tests`