### PR TITLE
refactor(parser): remove allocator helper

### DIFF
--- a/crates/oxc_css_parser/src/parser/less.rs
+++ b/crates/oxc_css_parser/src/parser/less.rs
@@ -1114,7 +1114,7 @@ impl<'a> Parse<'a> for LessMixinCall<'a> {
                         if semicolon_comes_at > 0 {
                             let comma_spans = mem::replace(&mut comma_spans, input.vec());
                             wrap_less_mixin_args_into_less_list(
-                                input.allocator(),
+                                input.allocator,
                                 &mut args,
                                 comma_spans,
                                 semicolon_comes_at,
@@ -1203,7 +1203,7 @@ impl<'a> Parse<'a> for LessMixinCall<'a> {
                         let TokenWithSpan { span, .. } = input.cursor.bump()?;
                         let comma_spans = mem::replace(&mut comma_spans, input.vec());
                         wrap_less_mixin_args_into_less_list(
-                            input.allocator(),
+                            input.allocator,
                             &mut args,
                             comma_spans,
                             semicolon_comes_at,
@@ -1358,7 +1358,7 @@ impl<'a> Parser<'a> {
                     if semicolon_comes_at > 0 {
                         let comma_spans = mem::replace(&mut comma_spans, self.vec());
                         wrap_less_mixin_params_into_less_list(
-                            self.allocator(),
+                            self.allocator,
                             &mut params,
                             comma_spans,
                             semicolon_comes_at,
@@ -1383,7 +1383,7 @@ impl<'a> Parser<'a> {
                     let span = self.cursor.bump()?.span;
                     let comma_spans = mem::replace(&mut comma_spans, self.vec());
                     wrap_less_mixin_params_into_less_list(
-                        self.allocator(),
+                        self.allocator,
                         &mut params,
                         comma_spans,
                         semicolon_comes_at,
@@ -1531,7 +1531,7 @@ impl<'a> Parse<'a> for LessMixinName<'a> {
                         .push(Error { kind: ErrorKind::InvalidIdSelectorName, span: span.clone() });
                 }
                 let name =
-                    if hash.escaped { util::handle_escape_in(raw, input.allocator()) } else { raw };
+                    if hash.escaped { util::handle_escape_in(raw, input.allocator) } else { raw };
                 let name_span = Span { start: span.start + 1, end: span.end };
                 Ok(LessMixinName::IdSelector(IdSelector {
                     name: InterpolableIdent::Literal(Ident { name, raw, span: name_span }),

--- a/crates/oxc_css_parser/src/parser/mod.rs
+++ b/crates/oxc_css_parser/src/parser/mod.rs
@@ -587,11 +587,6 @@ impl<'a> Parser<'a> {
     }
 
     #[inline]
-    pub(crate) fn allocator(&self) -> &'a Allocator {
-        self.allocator
-    }
-
-    #[inline]
     pub(crate) fn alloc<T>(&self, value: T) -> oxc_allocator::Box<'a, T> {
         oxc_allocator::Box::new_in(value, &self.allocator)
     }

--- a/crates/oxc_css_parser/src/parser/selector.rs
+++ b/crates/oxc_css_parser/src/parser/selector.rs
@@ -705,11 +705,8 @@ impl<'a> Parse<'a> for IdSelector<'a> {
                         .recoverable_errors
                         .push(Error { kind: ErrorKind::InvalidIdSelectorName, span: span.clone() });
                 }
-                let value = if token.escaped {
-                    util::handle_escape_in(raw, input.allocator())
-                } else {
-                    raw
-                };
+                let value =
+                    if token.escaped { util::handle_escape_in(raw, input.allocator) } else { raw };
                 let first = Ident { name: value, raw: token.raw, span: first_span };
                 let name = match input.cursor.peek()? {
                     TokenWithSpan { token: Token::HashLBrace(..), span }

--- a/crates/oxc_css_parser/src/parser/stmt.rs
+++ b/crates/oxc_css_parser/src/parser/stmt.rs
@@ -62,7 +62,7 @@ impl<'a> Parse<'a> for Declaration<'a> {
             };
             name_prefix = Some((span.start, '#'));
             let name = if hash.escaped {
-                crate::util::handle_escape_in(hash.raw, input.allocator())
+                crate::util::handle_escape_in(hash.raw, input.allocator)
             } else {
                 hash.raw
             };

--- a/crates/oxc_css_parser/src/parser/value.rs
+++ b/crates/oxc_css_parser/src/parser/value.rs
@@ -960,8 +960,7 @@ impl<'a> Parse<'a> for HexColor<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (token, span) = input.cursor.expect_hash()?;
         let raw = token.raw;
-        let value =
-            if token.escaped { util::handle_escape_in(raw, input.allocator()) } else { raw };
+        let value = if token.escaped { util::handle_escape_in(raw, input.allocator) } else { raw };
         Ok(HexColor { value, raw, span })
     }
 }
@@ -1143,7 +1142,7 @@ impl<'a> Parse<'a> for UrlRaw<'a> {
         match input.cursor.tokenizer.scan_url_raw_or_template()? {
             TokenWithSpan { token: Token::UrlRaw(url), span } => {
                 let value = if url.escaped {
-                    util::handle_escape_in(url.raw, input.allocator())
+                    util::handle_escape_in(url.raw, input.allocator)
                 } else {
                     url.raw
                 };


### PR DESCRIPTION
Remove the private Parser::allocator() forwarding method and pass the parser allocator field directly from parser submodules.

Validation: cargo fmt --check; cargo check -p oxc-css-parser; cargo check -p oxc-css-parser --all-features; cargo test -p oxc-css-parser --lib --tests