### PR TITLE
refactor(parser): replace eat macro with methods

### DIFF
--- a/crates/oxc_css_parser/src/parser/at_rule/container.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/container.rs
@@ -2,7 +2,6 @@ use super::Parser;
 use crate::{
     Parse,
     ast::*,
-    eat,
     error::{Error, ErrorKind, PResult},
     expect, expect_without_ws_or_comments,
     pos::{Span, Spanned},
@@ -93,7 +92,7 @@ impl<'a> Parse<'a> for ContainerConditionOr<'a> {
 
 impl<'a> Parse<'a> for QueryInParens<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        if let Some((_, Span { start, .. })) = eat!(input, LParen) {
+        if let Some((_, Span { start, .. })) = input.cursor.eat_l_paren()? {
             let kind = if let Ok(container_condition) = input.try_parse(ContainerCondition::parse) {
                 QueryInParensKind::ContainerCondition(container_condition)
             } else {
@@ -250,7 +249,7 @@ impl<'a> Parse<'a> for StyleQuery<'a> {
             Ok(StyleQuery::FeatureName(name))
         } else {
             let feature = input.parse().map(StyleQuery::Feature);
-            eat!(input, Semicolon);
+            input.cursor.eat_semicolon()?;
             feature
         }
     }

--- a/crates/oxc_css_parser/src/parser/at_rule/document.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/document.rs
@@ -1,5 +1,5 @@
 use super::Parser;
-use crate::{Parse, Spanned, ast::*, eat, error::PResult};
+use crate::{Parse, Spanned, ast::*, error::PResult};
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/@document
 impl<'a> Parse<'a> for DocumentPrelude<'a> {
@@ -9,7 +9,7 @@ impl<'a> Parse<'a> for DocumentPrelude<'a> {
 
         let mut matchers = input.vec1(first);
         let mut comma_spans = input.vec();
-        while let Some((_, comma_span)) = eat!(input, Comma) {
+        while let Some((_, comma_span)) = input.cursor.eat_comma()? {
             comma_spans.push(comma_span);
             matchers.push(input.parse()?);
         }

--- a/crates/oxc_css_parser/src/parser/at_rule/keyframes.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/keyframes.rs
@@ -2,7 +2,6 @@ use super::Parser;
 use crate::{
     Parse,
     ast::*,
-    eat,
     error::{Error, ErrorKind, PResult},
     parser::state::ParserState,
     pos::{Span, Spanned},
@@ -19,7 +18,7 @@ impl<'a> Parse<'a> for KeyframeBlock<'a> {
         let mut selectors = input.vec_with_capacity(2);
         selectors.push(first_selector);
         let mut comma_spans = input.vec();
-        while let Some((_, comma_span)) = eat!(input, Comma) {
+        while let Some((_, comma_span)) = input.cursor.eat_comma()? {
             comma_spans.push(comma_span);
             selectors.push(input.parse()?);
         }

--- a/crates/oxc_css_parser/src/parser/at_rule/layer.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/layer.rs
@@ -2,7 +2,6 @@ use super::Parser;
 use crate::{
     Parse,
     ast::*,
-    eat,
     error::{Error, PResult},
     pos::{Span, Spanned},
     tokenizer::{Token, TokenWithSpan},
@@ -17,7 +16,7 @@ impl<'a> Parse<'a> for LayerNames<'a> {
 
         let mut names = input.vec1(first);
         let mut comma_spans = input.vec();
-        while let Some((_, comma_span)) = eat!(input, Comma) {
+        while let Some((_, comma_span)) = input.cursor.eat_comma()? {
             comma_spans.push(comma_span);
             names.push(input.parse()?);
         }

--- a/crates/oxc_css_parser/src/parser/at_rule/media.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/media.rs
@@ -2,7 +2,6 @@ use super::Parser;
 use crate::{
     Parse, Syntax,
     ast::*,
-    eat,
     error::{Error, ErrorKind, PResult},
     expect,
     pos::{Span, Spanned},
@@ -237,7 +236,7 @@ impl<'a> Parse<'a> for MediaQueryList<'a> {
 
         let mut queries = input.vec1(first);
         let mut comma_spans = input.vec();
-        while let Some((_, comma_span)) = eat!(input, Comma) {
+        while let Some((_, comma_span)) = input.cursor.eat_comma()? {
             comma_spans.push(comma_span);
             queries.push(input.parse()?);
         }

--- a/crates/oxc_css_parser/src/parser/at_rule/page.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/page.rs
@@ -2,7 +2,6 @@ use super::Parser;
 use crate::{
     Parse,
     ast::*,
-    eat,
     error::PResult,
     expect,
     pos::{Span, Spanned},
@@ -53,7 +52,7 @@ impl<'a> Parse<'a> for PageSelectorList<'a> {
 
         let mut selectors = input.vec1(first);
         let mut comma_spans = input.vec();
-        while let Some((_, comma_span)) = eat!(input, Comma) {
+        while let Some((_, comma_span)) = input.cursor.eat_comma()? {
             comma_spans.push(comma_span);
             selectors.push(input.parse()?);
         }

--- a/crates/oxc_css_parser/src/parser/less.rs
+++ b/crates/oxc_css_parser/src/parser/less.rs
@@ -6,7 +6,6 @@ use crate::{
     Parse,
     ast::*,
     config::Syntax,
-    eat,
     error::{Error, ErrorKind, PResult},
     expect, expect_without_ws_or_comments,
     pos::{Span, Spanned},
@@ -162,7 +161,7 @@ impl<'a> Parser<'a> {
                 }
                 Token::Ident(ident) if ident.raw == "not" => {
                     let Span { start, .. } = self.cursor.bump()?.span;
-                    let (condition, end) = if eat!(self, LParen).is_some() {
+                    let (condition, end) = if self.cursor.eat_l_paren()?.is_some() {
                         self.parse_less_guard_paren_condition(needs_parens)?
                     } else {
                         // less.js also accepts a bare operand: `when not @a`
@@ -869,7 +868,7 @@ impl<'a> Parse<'a> for LessExtendList<'a> {
 
         let mut elements = input.vec1(first);
         let mut comma_spans = input.vec();
-        while let Some((_, comma_span)) = eat!(input, Comma) {
+        while let Some((_, comma_span)) = input.cursor.eat_comma()? {
             comma_spans.push(comma_span);
             elements.push(input.parse()?);
         }
@@ -1020,7 +1019,7 @@ impl<'a> Parse<'a> for LessInterpolatedStr<'a> {
 
 impl<'a> Parse<'a> for LessJavaScriptSnippet<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        let tilde = eat!(input, Tilde);
+        let tilde = input.cursor.eat_tilde()?;
         let (token, span) = expect!(input, BacktickCode);
 
         Ok(LessJavaScriptSnippet {
@@ -1113,7 +1112,7 @@ impl<'a> Parse<'a> for LessMixinCall<'a> {
         let callee = input.parse::<LessMixinCallee>()?;
 
         let mut end = callee.span.end;
-        let args = if let Some((_, lparen_span)) = eat!(input, LParen) {
+        let args = if let Some((_, lparen_span)) = input.cursor.eat_l_paren()? {
             let mut semicolon_comes_at = 0;
             let mut args = input.vec();
             let mut comma_spans = input.vec();
@@ -1168,7 +1167,7 @@ impl<'a> Parse<'a> for LessMixinCall<'a> {
                                 }
                             }
                         };
-                        if let Some((_, colon_span)) = eat!(input, Colon) {
+                        if let Some((_, colon_span)) = input.cursor.eat_colon()? {
                             let value = if matches!(input.cursor.peek()?.token, Token::LBrace(..)) {
                                 input.parse().map(ComponentValue::LessDetachedRuleset)?
                             } else {
@@ -1183,7 +1182,7 @@ impl<'a> Parse<'a> for LessMixinCall<'a> {
                                 value,
                                 span,
                             }));
-                        } else if let Some((_, dotdotdot_span)) = eat!(input, DotDotDot) {
+                        } else if let Some((_, dotdotdot_span)) = input.cursor.eat_dot_dot_dot()? {
                             // unlike definitions, call-site spreads may appear
                             // anywhere and repeat: `.m(@x..., @a: 0)`,
                             // `.aa(@y, @x..., and again, @y...)`
@@ -1285,7 +1284,7 @@ impl<'a> Parser<'a> {
                         name: None,
                         span,
                     }));
-                    eat!(self, Semicolon);
+                    self.cursor.eat_semicolon()?;
                     (_, rparen_span) = expect!(self, RParen);
                     break;
                 }
@@ -1320,7 +1319,7 @@ impl<'a> Parser<'a> {
                         }
                     };
                     let name_span = name.span();
-                    if let Some((_, colon_span)) = eat!(self, Colon) {
+                    if let Some((_, colon_span)) = self.cursor.eat_colon()? {
                         let value = if matches!(self.cursor.peek()?.token, Token::LBrace(..)) {
                             self.parse().map(ComponentValue::LessDetachedRuleset)?
                         } else {
@@ -1341,13 +1340,13 @@ impl<'a> Parser<'a> {
                             value: Some(default_value),
                             span,
                         }));
-                    } else if let Some((_, Span { end, .. })) = eat!(self, DotDotDot) {
+                    } else if let Some((_, Span { end, .. })) = self.cursor.eat_dot_dot_dot()? {
                         let span = Span { start: name_span.start, end };
                         params.push(LessMixinParameter::Variadic(LessMixinVariadicParameter {
                             name: Some(name),
                             span,
                         }));
-                        if let Some((_, semicolon_span)) = eat!(self, Semicolon) {
+                        if let Some((_, semicolon_span)) = self.cursor.eat_semicolon()? {
                             semicolon_spans.push(semicolon_span);
                         };
                         (_, rparen_span) = expect!(self, RParen);
@@ -1449,7 +1448,9 @@ impl<'a> Parse<'a> for LessMixinCallee<'a> {
             span: span.clone(),
         });
         loop {
-            let combinator = eat!(input, GreaterThan)
+            let combinator = input
+                .cursor
+                .eat_greater_than()?
                 .map(|(_, span)| Combinator { kind: CombinatorKind::Child, span });
             let at_name = {
                 let TokenWithSpan { token, span } = input.cursor.peek()?;
@@ -1646,7 +1647,7 @@ impl<'a> Parse<'a> for LessPlugin<'a> {
 
         let mut start = None;
 
-        let args = if let Some((_, span)) = eat!(input, LParen) {
+        let args = if let Some((_, span)) = input.cursor.eat_l_paren()? {
             start = Some(span.start);
             let args = input.parse_tokens_in_parens()?;
             expect!(input, RParen);

--- a/crates/oxc_css_parser/src/parser/macros.rs
+++ b/crates/oxc_css_parser/src/parser/macros.rs
@@ -72,19 +72,3 @@ macro_rules! expect_without_ws_or_comments {
         }
     }};
 }
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! eat {
-    ($parser:expr, $variant:ident) => {{
-        use $crate::tokenizer::{Token, TokenWithSpan};
-        let token_with_span = $parser.cursor.bump()?;
-        match token_with_span {
-            TokenWithSpan { token: Token::$variant(token), span } => Some((token, span)),
-            value => {
-                $parser.cursor.cached_token = Some(value);
-                None
-            }
-        }
-    }};
-}

--- a/crates/oxc_css_parser/src/parser/mod.rs
+++ b/crates/oxc_css_parser/src/parser/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     error::{Error, PResult},
     expect,
     pos::Span,
-    tokenizer::{TokenWithSpan, Tokenizer, token},
+    tokenizer::{Token, TokenWithSpan, Tokenizer, token},
     util,
 };
 pub use builder::ParserBuilder;
@@ -61,6 +61,125 @@ impl<'a> ParserCursor<'a> {
             Some(token_with_span) => Ok(token_with_span),
             None => unreachable!(),
         }
+    }
+
+    #[inline]
+    fn eat_token<T>(
+        &mut self,
+        extract: impl FnOnce(Token<'a>) -> Result<T, Token<'a>>,
+    ) -> PResult<Option<(T, Span)>> {
+        let TokenWithSpan { token, span } = self.bump()?;
+        match extract(token) {
+            Ok(token) => Ok(Some((token, span))),
+            Err(token) => {
+                self.cached_token = Some(TokenWithSpan { token, span });
+                Ok(None)
+            }
+        }
+    }
+
+    #[inline]
+    fn eat_bar(&mut self) -> PResult<Option<(token::Bar, Span)>> {
+        self.eat_token(|token| match token {
+            Token::Bar(token) => Ok(token),
+            token => Err(token),
+        })
+    }
+
+    #[inline]
+    fn eat_colon(&mut self) -> PResult<Option<(token::Colon, Span)>> {
+        self.eat_token(|token| match token {
+            Token::Colon(token) => Ok(token),
+            token => Err(token),
+        })
+    }
+
+    #[inline]
+    fn eat_comma(&mut self) -> PResult<Option<(token::Comma, Span)>> {
+        self.eat_token(|token| match token {
+            Token::Comma(token) => Ok(token),
+            token => Err(token),
+        })
+    }
+
+    #[inline]
+    fn eat_dot_dot_dot(&mut self) -> PResult<Option<(token::DotDotDot, Span)>> {
+        self.eat_token(|token| match token {
+            Token::DotDotDot(token) => Ok(token),
+            token => Err(token),
+        })
+    }
+
+    #[inline]
+    fn eat_exclamation(&mut self) -> PResult<Option<(token::Exclamation, Span)>> {
+        self.eat_token(|token| match token {
+            Token::Exclamation(token) => Ok(token),
+            token => Err(token),
+        })
+    }
+
+    #[inline]
+    fn eat_greater_than(&mut self) -> PResult<Option<(token::GreaterThan, Span)>> {
+        self.eat_token(|token| match token {
+            Token::GreaterThan(token) => Ok(token),
+            token => Err(token),
+        })
+    }
+
+    #[inline]
+    fn eat_ident(&mut self) -> PResult<Option<(token::Ident<'a>, Span)>> {
+        self.eat_token(|token| match token {
+            Token::Ident(token) => Ok(token),
+            token => Err(token),
+        })
+    }
+
+    #[inline]
+    fn eat_indent(&mut self) -> PResult<Option<(token::Indent, Span)>> {
+        self.eat_token(|token| match token {
+            Token::Indent(token) => Ok(token),
+            token => Err(token),
+        })
+    }
+
+    #[inline]
+    fn eat_linebreak(&mut self) -> PResult<Option<(token::Linebreak, Span)>> {
+        self.eat_token(|token| match token {
+            Token::Linebreak(token) => Ok(token),
+            token => Err(token),
+        })
+    }
+
+    #[inline]
+    fn eat_l_paren(&mut self) -> PResult<Option<(token::LParen, Span)>> {
+        self.eat_token(|token| match token {
+            Token::LParen(token) => Ok(token),
+            token => Err(token),
+        })
+    }
+
+    #[inline]
+    fn eat_r_paren(&mut self) -> PResult<Option<(token::RParen, Span)>> {
+        self.eat_token(|token| match token {
+            Token::RParen(token) => Ok(token),
+            token => Err(token),
+        })
+    }
+
+    #[inline]
+    fn eat_semicolon(&mut self) -> PResult<Option<(token::Semicolon, Span)>> {
+        self.eat_token(|token| match token {
+            Token::Semicolon(token) => Ok(token),
+            token => Err(token),
+        })
+    }
+
+    #[inline]
+    fn eat_tilde(&mut self) -> PResult<Option<(token::Tilde, Span)>> {
+        self.eat_token(|token| match token {
+            Token::Tilde(token) => Ok(token),
+            token => Err(token),
+        })
     }
 }
 

--- a/crates/oxc_css_parser/src/parser/sass.rs
+++ b/crates/oxc_css_parser/src/parser/sass.rs
@@ -6,7 +6,6 @@ use crate::{
     Parse,
     ast::*,
     config::Syntax,
-    eat,
     error::{Error, ErrorKind, PResult},
     expect, expect_without_ws_or_comments,
     pos::{Span, Spanned},
@@ -471,7 +470,7 @@ impl<'a> Parser<'a> {
     ) -> PResult<(oxc_allocator::Vec<'a, SassFlag<'a>>, Option<usize>)> {
         let mut flags: oxc_allocator::Vec<'a, SassFlag<'a>> = self.vec_with_capacity(1);
         let mut end = None;
-        while let Some((_, exclamation_span)) = eat!(self, Exclamation) {
+        while let Some((_, exclamation_span)) = self.cursor.eat_exclamation()? {
             let keyword = self.parse::<Ident>()?;
             let keyword_span = keyword.span.clone();
             util::assert_no_ws_or_comment(&exclamation_span, &keyword_span)?;
@@ -595,14 +594,14 @@ impl<'a> Parser<'a> {
                 }
                 _ => {
                     let value = self.parse_maybe_sass_list(/* allow_comma */ false)?;
-                    if let Some((_, span)) = eat!(self, DotDotDot) {
+                    if let Some((_, span)) = self.cursor.eat_dot_dot_dot()? {
                         let span = Span { start: value.span().start, end: span.end };
                         values.push(ComponentValue::SassArbitraryArgument(SassArbitraryArgument {
                             value: self.alloc(value),
                             span,
                         }));
                     } else if let ComponentValue::SassVariable(sass_var) = value {
-                        if let Some((_, colon_span)) = eat!(self, Colon) {
+                        if let Some((_, colon_span)) = self.cursor.eat_colon()? {
                             let value = self.parse_maybe_sass_list(/* allow_comma */ false)?;
                             let span = Span { start: sass_var.span.start, end: value.span().end };
                             values.push(ComponentValue::SassKeywordArgument(SassKeywordArgument {
@@ -642,18 +641,18 @@ impl<'a> Parser<'a> {
                 let item = self.parse_sass_module_config_item(allow_overridable)?;
                 let mut items = self.vec1(item);
                 let mut comma_spans = self.vec();
-                if let Some((_, span)) = eat!(self, RParen) {
+                if let Some((_, span)) = self.cursor.eat_r_paren()? {
                     end = span.end;
                 } else {
                     comma_spans.push(expect!(self, Comma).1);
                     loop {
-                        if let Some((_, span)) = eat!(self, RParen) {
+                        if let Some((_, span)) = self.cursor.eat_r_paren()? {
                             end = span.end;
                             break;
                         }
 
                         items.push(self.parse_sass_module_config_item(allow_overridable)?);
-                        if let Some((_, span)) = eat!(self, RParen) {
+                        if let Some((_, span)) = self.cursor.eat_r_paren()? {
                             end = span.end;
                             break;
                         } else {
@@ -701,7 +700,7 @@ impl<'a> Parser<'a> {
         let mut comma_spans = self.vec();
         let end;
         loop {
-            if let Some((_, span)) = eat!(self, RParen) {
+            if let Some((_, span)) = self.cursor.eat_r_paren()? {
                 end = span.end;
                 break;
             }
@@ -733,7 +732,7 @@ impl<'a> Parser<'a> {
                 Token::DotDotDot(..) => {
                     let span = Span { start: name.span().start, end: token_with_span.span.end };
                     arbitrary_parameter = Some(SassArbitraryParameter { name, span });
-                    if let Some((_, comma_span)) = eat!(self, Comma) {
+                    if let Some((_, comma_span)) = self.cursor.eat_comma()? {
                         comma_spans.push(comma_span);
                     }
                     end = expect!(self, RParen).1.end;
@@ -752,7 +751,7 @@ impl<'a> Parser<'a> {
                     });
                 }
             }
-            if let Some((_, span)) = eat!(self, RParen) {
+            if let Some((_, span)) = self.cursor.eat_r_paren()? {
                 end = span.end;
                 break;
             } else {
@@ -901,7 +900,7 @@ impl<'a> Parse<'a> for SassEach<'a> {
         loop {
             // the comma may sit on a continuation line (`@each $a\n  , $b in ...`)
             input.eat_sass_line_continuation()?;
-            let Some((_, comma_span)) = eat!(input, Comma) else { break };
+            let Some((_, comma_span)) = input.cursor.eat_comma()? else { break };
             comma_spans.push(comma_span);
             input.eat_sass_line_continuation()?;
             bindings.push(input.parse()?);
@@ -928,7 +927,7 @@ impl<'a> Parse<'a> for SassExtend<'a> {
         let start = selectors.span.start;
         let mut end = selectors.span.end;
 
-        let optional = if let Some((_, exclamation_span)) = eat!(input, Exclamation) {
+        let optional = if let Some((_, exclamation_span)) = input.cursor.eat_exclamation()? {
             let (keyword, keyword_span) = expect_without_ws_or_comments!(input, Ident);
             if keyword.name().eq_ignore_ascii_case("optional") {
                 end = keyword_span.end;
@@ -1025,7 +1024,7 @@ impl<'a> Parse<'a> for SassForward<'a> {
                         }
                         _ => members.push(input.parse().map(SassForwardMember::Variable)?),
                     }
-                    if let Some((_, span)) = eat!(input, Comma) {
+                    if let Some((_, span)) = input.cursor.eat_comma()? {
                         comma_spans.push(span);
                     } else {
                         break;
@@ -1052,7 +1051,7 @@ impl<'a> Parse<'a> for SassForward<'a> {
                         }
                         _ => members.push(input.parse().map(SassForwardMember::Variable)?),
                     }
-                    if let Some((_, span)) = eat!(input, Comma) {
+                    if let Some((_, span)) = input.cursor.eat_comma()? {
                         comma_spans.push(span);
                     } else {
                         break;
@@ -1117,7 +1116,7 @@ impl<'a> Parse<'a> for SassIfAtRule<'a> {
             // (Linebreak tokens exist only in the indented syntax, so the
             // rollback snapshot is needed only when one is present.)
             fn else_keyword<'a>(p: &mut Parser<'a>) -> PResult<(Span, bool)> {
-                while eat!(p, Linebreak).is_some() {}
+                while p.cursor.eat_linebreak()?.is_some() {}
                 let is_else = match &p.cursor.peek()?.token {
                     Token::AtKeyword(at_keyword) => match &*at_keyword.ident.name() {
                         "else" => true,
@@ -1179,7 +1178,7 @@ impl<'a> Parse<'a> for SassImportPrelude<'a> {
 
         let mut paths = input.vec1(first);
         let mut comma_spans = input.vec();
-        while let Some((_, comma_span)) = eat!(input, Comma) {
+        while let Some((_, comma_span)) = input.cursor.eat_comma()? {
             comma_spans.push(comma_span);
             paths.push(input.parse()?);
         }
@@ -1428,7 +1427,7 @@ impl<'a> Parse<'a> for SassNestingDeclaration<'a> {
 impl<'a> Parse<'a> for SassParenthesizedExpression<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let start = expect!(input, LParen).1.start;
-        eat!(input, Indent);
+        input.cursor.eat_indent()?;
         let expr = input
             .with_state(ParserState {
                 sass_ctx: input.state.sass_ctx | SASS_CTX_ALLOW_DIV | SASS_CTX_IN_PARENS,
@@ -1528,7 +1527,7 @@ impl<'a> Parse<'a> for SassVariableDeclaration<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
 
-        let namespace = if let Some((ident_token, span)) = eat!(input, Ident) {
+        let namespace = if let Some((ident_token, span)) = input.cursor.eat_ident()? {
             let (_, dot_span) = expect!(input, Dot);
             util::assert_no_ws_or_comment(&span, &dot_span)?;
             let TokenWithSpan { span: next_span, .. } = input.cursor.peek()?;

--- a/crates/oxc_css_parser/src/parser/selector.rs
+++ b/crates/oxc_css_parser/src/parser/selector.rs
@@ -2,7 +2,6 @@ use super::Parser;
 use crate::{
     Parse, Syntax,
     ast::*,
-    eat,
     error::{Error, ErrorKind, PResult},
     expect, expect_without_ws_or_comments,
     pos::{Span, Spanned},
@@ -322,7 +321,7 @@ impl<'a> Parse<'a> for AttributeSelector<'a> {
             } => {
                 let ident = input.parse::<InterpolableIdent>()?;
                 let ident_span = ident.span();
-                if let Some((_, bar_token_span)) = eat!(input, Bar) {
+                if let Some((_, bar_token_span)) = input.cursor.eat_bar()? {
                     let name = input.parse::<InterpolableIdent>()?;
                     let name_span = name.span();
 
@@ -678,7 +677,7 @@ impl<'a> Parse<'a> for CompoundSelectorList<'a> {
 
         let mut selectors = input.vec1(first);
         let mut comma_spans = input.vec();
-        while let Some((_, comma_span)) = eat!(input, Comma) {
+        while let Some((_, comma_span)) = input.cursor.eat_comma()? {
             comma_spans.push(comma_span);
             input.eat_sass_line_continuation()?;
             selectors.push(input.parse()?);
@@ -765,7 +764,7 @@ impl<'a> Parse<'a> for LanguageRangeList<'a> {
 
         let mut ranges = input.vec1(first);
         let mut comma_spans = input.vec();
-        while let Some((_, comma_span)) = eat!(input, Comma) {
+        while let Some((_, comma_span)) = input.cursor.eat_comma()? {
             comma_spans.push(comma_span);
             ranges.push(input.parse()?);
         }
@@ -1083,7 +1082,7 @@ impl<'a> Parse<'a> for RelativeSelectorList<'a> {
 
         let mut selectors = input.vec1(first);
         let mut comma_spans = input.vec();
-        while let Some((_, comma_span)) = eat!(input, Comma) {
+        while let Some((_, comma_span)) = input.cursor.eat_comma()? {
             comma_spans.push(comma_span);
             selectors.push(input.parse()?);
         }
@@ -1107,13 +1106,13 @@ impl<'a> Parse<'a> for SelectorList<'a> {
         let mut comma_spans = input.vec();
 
         let is_css = input.syntax == Syntax::Css;
-        while let Some((_, comma_span)) = eat!(input, Comma) {
+        while let Some((_, comma_span)) = input.cursor.eat_comma()? {
             span.end = comma_span.end;
             comma_spans.push(comma_span);
             // legacy corpora carry doubled/trailing commas (`div,, span,, {`);
             // absorb the extras in SCSS like libsass did
             if input.syntax == Syntax::Scss {
-                while let Some((_, comma_span)) = eat!(input, Comma) {
+                while let Some((_, comma_span)) = input.cursor.eat_comma()? {
                     span.end = comma_span.end;
                     comma_spans.push(comma_span);
                 }

--- a/crates/oxc_css_parser/src/parser/stmt.rs
+++ b/crates/oxc_css_parser/src/parser/stmt.rs
@@ -5,7 +5,6 @@ use super::{
 use crate::{
     Parse, Syntax,
     ast::*,
-    eat,
     error::{Error, ErrorKind, PResult},
     expect,
     pos::{Span, Spanned},
@@ -274,7 +273,7 @@ impl<'a> Parse<'a> for SimpleBlock<'a> {
             // pending indent whose `Dedent` arrives before the block opens
             // (`a,\n    b\n  c: d`); cancel those out first.
             let drained = input.drain_sass_pending_dedents()?;
-            if let Some((_, span)) = eat!(input, Indent) {
+            if let Some((_, span)) = input.cursor.eat_indent()? {
                 span.end
             } else if drained
                 && input.sass_pending_indents == 0
@@ -847,14 +846,14 @@ impl<'a> Parser<'a> {
                         // The indented syntax also accepts `;` as a statement
                         // terminator/separator (`a; b`), like a newline.
                         if is_block_element {
-                            if eat!(self, Semicolon).is_none() {
-                                eat!(self, Linebreak);
+                            if self.cursor.eat_semicolon()?.is_none() {
+                                self.cursor.eat_linebreak()?;
                             }
-                        } else if eat!(self, Semicolon).is_none() {
+                        } else if self.cursor.eat_semicolon()?.is_none() {
                             expect!(self, Linebreak);
                         }
                     } else if is_block_element {
-                        eat!(self, Semicolon);
+                        self.cursor.eat_semicolon()?;
                     } else {
                         expect!(self, Semicolon);
                     }

--- a/crates/oxc_css_parser/src/parser/value.rs
+++ b/crates/oxc_css_parser/src/parser/value.rs
@@ -2,7 +2,6 @@ use super::{Parser, state::QualifiedRuleContext};
 use crate::{
     Parse, Syntax,
     ast::*,
-    eat,
     error::{Error, ErrorKind, PResult},
     expect,
     pos::{Span, Spanned},
@@ -47,7 +46,7 @@ impl<'a> Parser<'a> {
         allow_modulo: bool,
     ) -> PResult<ComponentValue<'a>> {
         let mut left = if precedence >= PRECEDENCE_MULTIPLY {
-            if eat!(self, LParen).is_some() {
+            if self.cursor.eat_l_paren()?.is_some() {
                 let expr = self.parse_calc_expr(allow_modulo)?;
                 expect!(self, RParen);
                 expr
@@ -639,13 +638,13 @@ impl<'a> Parser<'a> {
                         continue;
                     };
                     if matches!(self.syntax, Syntax::Scss | Syntax::Sass) {
-                        if let Some((_, mut span)) = eat!(self, DotDotDot) {
+                        if let Some((_, mut span)) = self.cursor.eat_dot_dot_dot()? {
                             span.start = value.span().start;
                             values.push(ComponentValue::SassArbitraryArgument(
                                 SassArbitraryArgument { value: self.alloc(value), span },
                             ));
                         } else if let ComponentValue::SassVariable(sass_var) = value {
-                            if let Some((_, colon_span)) = eat!(self, Colon) {
+                            if let Some((_, colon_span)) = self.cursor.eat_colon()? {
                                 let value = self.parse::<ComponentValue>()?;
                                 let span =
                                     Span { start: sass_var.span.start, end: value.span().end };


### PR DESCRIPTION
Replace `eat!` with typed parser cursor methods for optional token consumption.

Validation:
- `cargo fmt --check`
- `cargo check -p oxc-css-parser`
- `cargo test -p oxc-css-parser --lib --tests`