### PR TITLE
refactor(tokenizer): remove token wrapper spanned impl

### DIFF
--- a/crates/oxc_css_parser/src/ast_generated.rs
+++ b/crates/oxc_css_parser/src/ast_generated.rs
@@ -204,7 +204,7 @@ impl<'a> crate::pos::Spanned for ComponentValue<'a> {
             Self::SassParentSelector(value) => value.span(),
             Self::SassUnaryExpression(value) => value.span(),
             Self::SassVariable(value) => value.span(),
-            Self::TokenWithSpan(value) => value.span(),
+            Self::TokenWithSpan(value) => &value.span,
             Self::UnicodeRange(value) => value.span(),
             Self::Url(value) => value.span(),
         }

--- a/crates/oxc_css_parser/src/parser/at_rule/mod.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/mod.rs
@@ -674,7 +674,7 @@ impl<'a> Parser<'a> {
                 }
             }
             if let Some((first, last)) = tokens.first().zip(tokens.last()) {
-                let span = Span { start: first.span().start, end: last.span().end };
+                let span = Span { start: first.span.start, end: last.span.end };
                 Ok(Some(UnknownAtRulePrelude::TokenSeq(TokenSeq { tokens, span })))
             } else {
                 Ok(None)

--- a/crates/oxc_css_parser/src/tokenizer/token.rs
+++ b/crates/oxc_css_parser/src/tokenizer/token.rs
@@ -95,13 +95,6 @@ pub struct TokenWithSpan<'s> {
     pub span: Span,
 }
 
-impl crate::pos::Spanned for TokenWithSpan<'_> {
-    #[inline]
-    fn span(&self) -> &Span {
-        &self.span
-    }
-}
-
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]


### PR DESCRIPTION
Remove the Spanned impl for TokenWithSpan and use its span field directly at the two call sites that need it.

Validation: cargo fmt --check; cargo check -p oxc-css-parser; cargo check -p oxc-css-parser --all-features; cargo test -p oxc-css-parser --lib --tests
