### PR TITLE
fix: resolve clippy warnings

### DIFF
--- a/crates/oxc_css_parser/src/parser/at_rule/import.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/import.rs
@@ -86,10 +86,10 @@ impl<'a> Parse<'a> for ImportPrelude<'a> {
         if let Some(media) = &media {
             span.end = media.span.end;
         }
-        if let Some(modifiers) = &modifiers {
-            if modifiers.span.end > modifiers.span.start {
-                span.end = modifiers.span.end;
-            }
+        if let Some(modifiers) = &modifiers
+            && modifiers.span.end > modifiers.span.start
+        {
+            span.end = modifiers.span.end;
         }
 
         Ok(ImportPrelude { href, layer, supports, media, modifiers, span })

--- a/crates/oxc_css_parser/src/parser/less.rs
+++ b/crates/oxc_css_parser/src/parser/less.rs
@@ -354,7 +354,7 @@ impl<'a> Parser<'a> {
                 bump!(self);
                 let (_, Span { end, .. }) = expect!(self, RParen);
                 let span = Span { start: variable.span.start, end };
-                return Ok(ComponentValue::LessVariableCall(LessVariableCall { variable, span }));
+                Ok(ComponentValue::LessVariableCall(LessVariableCall { variable, span }))
             }
             TokenWithSpan { token: Token::LBracket(..), span }
                 if variable.span.end == span.start =>

--- a/crates/oxc_css_parser/src/util.rs
+++ b/crates/oxc_css_parser/src/util.rs
@@ -42,10 +42,8 @@ pub(crate) fn track_paired_token(
             }
         }
         Token::LBrace(..) | Token::HashLBrace(..) => pairs.push(PairedToken::Brace),
-        Token::RBrace(..) => {
-            if !matches!(pairs.pop(), Some(PairedToken::Brace)) {
-                return false;
-            }
+        Token::RBrace(..) if !matches!(pairs.pop(), Some(PairedToken::Brace)) => {
+            return false;
         }
         _ => {}
     }


### PR DESCRIPTION
Resolves clippy warnings surfaced with exported API linting enabled.

Validated with `cargo clippy --workspace --all-targets --all-features`.
