### PR TITLE
docs(parser): annotate every grammar production with its spec grammar

### DIFF
--- a/crates/oxc_css_parser/src/parser/at_rule/color_profile.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/color_profile.rs
@@ -2,6 +2,8 @@ use super::Parser;
 use crate::{Parse, ast::*, error::PResult};
 
 // https://www.w3.org/TR/css-color-5/#at-profile
+//
+// @color-profile [ <dashed-ident> | device-cmyk ] { <declaration-list> }
 impl<'a> Parse<'a> for ColorProfilePrelude<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.parse_dashed_ident()? {

--- a/crates/oxc_css_parser/src/parser/at_rule/container.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/container.rs
@@ -7,6 +7,12 @@ use crate::{
     tokenizer::{Token, TokenWithSpan},
 };
 
+// https://drafts.csswg.org/css-conditional-5/#container-queries
+//
+// Spec `<container-query>` — the boolean logic over `<query-in-parens>`
+// (this AST names the node `ContainerCondition`):
+// <container-query> = not <query-in-parens>
+//                   | <query-in-parens> [ [ and <query-in-parens> ]* | [ or <query-in-parens> ]* ]
 impl<'a> Parse<'a> for ContainerCondition<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &input.cursor.peek()?.token {
@@ -50,6 +56,7 @@ impl<'a> Parse<'a> for ContainerCondition<'a> {
     }
 }
 
+// and <query-in-parens>
 impl<'a> Parse<'a> for ContainerConditionAnd<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let keyword = input.parse::<Ident>()?;
@@ -63,6 +70,7 @@ impl<'a> Parse<'a> for ContainerConditionAnd<'a> {
     }
 }
 
+// not <query-in-parens>
 impl<'a> Parse<'a> for ContainerConditionNot<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let keyword = input.parse::<Ident>()?;
@@ -76,6 +84,7 @@ impl<'a> Parse<'a> for ContainerConditionNot<'a> {
     }
 }
 
+// or <query-in-parens>
 impl<'a> Parse<'a> for ContainerConditionOr<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let keyword = input.parse::<Ident>()?;
@@ -89,6 +98,11 @@ impl<'a> Parse<'a> for ContainerConditionOr<'a> {
     }
 }
 
+// <query-in-parens> = ( <container-query> )
+//                   | ( <size-feature> )
+//                   | style( <style-query> )
+//                   | scroll-state( <scroll-state-query> )
+//                   | <general-enclosed>
 impl<'a> Parse<'a> for QueryInParens<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if let Some((_, Span { start, .. })) = input.cursor.eat_l_paren()? {
@@ -122,6 +136,10 @@ impl<'a> Parse<'a> for QueryInParens<'a> {
     }
 }
 
+// https://drafts.csswg.org/css-contain-3/#typedef-style-query
+//
+// <style-condition> = not <style-in-parens>
+//                   | <style-in-parens> [ [ and <style-in-parens> ]* | [ or <style-in-parens> ]* ]
 impl<'a> Parse<'a> for StyleCondition<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &input.cursor.peek()?.token {
@@ -168,6 +186,7 @@ impl<'a> Parse<'a> for StyleCondition<'a> {
     }
 }
 
+// and <style-in-parens>
 impl<'a> Parse<'a> for StyleConditionAnd<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let ident = input.parse::<Ident>()?;
@@ -181,6 +200,7 @@ impl<'a> Parse<'a> for StyleConditionAnd<'a> {
     }
 }
 
+// not <style-in-parens>
 impl<'a> Parse<'a> for StyleConditionNot<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let keyword = input.parse::<Ident>()?;
@@ -194,6 +214,7 @@ impl<'a> Parse<'a> for StyleConditionNot<'a> {
     }
 }
 
+// or <style-in-parens>
 impl<'a> Parse<'a> for StyleConditionOr<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let keyword = input.parse::<Ident>()?;
@@ -207,6 +228,7 @@ impl<'a> Parse<'a> for StyleConditionOr<'a> {
     }
 }
 
+// <style-in-parens> = ( <style-condition> ) | ( <style-feature> ) | <general-enclosed>
 impl<'a> Parse<'a> for StyleInParens<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = input.cursor.expect_l_paren()?;
@@ -216,6 +238,7 @@ impl<'a> Parse<'a> for StyleInParens<'a> {
     }
 }
 
+// <style-condition> | <style-feature>
 impl<'a> Parse<'a> for StyleInParensKind<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if let Ok(style_condition) = input.try_parse(StyleCondition::parse) {
@@ -226,6 +249,8 @@ impl<'a> Parse<'a> for StyleInParensKind<'a> {
     }
 }
 
+// <style-query> = <style-condition> | <style-feature>
+// (a bare custom-property name, e.g. `style(--theme)`, is a boolean-context <style-feature>)
 impl<'a> Parse<'a> for StyleQuery<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if let Ok(condition) = input.try_parse(StyleCondition::parse) {
@@ -255,6 +280,9 @@ impl<'a> Parse<'a> for StyleQuery<'a> {
 }
 
 // https://drafts.csswg.org/css-contain-3/#container-rule
+//
+// @container <container-name>? <container-query> { <block-contents> }
+// <container-name> = <custom-ident>
 impl<'a> Parse<'a> for ContainerPrelude<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let name = input.try_parse(|parser| match parser.parse()? {

--- a/crates/oxc_css_parser/src/parser/at_rule/counter_style.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/counter_style.rs
@@ -7,6 +7,8 @@ use crate::{
 
 // https://www.w3.org/TR/css-counter-styles-3/#the-counter-style-rule
 impl<'a> Parser<'a> {
+    // @counter-style <counter-style-name> { <declaration-list> }
+    // <counter-style-name> = <custom-ident>  (excludes CSS-wide keywords and `none`)
     pub(super) fn parse_counter_style_prelude(&mut self) -> PResult<InterpolableIdent<'a>> {
         let ident = self.parse()?;
         match &ident {

--- a/crates/oxc_css_parser/src/parser/at_rule/custom_media.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/custom_media.rs
@@ -2,6 +2,9 @@ use super::Parser;
 use crate::{Parse, ast::*, error::PResult, pos::Span, tokenizer::Token};
 
 // https://www.w3.org/TR/mediaqueries-5/#custom-mq
+//
+// @custom-media <extension-name> [ <media-query-list> | true | false ] ;
+// <extension-name> = <dashed-ident>
 impl<'a> Parse<'a> for CustomMedia<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let name = input.parse_dashed_ident()?;
@@ -11,6 +14,7 @@ impl<'a> Parse<'a> for CustomMedia<'a> {
     }
 }
 
+// <custom-media-value> = <media-query-list> | true | false
 impl<'a> Parse<'a> for CustomMediaValue<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &input.cursor.peek()?.token {

--- a/crates/oxc_css_parser/src/parser/at_rule/custom_selector.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/custom_selector.rs
@@ -1,6 +1,8 @@
 use super::Parser;
 use crate::{Parse, ast::*, error::PResult, pos::Span, tokenizer::Token, util};
 
+// The custom-selector name token `:<ident>` (e.g. `:--heading`), extended here
+// with this parser's optional `$arg` prefix and `(args)` list (PostCSS/Sass).
 impl<'a> Parse<'a> for CustomSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let prefix_arg = if matches!(input.cursor.peek()?.token, Token::DollarVar(..)) {
@@ -33,6 +35,7 @@ impl<'a> Parse<'a> for CustomSelector<'a> {
     }
 }
 
+// A custom-selector argument placeholder: '$' <ident>
 impl<'a> Parse<'a> for CustomSelectorArg<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (dollar_var, dollar_var_span) = input.cursor.expect_dollar_var()?;
@@ -46,6 +49,7 @@ impl<'a> Parse<'a> for CustomSelectorArg<'a> {
     }
 }
 
+// The argument list of a custom selector: '(' <arg> [ , <arg> ]* ')'
 impl<'a> Parse<'a> for CustomSelectorArgs<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = input.cursor.expect_l_paren()?;
@@ -65,6 +69,9 @@ impl<'a> Parse<'a> for CustomSelectorArgs<'a> {
 }
 
 // https://drafts.csswg.org/css-extensions/#custom-selectors
+//
+// @custom-selector : <extension-name> <selector-list> ;
+// <extension-name> = <dashed-ident>  (spelled with a leading `:`, e.g. `:--heading`)
 impl<'a> Parse<'a> for CustomSelectorPrelude<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let custom_selector = input.parse::<CustomSelector>()?;

--- a/crates/oxc_css_parser/src/parser/at_rule/document.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/document.rs
@@ -2,6 +2,9 @@ use super::Parser;
 use crate::{Parse, ast::*, error::PResult};
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/@document
+//
+// Non-standard (dropped from css-conditional); a comma-separated matcher list:
+// @document <matcher> [ , <matcher> ]* { <rule-list> }
 impl<'a> Parse<'a> for DocumentPrelude<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<DocumentPreludeMatcher>()?;
@@ -22,6 +25,9 @@ impl<'a> Parse<'a> for DocumentPrelude<'a> {
     }
 }
 
+// <matcher> = <url>
+//           | url-prefix( <string> ) | domain( <string> )
+//           | media-document( <string> ) | regexp( <string> )
 impl<'a> Parse<'a> for DocumentPreludeMatcher<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if let Ok(url) = input.try_parse(Url::parse) {

--- a/crates/oxc_css_parser/src/parser/at_rule/font_feature_values.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/font_feature_values.rs
@@ -1,7 +1,10 @@
 use super::Parser;
 use crate::{Parse, ast::*, error::PResult, tokenizer::Token};
 
-// https://drafts.csswg.org/css-fonts/Overview.bs
+// https://drafts.csswg.org/css-fonts/#typedef-family-name
+//
+// @font-feature-values <family-name># { ... }
+// <family-name> = <string> | <custom-ident>+
 impl<'a> Parse<'a> for FontFamilyName<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &input.cursor.peek()?.token {

--- a/crates/oxc_css_parser/src/parser/at_rule/import.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/import.rs
@@ -8,6 +8,12 @@ use crate::{
 };
 
 // https://www.w3.org/TR/css-cascade-5/#at-import
+//
+// @import [ <url> | <string> ]
+//         [ layer | layer( <layer-name> ) ]?
+//         <import-conditions> ;
+// <import-conditions> = [ supports( [ <supports-condition> | <declaration> ] ) ]?
+//                       <media-query-list>?
 impl<'a> Parse<'a> for ImportPrelude<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         // The indented syntax accepts an unquoted path (`@import other.css`),

--- a/crates/oxc_css_parser/src/parser/at_rule/keyframes.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/keyframes.rs
@@ -10,6 +10,8 @@ use crate::{
 };
 
 // https://drafts.csswg.org/css-animations/#keyframes
+//
+// <keyframe-block> = <keyframe-selector># { <declaration-list> }
 impl<'a> Parse<'a> for KeyframeBlock<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first_selector = input.parse::<KeyframeSelector>()?;
@@ -33,6 +35,7 @@ impl<'a> Parse<'a> for KeyframeBlock<'a> {
     }
 }
 
+// <keyframe-selector> = from | to | <percentage [0,100]>
 impl<'a> Parse<'a> for KeyframeSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &input.cursor.peek()?.token {
@@ -58,6 +61,9 @@ impl<'a> Parse<'a> for KeyframeSelector<'a> {
 }
 
 // https://drafts.csswg.org/css-animations/#keyframes
+//
+// @keyframes <keyframes-name> { <rule-list> }
+// <keyframes-name> = <custom-ident> | <string>   (not a CSS-wide keyword)
 impl<'a> Parse<'a> for KeyframesName<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &input.cursor.peek()?.token {

--- a/crates/oxc_css_parser/src/parser/at_rule/layer.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/layer.rs
@@ -9,6 +9,9 @@ use crate::{
 };
 
 // https://drafts.csswg.org/css-cascade-5/#layering
+//
+// @layer <layer-name># ;                (statement form)
+// @layer <layer-name>? { <rule-list> }  (block form)
 impl<'a> Parse<'a> for LayerNames<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<LayerName>()?;
@@ -29,6 +32,8 @@ impl<'a> Parse<'a> for LayerNames<'a> {
 }
 
 // https://drafts.csswg.org/css-cascade-5/#layer-names
+//
+// <layer-name> = <ident> [ '.' <ident> ]*
 impl<'a> Parse<'a> for LayerName<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<InterpolableIdent>()?;

--- a/crates/oxc_css_parser/src/parser/at_rule/media.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/media.rs
@@ -7,6 +7,7 @@ use crate::{
     tokenizer::{Token, TokenWithSpan},
 };
 
+// <media-and> = and <media-in-parens>
 impl<'a> Parse<'a> for MediaAnd<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let keyword = input.parse::<Ident>()?;
@@ -20,6 +21,8 @@ impl<'a> Parse<'a> for MediaAnd<'a> {
     }
 }
 
+// The `and`-led tail after a <media-type> (top-level `or` not allowed here):
+// [ and <media-condition-without-or> ]
 impl<'a> Parse<'a> for MediaConditionAfterMediaType<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let and: Ident = match input.cursor.bump()? {
@@ -42,6 +45,11 @@ impl<'a> Parse<'a> for MediaConditionAfterMediaType<'a> {
     }
 }
 
+// https://www.w3.org/TR/mediaqueries-4/#mq-features
+//
+// <media-feature> = ( [ <mf-plain> | <mf-boolean> | <mf-range> ] )
+// <mf-plain>   = <mf-name> : <mf-value>
+// <mf-boolean> = <mf-name>
 impl<'a> Parse<'a> for MediaFeature<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.parse_media_feature_value()? {
@@ -81,6 +89,7 @@ impl<'a> Parse<'a> for MediaFeature<'a> {
     }
 }
 
+// <mf-comparison> = '<' | '>' | '<=' | '>=' | '='
 impl<'a> Parse<'a> for MediaFeatureComparison {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.cursor.bump()? {
@@ -110,6 +119,7 @@ impl<'a> Parse<'a> for MediaFeatureComparison {
     }
 }
 
+// <media-in-parens> = ( <media-condition> ) | <media-feature> | <general-enclosed>
 impl<'a> Parse<'a> for MediaInParens<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         // Sass allows an interpolation wherever `<media-in-parens>` is expected,
@@ -132,6 +142,7 @@ impl<'a> Parse<'a> for MediaInParens<'a> {
     }
 }
 
+// The contents inside the parens: ( <media-condition> ) | <media-feature> | <general-enclosed>
 impl<'a> Parse<'a> for MediaInParensKind<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if let Ok(media_condition) = input.try_parse(|parser| {
@@ -168,6 +179,7 @@ impl<'a> Parse<'a> for MediaInParensKind<'a> {
     }
 }
 
+// <media-not> = not <media-in-parens>
 impl<'a> Parse<'a> for MediaNot<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let keyword = input.parse::<Ident>()?;
@@ -181,6 +193,7 @@ impl<'a> Parse<'a> for MediaNot<'a> {
     }
 }
 
+// <media-or> = or <media-in-parens>
 impl<'a> Parse<'a> for MediaOr<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let keyword = input.parse::<Ident>()?;
@@ -194,6 +207,10 @@ impl<'a> Parse<'a> for MediaOr<'a> {
     }
 }
 
+// https://www.w3.org/TR/mediaqueries-4/#mq-syntax
+//
+// <media-query> = <media-condition>
+//               | [ not | only ]? <media-type> [ and <media-condition-without-or> ]?
 impl<'a> Parse<'a> for MediaQuery<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if let Ok(condition_only) = input.try_parse(|parser| {
@@ -228,6 +245,8 @@ impl<'a> Parse<'a> for MediaQuery<'a> {
 }
 
 // https://www.w3.org/TR/mediaqueries-4/#mq-syntax
+//
+// <media-query-list> = <media-query>#
 impl<'a> Parse<'a> for MediaQueryList<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<MediaQuery>()?;
@@ -250,6 +269,8 @@ impl<'a> Parse<'a> for MediaQueryList<'a> {
     }
 }
 
+// [ not | only ]? <media-type> [ and <media-condition-without-or> ]?
+// <media-type> = <ident>   (not `only` / `not` / `and` / `or` / `layer`)
 impl<'a> Parse<'a> for MediaQueryWithType<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let modifier = if let Token::Ident(ident) = &input.cursor.peek()?.token {
@@ -318,6 +339,8 @@ impl<'a> Parser<'a> {
         self.parse()
     }
 
+    // <media-condition>            = <media-not> | <media-in-parens> [ <media-and>* | <media-or>* ]
+    // <media-condition-without-or> = <media-not> | <media-in-parens> <media-and>*   (allow_or = false)
     fn parse_media_condition(
         &mut self,
         allow_or: bool,
@@ -370,6 +393,7 @@ impl<'a> Parser<'a> {
         }
     }
 
+    // <mf-plain> = <mf-name> : <mf-value>
     fn parse_media_feature_plain(
         &mut self,
         ident: InterpolableIdent<'a>,
@@ -380,6 +404,9 @@ impl<'a> Parser<'a> {
         Ok(MediaFeaturePlain { name: MediaFeatureName::Ident(ident), colon_span, value, span })
     }
 
+    // <mf-range> = <mf-name>  <mf-comparison> <mf-value>                             (range)
+    //            | <mf-value> <mf-comparison> <mf-name>                             (range)
+    //            | <mf-value> <mf-comparison> <mf-name> <mf-comparison> <mf-value>  (interval)
     fn parse_media_feature_range_or_range_interval(
         &mut self,
         left: ComponentValue<'a>,
@@ -434,6 +461,7 @@ impl<'a> Parser<'a> {
         }
     }
 
+    // <mf-value> = <number> | <dimension> | <ident> | <ratio>
     fn parse_media_feature_value(&mut self) -> PResult<ComponentValue<'a>> {
         let value = match self.syntax {
             Syntax::Css => self.parse_component_value_atom()?,
@@ -453,6 +481,8 @@ impl<'a> Parser<'a> {
         }
     }
 
+    // The `[ not | only ]? <media-type> …` branch of <media-query>; a media type
+    // glued to `(` is also accepted as a function form (`screen(...)`, used by Less).
     fn parse_media_query_with_type_or_function(&mut self) -> PResult<MediaQuery<'a>> {
         let media_query_with_type = self.parse::<MediaQueryWithType>()?;
         match (media_query_with_type, self.cursor.peek()?) {

--- a/crates/oxc_css_parser/src/parser/at_rule/mod.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/mod.rs
@@ -23,6 +23,13 @@ mod page;
 mod scope;
 mod supports;
 
+// https://drafts.csswg.org/css-syntax-3/#consume-at-rule
+//
+// <at-rule> = <at-keyword-token> <component-value>* [ <{}-block> | ; ]
+//
+// This dispatches on the at-keyword name to a typed prelude/block grammar; each
+// rule's grammar is documented in its own module (see the `mod` list above).
+// Unrecognized names fall back to raw component values (`parse_unknown_at_rule`).
 impl<'a> Parse<'a> for AtRule<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (at_keyword, at_keyword_span) = input.cursor.expect_at_keyword()?;
@@ -624,6 +631,9 @@ impl<'a> Parser<'a> {
         Ok(UnknownAtRulePrelude::TokenSeq(TokenSeq { tokens, span }))
     }
 
+    // The generic `<at-rule>` for a name with no typed grammar: an arbitrary
+    // prelude of component values, then an optional `{}`-block or a `;`.
+    // https://drafts.csswg.org/css-syntax-3/#consume-at-rule
     pub(super) fn parse_unknown_at_rule(
         &mut self,
     ) -> PResult<(Option<UnknownAtRulePrelude<'a>>, Option<SimpleBlock<'a>>, Option<usize>)> {
@@ -652,6 +662,8 @@ impl<'a> Parser<'a> {
         Ok((prelude, block, end))
     }
 
+    // The prelude of an unknown at-rule: raw `<component-value>*` up to the body
+    // `{` or the statement boundary.
     fn parse_unknown_at_rule_prelude(&mut self) -> PResult<Option<UnknownAtRulePrelude<'a>>> {
         if let Ok(prelude) = self.try_parse(|parser| {
             let mut tokens = parser.vec();

--- a/crates/oxc_css_parser/src/parser/at_rule/namespace.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/namespace.rs
@@ -2,6 +2,9 @@ use super::Parser;
 use crate::{Parse, ast::*, error::PResult, tokenizer::Token};
 
 // https://www.w3.org/TR/css-namespaces-3/#syntax
+//
+// @namespace <namespace-prefix>? [ <string> | <url> ] ;
+// <namespace-prefix> = <ident>
 impl<'a> Parse<'a> for NamespacePrelude<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let prefix = match &input.cursor.peek()?.token {

--- a/crates/oxc_css_parser/src/parser/at_rule/page.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/page.rs
@@ -9,6 +9,8 @@ use crate::{
 };
 
 // https://www.w3.org/TR/css-page-3/#syntax-page-selector
+//
+// <page-selector> = [ <ident-token>? <pseudo-page>* ]!
 impl<'a> Parse<'a> for PageSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let mut name = None;
@@ -44,6 +46,7 @@ impl<'a> Parse<'a> for PageSelector<'a> {
     }
 }
 
+// <page-selector-list> = <page-selector>#
 impl<'a> Parse<'a> for PageSelectorList<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<PageSelector>()?;
@@ -63,6 +66,7 @@ impl<'a> Parse<'a> for PageSelectorList<'a> {
     }
 }
 
+// <pseudo-page> = ':' [ left | right | first | blank ]
 impl<'a> Parse<'a> for PseudoPage<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, colon_span) = input.cursor.expect_colon()?;

--- a/crates/oxc_css_parser/src/parser/at_rule/scope.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/scope.rs
@@ -7,6 +7,7 @@ use crate::{
     tokenizer::{Token, TokenWithSpan},
 };
 
+// to ( <scope-end> ) where <scope-end> = <selector-list>
 impl<'a> Parse<'a> for ScopeEnd<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let to_span = match input.cursor.bump()? {
@@ -30,6 +31,10 @@ impl<'a> Parse<'a> for ScopeEnd<'a> {
 }
 
 // https://drafts.csswg.org/css-cascade-6/#scope-syntax
+//
+// @scope [ ( <scope-start> ) ]? [ to ( <scope-end> ) ]? { <block-contents> }
+// <scope-start> = <selector-list>
+// <scope-end>   = <selector-list>
 impl<'a> Parse<'a> for ScopePrelude<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let start = if let Token::LParen(..) = input.cursor.peek()?.token {
@@ -59,6 +64,7 @@ impl<'a> Parse<'a> for ScopePrelude<'a> {
     }
 }
 
+// ( <scope-start> ) where <scope-start> = <selector-list>
 impl<'a> Parse<'a> for ScopeStart<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = input.cursor.expect_l_paren()?;

--- a/crates/oxc_css_parser/src/parser/at_rule/supports.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/supports.rs
@@ -8,6 +8,10 @@ use crate::{
 };
 
 // https://drafts.csswg.org/css-conditional-3/#at-supports
+//
+// <supports-condition> = not <supports-in-parens>
+//                      | <supports-in-parens> [ and <supports-in-parens> ]*
+//                      | <supports-in-parens> [ or <supports-in-parens> ]*
 impl<'a> Parse<'a> for SupportsCondition<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &input.cursor.peek()?.token {
@@ -61,6 +65,11 @@ impl<'a> Parse<'a> for SupportsCondition<'a> {
     }
 }
 
+// https://drafts.csswg.org/css-conditional-3/#typedef-supports-in-parens
+//
+// <supports-in-parens> = ( <supports-condition> )
+//                      | <supports-feature>
+//                      | <general-enclosed>
 impl<'a> Parse<'a> for SupportsInParens<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.cursor.peek()? {
@@ -165,6 +174,10 @@ impl<'a> Parse<'a> for SupportsInParens<'a> {
     }
 }
 
+// https://drafts.csswg.org/css-conditional-3/#typedef-supports-feature
+//
+// <supports-feature> = <supports-decl>
+// <supports-decl>    = ( <declaration> )
 impl<'a> Parse<'a> for SupportsDecl<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let start = input.cursor.expect_l_paren()?.1.start;

--- a/crates/oxc_css_parser/src/parser/less.rs
+++ b/crates/oxc_css_parser/src/parser/less.rs
@@ -20,6 +20,8 @@ const PRECEDENCE_MULTIPLY: u8 = 2;
 const PRECEDENCE_PLUS: u8 = 1;
 
 impl<'a> Parser<'a> {
+    // A guard condition: <condition> [ [ and | or ] <condition> ]*  (right-assoc)
+    // https://lesscss.org/features/#mixin-guards-feature
     pub(super) fn parse_less_condition(
         &mut self,
         needs_parens: bool,
@@ -27,6 +29,8 @@ impl<'a> Parser<'a> {
         self.parse_less_condition_recursively(needs_parens, 0)
     }
 
+    // <condition-atom> = <value> [ <comparison> <value> ]?
+    // <comparison> = '>' | '>=' | '<' | '<=' | '=' | '=<' | '=>'
     fn parse_less_condition_atom(&mut self) -> PResult<LessCondition<'a>> {
         let left =
             self.parse_less_operation(/* allow_mixin_call */ false).map(LessCondition::Value)?;
@@ -105,6 +109,7 @@ impl<'a> Parser<'a> {
         Ok((condition, end))
     }
 
+    // A guard operand inside `( … )`: a nested <condition> or a <condition-atom>.
     fn parse_less_condition_inside_parens(
         &mut self,
         needs_parens: bool,
@@ -143,6 +148,8 @@ impl<'a> Parser<'a> {
         .or_else(|_| self.parse_less_condition_atom())
     }
 
+    // Precedence-climbing worker for guards: `or` looser than `and`; a leaf is
+    // ( <condition> ) | not <condition-atom> | <condition-atom>.
     fn parse_less_condition_recursively(
         &mut self,
         needs_parens: bool,
@@ -221,6 +228,8 @@ impl<'a> Parser<'a> {
         Ok(left)
     }
 
+    // An identifier interleaving static parts with `@{ <name> }` / `${ <name> }`
+    // interpolation. https://lesscss.org/features/#variables-feature-variable-interpolation
     pub(super) fn parse_less_interpolated_ident(&mut self) -> PResult<InterpolableIdent<'a>> {
         debug_assert_eq!(self.syntax, Syntax::Less);
 
@@ -275,6 +284,7 @@ impl<'a> Parser<'a> {
         }))
     }
 
+    // The static/`@{…}`/`${…}` element sequence after an interpolated ident's first part.
     pub(super) fn parse_less_interpolated_ident_rest(
         &mut self,
         end: &mut usize,
@@ -313,6 +323,7 @@ impl<'a> Parser<'a> {
         }
     }
 
+    // <mixin-call> [ <lookups> ]?   (a mixin call, optionally with `[...]` lookups)
     pub(super) fn parse_less_maybe_mixin_call_or_with_lookups(
         &mut self,
     ) -> PResult<ComponentValue<'a>> {
@@ -330,6 +341,8 @@ impl<'a> Parser<'a> {
         }
     }
 
+    // <variable> [ '(' ')' | <lookups> ]?   (a variable, a detached-ruleset call,
+    // or a variable with `[...]` map lookups)
     pub(super) fn parse_less_maybe_variable_or_with_lookups(
         &mut self,
     ) -> PResult<ComponentValue<'a>> {
@@ -357,6 +370,8 @@ impl<'a> Parser<'a> {
         }
     }
 
+    // A Less arithmetic operation: <value> [ [ '+' | '-' | '*' | '/' ] <value> ]*
+    // ('*' / '/' bind tighter than '+' / '-'). https://lesscss.org/functions/#math
     pub(super) fn parse_less_operation(
         &mut self,
         allow_mixin_call: bool,
@@ -364,6 +379,7 @@ impl<'a> Parser<'a> {
         self.parse_less_operation_recursively(allow_mixin_call, 0)
     }
 
+    // Precedence-climbing worker for `parse_less_operation`.
     fn parse_less_operation_recursively(
         &mut self,
         allow_mixin_call: bool,
@@ -579,6 +595,7 @@ impl<'a> Parser<'a> {
         Ok(left)
     }
 
+    // ( <operation> )   (parentheses force math mode on their contents)
     fn parse_less_parenthesized_operation(
         &mut self,
         allow_mixin_call: bool,
@@ -597,6 +614,8 @@ impl<'a> Parser<'a> {
         })
     }
 
+    // A style rule that may carry a guard: <selector-list> [ when <guard> ]? { <block> }
+    // (guards are only allowed on a single-selector rule).
     pub(super) fn parse_less_qualified_rule(&mut self) -> PResult<Statement<'a>> {
         debug_assert_eq!(self.syntax, Syntax::Less);
 
@@ -637,6 +656,7 @@ impl<'a> Parser<'a> {
         Ok(Statement::QualifiedRule(QualifiedRule { selector: selector_list, block, span }))
     }
 
+    // A `#…`-led value that is either a <hex-color> or an id-selector <mixin-call>.
     pub(super) fn parse_maybe_hex_color_or_less_mixin_call(
         &mut self,
     ) -> PResult<ComponentValue<'a>> {
@@ -665,6 +685,7 @@ impl<'a> Parser<'a> {
         }
     }
 
+    // A Less list: space- or comma-separated values (comma binds looser than space).
     pub(super) fn parse_maybe_less_list(
         &mut self,
         allow_comma: bool,
@@ -753,6 +774,9 @@ impl<'a> Parser<'a> {
     }
 }
 
+// https://lesscss.org/features/#mixin-guards-feature
+//
+// A guard: when <condition> [ , <condition> ]*
 impl<'a> Parse<'a> for LessConditions<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let when_span = match input.cursor.bump()? {
@@ -790,6 +814,9 @@ impl<'a> Parse<'a> for LessConditions<'a> {
     }
 }
 
+// https://lesscss.org/features/#detached-rulesets-feature
+//
+// A detached ruleset (a `{ <block> }` stored in a variable).
 impl<'a> Parse<'a> for LessDetachedRuleset<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let block = input.parse::<SimpleBlock>()?;
@@ -798,6 +825,9 @@ impl<'a> Parse<'a> for LessDetachedRuleset<'a> {
     }
 }
 
+// https://lesscss.org/functions/#string-functions-e
+//
+// An escaped string: '~' <string>   (e.g. `~"raw value"`)
 impl<'a> Parse<'a> for LessEscapedStr<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = input.cursor.expect_tilde()?;
@@ -810,6 +840,9 @@ impl<'a> Parse<'a> for LessEscapedStr<'a> {
     }
 }
 
+// https://lesscss.org/features/#extend-feature
+//
+// One extend target inside `:extend(...)`: <complex-selector> [ all ]?
 impl<'a> Parse<'a> for LessExtend<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let mut selector = input.parse::<ComplexSelector>()?;
@@ -851,6 +884,7 @@ impl<'a> Parse<'a> for LessExtend<'a> {
     }
 }
 
+// <less-extend> [ , <less-extend> ]*   (the contents of `:extend(...)`)
 impl<'a> Parse<'a> for LessExtendList<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert_eq!(input.syntax, Syntax::Less);
@@ -873,6 +907,7 @@ impl<'a> Parse<'a> for LessExtendList<'a> {
     }
 }
 
+// The selector-attached extend form: '&' :extend( <extend-list> )
 impl<'a> Parse<'a> for LessExtendRule<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let nesting_selector = input.parse::<NestingSelector>()?;
@@ -904,6 +939,8 @@ impl<'a> Parse<'a> for LessExtendRule<'a> {
     }
 }
 
+// The Less `%(…)` string-format function name.
+// https://lesscss.org/functions/#string-functions-format
 impl<'a> Parse<'a> for LessFormatFunction {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, span) = input.cursor.expect_percent()?;
@@ -911,6 +948,9 @@ impl<'a> Parse<'a> for LessFormatFunction {
     }
 }
 
+// https://lesscss.org/features/#import-atrules-feature-import-options
+//
+// ( [ less | css | multiple | once | inline | reference | optional ]# )
 impl<'a> Parse<'a> for LessImportOptions<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = input.cursor.expect_l_paren()?;
@@ -935,6 +975,7 @@ impl<'a> Parse<'a> for LessImportOptions<'a> {
     }
 }
 
+// @import ( <import-options> ) [ <string> | <url> ] <media-query-list>?
 impl<'a> Parse<'a> for LessImportPrelude<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let options = input.parse::<LessImportOptions>()?;
@@ -958,6 +999,8 @@ impl<'a> Parse<'a> for LessImportPrelude<'a> {
     }
 }
 
+// A quoted string containing `@{ <name> }` / `${ <name> }` interpolation.
+// https://lesscss.org/features/#variables-feature-variable-interpolation
 impl<'a> Parse<'a> for LessInterpolatedStr<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (first, first_span) = input.cursor.expect_str_template()?;
@@ -1007,6 +1050,7 @@ impl<'a> Parse<'a> for LessInterpolatedStr<'a> {
     }
 }
 
+// Inline JavaScript evaluation: '~'? '`' <code> '`'  (deprecated Less feature)
 impl<'a> Parse<'a> for LessJavaScriptSnippet<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let tilde = input.cursor.eat_tilde()?;
@@ -1024,6 +1068,7 @@ impl<'a> Parse<'a> for LessJavaScriptSnippet<'a> {
     }
 }
 
+// The Less `~` function-name marker.
 impl<'a> Parse<'a> for LessListFunction {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, span) = input.cursor.expect_tilde()?;
@@ -1031,6 +1076,9 @@ impl<'a> Parse<'a> for LessListFunction {
     }
 }
 
+// https://lesscss.org/features/#maps-feature
+//
+// A map lookup: '[' <lookup-name>? ']'
 impl<'a> Parse<'a> for LessLookup<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert_eq!(input.syntax, Syntax::Less);
@@ -1046,6 +1094,7 @@ impl<'a> Parse<'a> for LessLookup<'a> {
     }
 }
 
+// <lookup-name> = @<var> | @@<var> | $<prop> | $@<var> | <ident>
 impl<'a> Parse<'a> for LessLookupName<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert_eq!(input.syntax, Syntax::Less);
@@ -1076,6 +1125,7 @@ impl<'a> Parse<'a> for LessLookupName<'a> {
     }
 }
 
+// <lookup>+   (a chain of `[...]` map lookups)
 impl<'a> Parse<'a> for LessLookups<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert_eq!(input.syntax, Syntax::Less);
@@ -1095,6 +1145,9 @@ impl<'a> Parse<'a> for LessLookups<'a> {
     }
 }
 
+// https://lesscss.org/features/#mixins-feature
+//
+// <mixin-callee> [ ( <mixin-args> ) ]? [ !important ]?
 impl<'a> Parse<'a> for LessMixinCall<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert_eq!(input.syntax, Syntax::Less);
@@ -1255,6 +1308,8 @@ impl<'a> Parse<'a> for LessMixinCall<'a> {
 }
 
 impl<'a> Parser<'a> {
+    // Declared mixin parameters: ( <parameter> [ [ ',' | ';' ] <parameter> ]* )
+    // <parameter> = <variable> [ ':' <default> ]? | <value> | <variable>... | ...
     fn parse_less_mixin_parameters(&mut self) -> PResult<LessMixinParameters<'a>> {
         let (_, lparen_span) = self.cursor.expect_l_paren()?;
         let rparen_span;
@@ -1427,6 +1482,7 @@ impl<'a> Parser<'a> {
     }
 }
 
+// A (possibly namespaced) mixin path: <mixin-name> [ '>' <mixin-name> ]*
 impl<'a> Parse<'a> for LessMixinCallee<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first_name = input.parse::<LessMixinName>()?;
@@ -1471,6 +1527,7 @@ impl<'a> Parse<'a> for LessMixinCallee<'a> {
     }
 }
 
+// A mixin definition: <mixin-name> ( <parameters> ) [ when <guard> ]? { <block> }
 impl<'a> Parse<'a> for LessMixinDefinition<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert_eq!(input.syntax, Syntax::Less);
@@ -1497,6 +1554,7 @@ impl<'a> Parse<'a> for LessMixinDefinition<'a> {
     }
 }
 
+// <mixin-name> = <class-selector> | <id-selector>   ('.name' or '#name')
 impl<'a> Parse<'a> for LessMixinName<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.cursor.bump()? {
@@ -1546,6 +1604,7 @@ impl<'a> Parse<'a> for LessMixinName<'a> {
     }
 }
 
+// <mixin-parameter-name> = @<var> | $<prop>
 impl<'a> Parse<'a> for LessMixinParameterName<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if matches!(input.cursor.peek()?.token, Token::AtKeyword(..)) {
@@ -1556,6 +1615,7 @@ impl<'a> Parse<'a> for LessMixinParameterName<'a> {
     }
 }
 
+// A namespaced value access: <callee> <lookups>   (e.g. `#ns.mixin()[@k]`)
 impl<'a> Parse<'a> for LessNamespaceValue<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let callee = input.parse::<LessNamespaceValueCallee>()?;
@@ -1569,6 +1629,7 @@ impl<'a> Parse<'a> for LessNamespaceValue<'a> {
     }
 }
 
+// <namespace-value-callee> = <less-variable> | <mixin-call>
 impl<'a> Parse<'a> for LessNamespaceValueCallee<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if matches!(input.cursor.peek()?.token, Token::AtKeyword(..)) {
@@ -1579,6 +1640,7 @@ impl<'a> Parse<'a> for LessNamespaceValueCallee<'a> {
     }
 }
 
+// A negated value: '-' [ <variable> | <property-var> | ( <operation> ) ]
 impl<'a> Parse<'a> for LessNegativeValue<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, minus_span) = input.cursor.expect_minus()?;
@@ -1609,6 +1671,7 @@ impl<'a> Parse<'a> for LessNegativeValue<'a> {
     }
 }
 
+// The `%` keyword (e.g. the Less `percentage`/format context).
 impl<'a> Parse<'a> for LessPercentKeyword {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, span) = input.cursor.expect_percent()?;
@@ -1616,6 +1679,9 @@ impl<'a> Parse<'a> for LessPercentKeyword {
     }
 }
 
+// https://lesscss.org/features/#plugin-atrules-feature
+//
+// @plugin [ ( <args> ) ]? <plugin-path>
 impl<'a> Parse<'a> for LessPlugin<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert_eq!(input.syntax, Syntax::Less);
@@ -1639,6 +1705,7 @@ impl<'a> Parse<'a> for LessPlugin<'a> {
     }
 }
 
+// <plugin-path> = <string> | <url>
 impl<'a> Parse<'a> for LessPluginPath<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if let Token::Str(..) = input.cursor.peek()?.token {
@@ -1649,6 +1716,7 @@ impl<'a> Parse<'a> for LessPluginPath<'a> {
     }
 }
 
+// A property-as-variable interpolation: '${' <ident> '}'
 impl<'a> Parse<'a> for LessPropertyInterpolation<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (dollar_lbrace_var, span) = input.cursor.expect_dollar_l_brace_var()?;
@@ -1660,6 +1728,9 @@ impl<'a> Parse<'a> for LessPropertyInterpolation<'a> {
     }
 }
 
+// https://lesscss.org/features/#merge-feature
+//
+// A property-merge flag after a property name: '+' (comma) | '+_' (space)
 impl<'a> Parse<'a> for Option<LessPropertyMerge> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Less | Syntax::Css));
@@ -1678,6 +1749,9 @@ impl<'a> Parse<'a> for Option<LessPropertyMerge> {
     }
 }
 
+// https://lesscss.org/features/#variables-feature-properties-as-variables
+//
+// A property accessor: '$' <ident>
 impl<'a> Parse<'a> for LessPropertyVariable<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (dollar_var, span) = input.cursor.expect_dollar_var()?;
@@ -1688,6 +1762,9 @@ impl<'a> Parse<'a> for LessPropertyVariable<'a> {
     }
 }
 
+// https://lesscss.org/features/#variables-feature
+//
+// A variable reference: '@' <ident>
 impl<'a> Parse<'a> for LessVariable<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (at_keyword, span) = input.cursor.expect_at_keyword()?;
@@ -1698,6 +1775,7 @@ impl<'a> Parse<'a> for LessVariable<'a> {
     }
 }
 
+// A detached-ruleset call: '@' <ident> '(' ')'
 impl<'a> Parse<'a> for LessVariableCall<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let variable = input.parse::<LessVariable>()?;
@@ -1709,6 +1787,7 @@ impl<'a> Parse<'a> for LessVariableCall<'a> {
     }
 }
 
+// A variable declaration: '@' <ident> ':' <value>
 impl<'a> Parse<'a> for LessVariableDeclaration<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert_eq!(input.syntax, Syntax::Less);
@@ -1767,6 +1846,7 @@ impl<'a> Parse<'a> for LessVariableDeclaration<'a> {
     }
 }
 
+// A variable interpolation: '@{' <ident> '}'
 impl<'a> Parse<'a> for LessVariableInterpolation<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (at_lbrace_var, span) = input.cursor.expect_at_l_brace_var()?;
@@ -1778,6 +1858,7 @@ impl<'a> Parse<'a> for LessVariableInterpolation<'a> {
     }
 }
 
+// A variable-variable (indirection): '@@' <ident>
 impl<'a> Parse<'a> for LessVariableVariable<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, at_span) = input.cursor.expect_at()?;

--- a/crates/oxc_css_parser/src/parser/mod.rs
+++ b/crates/oxc_css_parser/src/parser/mod.rs
@@ -613,6 +613,8 @@ impl<'a> Parser<'a> {
         Ident { name: self.ident_name(&token), raw: token.raw, span }
     }
 
+    // A `$`-prefixed variable name: '$' <ident>  (Sass variables, Less property
+    // accessors, postcss-simple-vars).
     pub(super) fn parse_dollar_var_ident(&mut self) -> PResult<(Ident<'a>, Span)> {
         let (dollar_var, span) = self.cursor.expect_dollar_var()?;
         let name = self.ident(dollar_var.ident, Span { start: span.start + 1, end: span.end });

--- a/crates/oxc_css_parser/src/parser/postcss_simple_vars.rs
+++ b/crates/oxc_css_parser/src/parser/postcss_simple_vars.rs
@@ -1,6 +1,8 @@
 use super::Parser;
 use crate::{Parse, ast::*, config::Syntax, error::PResult, pos::Span, tokenizer::Token};
 
+// postcss-simple-vars variable reference: `$` <ident>
+// https://github.com/postcss/postcss-simple-vars
 impl<'a> Parse<'a> for PostcssSimpleVar<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(input.syntax == Syntax::Css && input.options.allow_postcss_simple_vars);
@@ -10,6 +12,8 @@ impl<'a> Parse<'a> for PostcssSimpleVar<'a> {
     }
 }
 
+// postcss-simple-vars declaration: `$` <ident> ':' <declaration-value>
+// (textual substitution; a trailing `!important` stays part of the value)
 impl<'a> Parse<'a> for PostcssSimpleVarDeclaration<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(input.syntax == Syntax::Css && input.options.allow_postcss_simple_vars);

--- a/crates/oxc_css_parser/src/parser/sass.rs
+++ b/crates/oxc_css_parser/src/parser/sass.rs
@@ -67,6 +67,8 @@ impl<'a> Parser<'a> {
         Ok(drained)
     }
 
+    // A SassScript list: space- or comma-separated <expression>s (comma binds
+    // looser than space). https://sass-lang.com/documentation/values/lists
     pub(super) fn parse_maybe_sass_list(
         &mut self,
         allow_comma: bool,
@@ -163,6 +165,9 @@ impl<'a> Parser<'a> {
         }
     }
 
+    // A SassScript binary-operator expression, loosest tier first:
+    //   or → and → not → ==/!= → </>/<=/>= → +/- → */%// → <unary-expression>
+    // https://sass-lang.com/documentation/operators
     pub(super) fn parse_sass_bin_expr(
         &mut self,
         allow_comparison: bool,
@@ -171,6 +176,7 @@ impl<'a> Parser<'a> {
         self.parse_sass_bin_expr_with_min_precedence(PRECEDENCE_OR, allow_comparison)
     }
 
+    // Precedence-climbing worker for `parse_sass_bin_expr`.
     fn parse_sass_bin_expr_with_min_precedence(
         &mut self,
         min_precedence: u8,
@@ -464,6 +470,7 @@ impl<'a> Parser<'a> {
         Ok(left)
     }
 
+    // Trailing declaration flags: [ '!' [ default | global ] ]*
     fn parse_sass_flags(
         &mut self,
     ) -> PResult<(oxc_allocator::Vec<'a, SassFlag<'a>>, Option<usize>)> {
@@ -492,6 +499,8 @@ impl<'a> Parser<'a> {
         Ok((flags, end))
     }
 
+    // An identifier interleaving static parts with `#{ <expression> }` interpolation.
+    // https://sass-lang.com/documentation/interpolation
     pub(super) fn parse_sass_interpolated_ident(&mut self) -> PResult<InterpolableIdent<'a>> {
         debug_assert!(matches!(self.syntax, Syntax::Scss | Syntax::Sass));
 
@@ -534,6 +543,7 @@ impl<'a> Parser<'a> {
         }))
     }
 
+    // The static/`#{…}` element sequence after an interpolated ident's first part.
     pub(super) fn parse_sass_interpolated_ident_rest(
         &mut self,
         end: &mut usize,
@@ -558,6 +568,7 @@ impl<'a> Parser<'a> {
         }
     }
 
+    // One `#{ <expression> }` element of an interpolated ident.
     fn parse_sass_interpolated_ident_expr(
         &mut self,
     ) -> PResult<(SassInterpolatedIdentElement<'a>, Span)> {
@@ -569,6 +580,9 @@ impl<'a> Parser<'a> {
         Ok((SassInterpolatedIdentElement::Expression(expr), Span { start, end }))
     }
 
+    // Call arguments for @include / function calls:
+    //   [ <expression> | $<name> : <expression> | <expression>... ]#
+    // https://sass-lang.com/documentation/at-rules/mixin#passing-arguments
     pub(super) fn parse_sass_invocation_args(
         &mut self,
     ) -> PResult<(oxc_allocator::Vec<'a, ComponentValue<'a>>, oxc_allocator::Vec<'a, Span>)> {
@@ -618,6 +632,9 @@ impl<'a> Parser<'a> {
         Ok((values, comma_spans))
     }
 
+    // Module configuration for @use / @forward:
+    //   with ( <config-item> [ , <config-item> ]* )
+    // https://sass-lang.com/documentation/at-rules/use#configuration
     fn parse_sass_module_config(
         &mut self,
         allow_overridable: bool,
@@ -666,6 +683,7 @@ impl<'a> Parser<'a> {
         }
     }
 
+    // <config-item> = $<name> : <expression> [ !default ]?
     fn parse_sass_module_config_item(
         &mut self,
         allow_overridable: bool,
@@ -686,6 +704,9 @@ impl<'a> Parser<'a> {
     }
 
     /// This method will consume `)` token.
+    // Declared @mixin / @function parameters:
+    //   [ $<name> [ : <default-expression> ]? ]#  with an optional trailing
+    //   `$<name>...` (arbitrary/rest argument).
     fn parse_sass_params(&mut self) -> PResult<SassParams<'a>> {
         let mut parameters = self.vec();
         let mut arbitrary_parameter = None;
@@ -757,6 +778,7 @@ impl<'a> Parser<'a> {
         Ok((parameters, arbitrary_parameter, comma_spans, end))
     }
 
+    // A namespaced module member: <module-ident> '.' <member>
     pub(super) fn parse_sass_qualified_name(
         &mut self,
         module: Ident<'a>,
@@ -777,6 +799,7 @@ impl<'a> Parser<'a> {
         Ok(SassQualifiedName { module, member, span })
     }
 
+    // <unary-expression> = [ '+' | '-' | not ]? <value>
     fn parse_sass_unary_expression(&mut self) -> PResult<ComponentValue<'a>> {
         // dart-sass accepts a bare `%` in declaration values (`b: %`,
         // `b: % c`, `b: c %`) as a plain token. Calculations bypass this
@@ -812,6 +835,9 @@ impl<'a> Parser<'a> {
     }
 }
 
+// https://sass-lang.com/documentation/at-rules/at-root
+//
+// @at-root [ ( <at-root-query> ) | <selector> ] { <block> }
 impl<'a> Parse<'a> for SassAtRoot<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let kind = if matches!(input.cursor.peek()?.token, Token::LParen(..)) {
@@ -825,6 +851,7 @@ impl<'a> Parse<'a> for SassAtRoot<'a> {
     }
 }
 
+// <at-root-query> = ( [ with | without ] : [ <ident> | <string> ]+ )
 impl<'a> Parse<'a> for SassAtRootQuery<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let start = input.cursor.expect_l_paren()?.1.start;
@@ -860,6 +887,7 @@ impl<'a> Parse<'a> for SassAtRootQuery<'a> {
     }
 }
 
+// A conditional clause: <expression> { <block> }  (body of @if / @else if / @while)
 impl<'a> Parse<'a> for SassConditionalClause<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         input.eat_sass_line_continuation()?;
@@ -870,6 +898,9 @@ impl<'a> Parse<'a> for SassConditionalClause<'a> {
     }
 }
 
+// https://sass-lang.com/documentation/at-rules/mixin#content-blocks
+//
+// @content [ ( <invocation-args> ) ]?
 impl<'a> Parse<'a> for SassContent<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = input.cursor.expect_l_paren()?;
@@ -879,6 +910,9 @@ impl<'a> Parse<'a> for SassContent<'a> {
     }
 }
 
+// https://sass-lang.com/documentation/at-rules/control/each
+//
+// @each <variable> [ , <variable> ]* in <expression>
 impl<'a> Parse<'a> for SassEach<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
@@ -912,6 +946,9 @@ impl<'a> Parse<'a> for SassEach<'a> {
     }
 }
 
+// https://sass-lang.com/documentation/at-rules/extend
+//
+// @extend <compound-selector-list> [ !optional ]?
 impl<'a> Parse<'a> for SassExtend<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         input.eat_sass_line_continuation()?;
@@ -941,6 +978,9 @@ impl<'a> Parse<'a> for SassExtend<'a> {
     }
 }
 
+// https://sass-lang.com/documentation/at-rules/control/for
+//
+// @for <variable> from <expression> [ to | through ] <expression>
 impl<'a> Parse<'a> for SassFor<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
@@ -969,6 +1009,7 @@ impl<'a> Parse<'a> for SassFor<'a> {
     }
 }
 
+// to | through   (exclusive | inclusive upper bound of @for)
 impl<'a> Parse<'a> for SassForBoundary {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (keyword, span) = input.cursor.expect_ident()?;
@@ -980,6 +1021,9 @@ impl<'a> Parse<'a> for SassForBoundary {
     }
 }
 
+// https://sass-lang.com/documentation/at-rules/forward
+//
+// @forward <string> [ as <ident> '*' ]? [ [ show | hide ] <member># ]? [ with ( <config> ) ]?
 impl<'a> Parse<'a> for SassForward<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
@@ -1076,6 +1120,9 @@ impl<'a> Parse<'a> for SassForward<'a> {
     }
 }
 
+// https://sass-lang.com/documentation/at-rules/function
+//
+// @function <ident> <parameters> { <block> }
 impl<'a> Parse<'a> for SassFunction<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
@@ -1092,6 +1139,9 @@ impl<'a> Parse<'a> for SassFunction<'a> {
     }
 }
 
+// https://sass-lang.com/documentation/at-rules/control/if
+//
+// @if <clause> [ @else if <clause> ]* [ @else { <block> } ]?
 impl<'a> Parse<'a> for SassIfAtRule<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
@@ -1165,6 +1215,9 @@ impl<'a> Parse<'a> for SassIfAtRule<'a> {
     }
 }
 
+// https://sass-lang.com/documentation/at-rules/import
+//
+// @import <string> [ , <string> ]*   (Sass multi-path import of literal strings)
 impl<'a> Parse<'a> for SassImportPrelude<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<Str>()?;
@@ -1185,6 +1238,9 @@ impl<'a> Parse<'a> for SassImportPrelude<'a> {
     }
 }
 
+// https://sass-lang.com/documentation/at-rules/mixin
+//
+// @include <name> [ ( <invocation-args> ) ]? [ using ( <parameters> ) ]?
 impl<'a> Parse<'a> for SassInclude<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
@@ -1214,6 +1270,7 @@ impl<'a> Parse<'a> for SassInclude<'a> {
     }
 }
 
+// ( <invocation-args> )
 impl<'a> Parse<'a> for SassIncludeArgs<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = input.cursor.expect_l_paren()?;
@@ -1223,6 +1280,7 @@ impl<'a> Parse<'a> for SassIncludeArgs<'a> {
     }
 }
 
+// using ( <parameters> )   (parameters the mixin passes to its @content block)
 impl<'a> Parse<'a> for SassIncludeContentBlockParams<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.cursor.bump()? {
@@ -1241,6 +1299,8 @@ impl<'a> Parse<'a> for SassIncludeContentBlockParams<'a> {
     }
 }
 
+// A quoted string containing `#{ <expression> }` interpolation.
+// https://sass-lang.com/documentation/interpolation
 impl<'a> Parse<'a> for SassInterpolatedStr<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (first, first_span) = input.cursor.expect_str_template()?;
@@ -1278,6 +1338,7 @@ impl<'a> Parse<'a> for SassInterpolatedStr<'a> {
     }
 }
 
+// A `url()` body containing `#{ <expression> }` interpolation.
 impl<'a> Parse<'a> for SassInterpolatedUrl<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
@@ -1323,6 +1384,9 @@ impl<'a> Parse<'a> for SassInterpolatedUrl<'a> {
     }
 }
 
+// https://sass-lang.com/documentation/values/lists
+//
+// <sass-list> = <expression> [ <separator> <expression> ]*   (separator: ' ' or ',')
 impl<'a> Parse<'a> for SassList<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if let ComponentValue::SassList(list) =
@@ -1336,6 +1400,9 @@ impl<'a> Parse<'a> for SassList<'a> {
     }
 }
 
+// https://sass-lang.com/documentation/values/maps
+//
+// <sass-map> = ( [ <map-item> [ , <map-item> ]* ]? )
 impl<'a> Parse<'a> for SassMap<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let start = input.cursor.expect_l_paren()?.1.start;
@@ -1369,6 +1436,7 @@ impl<'a> Parse<'a> for SassMap<'a> {
     }
 }
 
+// <map-item> = <expression> : <expression>
 impl<'a> Parse<'a> for SassMapItem<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let key = input.parse_maybe_sass_list(/* allow_comma */ false)?;
@@ -1379,6 +1447,9 @@ impl<'a> Parse<'a> for SassMapItem<'a> {
     }
 }
 
+// https://sass-lang.com/documentation/at-rules/mixin
+//
+// @mixin <ident> [ <parameters> ]? { <block> }
 impl<'a> Parse<'a> for SassMixin<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
@@ -1400,6 +1471,7 @@ impl<'a> Parse<'a> for SassMixin<'a> {
     }
 }
 
+// Declared parameters: ( [ <parameter># ]? [ , <variable>... ]? )
 impl<'a> Parse<'a> for SassParameters<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = input.cursor.expect_l_paren()?;
@@ -1408,6 +1480,8 @@ impl<'a> Parse<'a> for SassParameters<'a> {
     }
 }
 
+// The nested `{ <declaration-list> }` of a Sass nested property (`font: { … }`).
+// https://sass-lang.com/documentation/style-rules/declarations#nesting
 impl<'a> Parse<'a> for SassNestingDeclaration<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let block = input.parse::<SimpleBlock>()?;
@@ -1417,6 +1491,7 @@ impl<'a> Parse<'a> for SassNestingDeclaration<'a> {
     }
 }
 
+// ( <expression> )   (a parenthesized SassScript expression)
 impl<'a> Parse<'a> for SassParenthesizedExpression<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let start = input.cursor.expect_l_paren()?.1.start;
@@ -1433,6 +1508,9 @@ impl<'a> Parse<'a> for SassParenthesizedExpression<'a> {
     }
 }
 
+// https://sass-lang.com/documentation/style-rules/placeholder-selectors
+//
+// <placeholder-selector> = '%' <ident>
 impl<'a> Parse<'a> for SassPlaceholderSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, percent_span) = input.cursor.expect_percent()?;
@@ -1444,6 +1522,9 @@ impl<'a> Parse<'a> for SassPlaceholderSelector<'a> {
     }
 }
 
+// https://sass-lang.com/documentation/at-rules/use
+//
+// @use <string> [ as [ <ident> | '*' ] ]? [ with ( <config> ) ]?
 impl<'a> Parse<'a> for SassUse<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         input.eat_sass_line_continuation()?;
@@ -1468,6 +1549,7 @@ impl<'a> Parse<'a> for SassUse<'a> {
     }
 }
 
+// as [ <ident> | '*' ]   ('*' loads members without a namespace prefix)
 impl<'a> Parse<'a> for SassUseNamespace<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let as_span = match input.cursor.peek()? {
@@ -1507,6 +1589,9 @@ impl<'a> Parse<'a> for SassUseNamespace<'a> {
     }
 }
 
+// https://sass-lang.com/documentation/variables
+//
+// <sass-variable> = '$' <ident>
 impl<'a> Parse<'a> for SassVariable<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
@@ -1516,6 +1601,10 @@ impl<'a> Parse<'a> for SassVariable<'a> {
     }
 }
 
+// https://sass-lang.com/documentation/variables
+//
+// [ <namespace> '.' ]? '$' <ident> ':' <expression> <flag>*
+// <flag> = !default | !global
 impl<'a> Parse<'a> for SassVariableDeclaration<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
@@ -1561,6 +1650,8 @@ impl<'a> Parse<'a> for SassVariableDeclaration<'a> {
     }
 }
 
+// A Sass at-rule with an unrecognized (possibly interpolated) name:
+// '@' <interpolated-ident> <prelude>? [ { <block> } | ; ]
 impl<'a> Parse<'a> for UnknownSassAtRule<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));

--- a/crates/oxc_css_parser/src/parser/selector.rs
+++ b/crates/oxc_css_parser/src/parser/selector.rs
@@ -9,6 +9,12 @@ use crate::{
 };
 
 // https://www.w3.org/TR/css-syntax-3/#the-anb-type
+//
+// <an+b> = odd | even | <integer>
+//        | <n-dimension>        [ <signed-integer> | [ '+' | '-' ] <signless-integer> ]?
+//        | '+'? n               [ <signed-integer> | [ '+' | '-' ] <signless-integer> ]?
+//        | -n                   [ <signed-integer> | [ '+' | '-' ] <signless-integer> ]?
+//        | <ndashdigit-dimension> | '+'? <ndashdigit-ident> | <dashndashdigit-ident>
 impl<'a> Parse<'a> for AnPlusB {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.cursor.peek()? {
@@ -310,6 +316,12 @@ impl<'a> Parse<'a> for AnPlusB {
     }
 }
 
+// https://www.w3.org/TR/selectors-4/#attribute-selectors
+//
+// <attribute-selector> = '[' <wq-name> ']'
+//                      | '[' <wq-name> <attr-matcher> [ <string-token> | <ident-token> ] <attr-modifier>? ']'
+// <attr-matcher>  = [ '~' | '|' | '^' | '$' | '*' ]? '='
+// <attr-modifier> = i | s
 impl<'a> Parse<'a> for AttributeSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let start = input.cursor.expect_l_bracket()?.1.start;
@@ -498,6 +510,7 @@ impl<'a> Parse<'a> for AttributeSelector<'a> {
     }
 }
 
+// <class-selector> = '.' <ident-token>
 impl<'a> Parse<'a> for ClassSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, dot_span) = input.cursor.expect_dot()?;
@@ -535,6 +548,7 @@ impl<'a> Parse<'a> for ClassSelector<'a> {
     }
 }
 
+// <complex-selector> = <compound-selector> [ <combinator>? <compound-selector> ]*
 impl<'a> Parse<'a> for ComplexSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let mut children = input.vec_with_capacity(3);
@@ -615,6 +629,8 @@ impl<'a> Parse<'a> for ComplexSelector<'a> {
     }
 }
 
+// <compound-selector> = [ <type-selector>? <subclass-selector>*
+//                         [ <pseudo-element-selector> <pseudo-class-selector>* ]* ]!
 impl<'a> Parse<'a> for CompoundSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<SimpleSelector>()?;
@@ -670,6 +686,7 @@ impl<'a> Parse<'a> for CompoundSelector<'a> {
     }
 }
 
+// <compound-selector-list> = <compound-selector>#
 impl<'a> Parse<'a> for CompoundSelectorList<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<CompoundSelector>()?;
@@ -692,6 +709,7 @@ impl<'a> Parse<'a> for CompoundSelectorList<'a> {
     }
 }
 
+// <id-selector> = <hash-token>
 impl<'a> Parse<'a> for IdSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.cursor.bump()? {
@@ -745,6 +763,7 @@ impl<'a> Parse<'a> for IdSelector<'a> {
     }
 }
 
+// A `:lang()` argument: <lang-range> = <ident-token> | <string-token>  (BCP 47 range)
 impl<'a> Parse<'a> for LanguageRange<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &input.cursor.peek()?.token {
@@ -754,6 +773,7 @@ impl<'a> Parse<'a> for LanguageRange<'a> {
     }
 }
 
+// :lang( <lang-range># )
 impl<'a> Parse<'a> for LanguageRangeList<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<LanguageRange>()?;
@@ -774,6 +794,10 @@ impl<'a> Parse<'a> for LanguageRangeList<'a> {
     }
 }
 
+// https://drafts.csswg.org/css-nesting-1/#nest-selector
+//
+// The nesting selector `&`. This parser also accepts a glued ident/interpolation
+// suffix (`&__x`, `&#{$m}`, `&-@{v}`) as used by Sass/Less.
 impl<'a> Parse<'a> for NestingSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, mut span) = input.cursor.expect_ampersand()?;
@@ -816,6 +840,8 @@ impl<'a> Parse<'a> for NestingSelector<'a> {
 }
 
 // https://drafts.csswg.org/selectors-4/#the-nth-child-pseudo
+//
+// The `:nth-child()` argument: <nth> [ of <complex-selector-list> ]?
 impl<'a> Parse<'a> for Nth<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let index = input.parse::<NthIndex>()?;
@@ -833,6 +859,7 @@ impl<'a> Parse<'a> for Nth<'a> {
     }
 }
 
+// <nth> = <an+b> | even | odd   (plus a plain <integer>)
 impl<'a> Parse<'a> for NthIndex<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &input.cursor.peek()?.token {
@@ -859,6 +886,7 @@ impl<'a> Parse<'a> for NthIndex<'a> {
     }
 }
 
+// of <complex-selector-list>
 impl<'a> Parse<'a> for NthMatcher<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (ident, mut span) = input.cursor.expect_ident()?;
@@ -878,6 +906,10 @@ impl<'a> Parse<'a> for NthMatcher<'a> {
     }
 }
 
+// https://www.w3.org/TR/selectors-4/#pseudo-classes
+//
+// <pseudo-class-selector> = ':' <ident-token>
+//                         | ':' <function-token> <any-value> ')'
 impl<'a> Parse<'a> for PseudoClassSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, colon_span) = input.cursor.expect_colon()?;
@@ -998,6 +1030,10 @@ impl<'a> Parse<'a> for PseudoClassSelector<'a> {
     }
 }
 
+// https://www.w3.org/TR/selectors-4/#pseudo-elements
+//
+// <pseudo-element-selector> = '::' <ident-token>
+//                           | '::' <function-token> <any-value> ')'
 impl<'a> Parse<'a> for PseudoElementSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, colon_colon_span) = input.cursor.expect_colon_colon()?;
@@ -1056,6 +1092,7 @@ impl<'a> Parse<'a> for PseudoElementSelector<'a> {
     }
 }
 
+// <relative-selector> = <combinator>? <complex-selector>
 impl<'a> Parse<'a> for RelativeSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let pos = input.cursor.tokenizer.current_offset();
@@ -1072,6 +1109,7 @@ impl<'a> Parse<'a> for RelativeSelector<'a> {
     }
 }
 
+// <relative-selector-list> = <relative-selector>#
 impl<'a> Parse<'a> for RelativeSelectorList<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<RelativeSelector>()?;
@@ -1093,6 +1131,9 @@ impl<'a> Parse<'a> for RelativeSelectorList<'a> {
     }
 }
 
+// https://www.w3.org/TR/selectors-4/#typedef-selector-list
+//
+// <selector-list> = <complex-selector-list> = <complex-selector>#
 impl<'a> Parse<'a> for SelectorList<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<ComplexSelector>()?;
@@ -1148,6 +1189,10 @@ impl<'a> Parse<'a> for SelectorList<'a> {
 }
 
 // https://www.w3.org/TR/selectors-4/#ref-for-typedef-simple-selector
+//
+// <simple-selector>   = <type-selector> | <subclass-selector>
+// <subclass-selector> = <id-selector> | <class-selector>
+//                     | <attribute-selector> | <pseudo-class-selector>
 impl<'a> Parse<'a> for SimpleSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.cursor.peek()? {
@@ -1197,6 +1242,9 @@ impl<'a> Parse<'a> for SimpleSelector<'a> {
     }
 }
 
+// <type-selector> = <wq-name> | <ns-prefix>? '*'
+// <wq-name>       = <ns-prefix>? <ident-token>
+// <ns-prefix>     = [ <ident-token> | '*' ]? '|'
 impl<'a> Parse<'a> for TypeSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         enum IdentOrAsterisk<'a> {
@@ -1292,6 +1340,9 @@ impl<'a> Parse<'a> for TypeSelector<'a> {
 }
 
 impl<'a> Parser<'a> {
+    // <combinator> = '>' | '+' | '~' | [ '|' '|' ]
+    // An absent combinator between two compounds is the descendant combinator
+    // (whitespace), which this returns as `CombinatorKind::Descendant`.
     fn parse_combinator(&mut self, pos: usize) -> PResult<Option<Combinator>> {
         match self.cursor.peek()? {
             TokenWithSpan {

--- a/crates/oxc_css_parser/src/parser/stmt.rs
+++ b/crates/oxc_css_parser/src/parser/stmt.rs
@@ -10,6 +10,9 @@ use crate::{
     tokenizer::{Token, TokenWithSpan},
 };
 
+// https://drafts.csswg.org/css-syntax-3/#consume-declaration
+//
+// <declaration> = <ident-token> : <declaration-value>? [ '!' important ]?
 impl<'a> Parse<'a> for Declaration<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         // Legacy IE hacks glued to the property name: `*color: red` targets
@@ -236,6 +239,7 @@ fn at_declaration_value_end(token: &Token) -> bool {
     )
 }
 
+// <important> = '!' important
 impl<'a> Parse<'a> for ImportantAnnotation<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, span) = input.cursor.expect_exclamation()?;
@@ -250,6 +254,11 @@ impl<'a> Parse<'a> for ImportantAnnotation<'a> {
     }
 }
 
+// https://drafts.csswg.org/css-syntax-3/#consume-qualified-rule
+//
+// <qualified-rule> = <prelude> <{}-block>
+// In a style context the prelude is a selector list:
+//   <style-rule> = <selector-list> { <style-block> }
 impl<'a> Parse<'a> for QualifiedRule<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let selector_list = input
@@ -264,6 +273,10 @@ impl<'a> Parse<'a> for QualifiedRule<'a> {
     }
 }
 
+// https://drafts.csswg.org/css-syntax-3/#consume-simple-block
+//
+// <simple-block> = '{' <block-contents> '}'
+// (Sass indented syntax substitutes Indent/Dedent for the braces.)
 impl<'a> Parse<'a> for SimpleBlock<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let is_sass = input.syntax == Syntax::Sass;
@@ -325,6 +338,9 @@ impl<'a> Parse<'a> for SimpleBlock<'a> {
     }
 }
 
+// https://drafts.csswg.org/css-syntax-3/#parse-a-stylesheet
+//
+// <stylesheet> = <rule-list>
 impl<'a> Parse<'a> for Stylesheet<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let statements = input.parse_statements(/* is_top_level */ true)?;
@@ -334,10 +350,12 @@ impl<'a> Parse<'a> for Stylesheet<'a> {
 }
 
 impl<'a> Parser<'a> {
-    /// Consume a declaration value as raw tokens (CSS Syntax "preserved
+    /// `<declaration-value>` consumed as raw tokens (CSS Syntax "preserved
     /// tokens"), balancing `()`/`[]`/`{}` pairs, until a top-level `;`, an
     /// unbalanced closer, or a statement boundary. Used for custom-property
     /// values and as the fallback for CSS values the typed grammar rejects.
+    ///
+    /// <https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value>
     ///
     /// `stop_at_top_level_brace` implements the CSS Nesting disambiguation: a
     /// `{` at the top level of a normal declaration's value means the whole
@@ -378,6 +396,8 @@ impl<'a> Parser<'a> {
         Ok(values)
     }
 
+    // The typed form of `<declaration-value>`: a list of `<component-value>` up to
+    // the declaration terminator (`;`, `!`, `}`, or a statement boundary).
     pub(super) fn parse_declaration_value(
         &mut self,
     ) -> PResult<oxc_allocator::Vec<'a, ComponentValue<'a>>> {
@@ -420,9 +440,12 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Parse a qualified rule, falling back to a declaration when the `foo: bar`
-    /// vs `foo { }` prelude is ambiguous. Returns the statement and whether it
-    /// opened a block (for the caller's `is_block_element`).
+    /// The CSS Nesting `<style-block>` ambiguity: parse a qualified rule, falling
+    /// back to a declaration when the `foo: bar` vs `foo { }` prelude is
+    /// ambiguous. Returns the statement and whether it opened a block (for the
+    /// caller's `is_block_element`).
+    ///
+    /// <https://drafts.csswg.org/css-nesting-1/#syntax>
     fn parse_rule_or_declaration(&mut self, is_top_level: bool) -> PResult<(Statement<'a>, bool)> {
         match self.try_parse(QualifiedRule::parse) {
             Ok(rule) => Ok((Statement::QualifiedRule(rule), true)),
@@ -455,6 +478,10 @@ impl<'a> Parser<'a> {
         self.with_state(ParserState { allow_ie_star_hack: true, ..self.state.clone() }).parse()
     }
 
+    // Block contents: a mix of declarations, nested style rules and at-rules
+    // (CSS Syntax `<block-contents>`; `is_top_level` selects the `<stylesheet>`
+    // rule-list, which has no declarations).
+    // https://drafts.csswg.org/css-syntax-3/#consume-block-contents
     fn parse_statements(
         &mut self,
         is_top_level: bool,

--- a/crates/oxc_css_parser/src/parser/token_seq.rs
+++ b/crates/oxc_css_parser/src/parser/token_seq.rs
@@ -8,6 +8,8 @@ use crate::{
 };
 
 impl<'a> Parser<'a> {
+    // The raw `( <any-value> )` body of a <general-enclosed>: balanced tokens up
+    // to the matching `)`. https://www.w3.org/TR/mediaqueries-4/#typedef-general-enclosed
     pub(super) fn parse_tokens_in_parens(&mut self) -> PResult<TokenSeq<'a>> {
         let start = self.cursor.tokenizer.current_offset();
         let mut tokens = self.vec_with_capacity(1);

--- a/crates/oxc_css_parser/src/parser/value.rs
+++ b/crates/oxc_css_parser/src/parser/value.rs
@@ -39,6 +39,13 @@ impl<'a> Parser<'a> {
         self.parse_calc_expr_recursively(0, allow_modulo)
     }
 
+    // https://drafts.csswg.org/css-values-4/#calc-syntax
+    //
+    // <calc-sum>     = <calc-product> [ [ '+' | '-' ] <calc-product> ]*
+    // <calc-product> = <calc-value>   [ [ '*' | '/' ] <calc-value> ]*
+    // <calc-value>   = <number> | <dimension> | <percentage> | ( <calc-sum> )
+    // Precedence-climbing over the two operator tiers (Sass `%` modulo shares the
+    // '*' tier when `allow_modulo`).
     fn parse_calc_expr_recursively(
         &mut self,
         precedence: u8,
@@ -127,6 +134,9 @@ impl<'a> Parser<'a> {
         Ok(left)
     }
 
+    // A single CSS `<component-value>`: a function, a `[]`/`()` block, or a
+    // preserved token (ident, number, dimension, percentage, string, hash, url, …).
+    // https://drafts.csswg.org/css-syntax-3/#component-value
     pub(super) fn parse_component_value_atom(&mut self) -> PResult<ComponentValue<'a>> {
         let token_with_span = self.cursor.peek()?;
         match &token_with_span.token {
@@ -358,6 +368,7 @@ impl<'a> Parser<'a> {
         }
     }
 
+    // <dashed-ident> = <ident-token> whose name starts with '--'
     pub(super) fn parse_dashed_ident(&mut self) -> PResult<InterpolableIdent<'a>> {
         let ident = self.parse()?;
         match &ident {
@@ -370,6 +381,7 @@ impl<'a> Parser<'a> {
         Ok(ident)
     }
 
+    // Build a `<function>` from an already-parsed name: '(' <function-args> ')'.
     pub(super) fn parse_function(&mut self, name: InterpolableIdent<'a>) -> PResult<Function<'a>> {
         self.cursor.expect_l_paren()?;
         let args = if let Token::RParen(..) = &self.cursor.peek()?.token {
@@ -593,6 +605,8 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
+    // A function's argument list: a run of `<component-value>` up to the closing
+    // `)` (commas/`/` are preserved Delimiters).
     pub(super) fn parse_function_args(
         &mut self,
     ) -> PResult<oxc_allocator::Vec<'a, ComponentValue<'a>>> {
@@ -670,6 +684,8 @@ impl<'a> Parser<'a> {
         Ok(values)
     }
 
+    // <ratio> = <number [0,∞]> [ '/' <number [0,∞]> ]?
+    // https://drafts.csswg.org/css-values-4/#ratios
     pub(super) fn parse_ratio(&mut self, numerator: Number<'a>) -> PResult<Ratio<'a>> {
         let (_, solidus_span) = self.cursor.expect_solidus()?;
         let denominator = self.parse::<Number>()?;
@@ -684,6 +700,8 @@ impl<'a> Parser<'a> {
         Ok(Ratio { numerator, solidus_span, denominator, span })
     }
 
+    // The `src()` value function: src( [ <string> ]? <url-modifier>* )
+    // https://drafts.csswg.org/css-values-4/#funcdef-src
     fn parse_src_url(&mut self, name: Ident<'a>) -> PResult<Url<'a>> {
         // caller of `parse_src_url` should make sure there're no whitespaces before paren
         self.cursor.expect_l_paren()?;
@@ -711,6 +729,8 @@ impl<'a> Parser<'a> {
         Ok(Url { name, value, modifiers, span })
     }
 
+    // <urange> = u '+' <ident-token> '?'* | u <dimension-token> '?'* | u <number-token> …
+    // Written `U+0-10FFFF`, `U+4??`, etc. https://drafts.csswg.org/css-syntax-3/#urange-syntax
     fn parse_unicode_range(&mut self, prefix_ident: Ident<'a>) -> PResult<UnicodeRange<'a>> {
         let prefix = prefix_ident.raw.chars().next().unwrap();
         let (span_start, span_end) = match self.cursor.bump()? {
@@ -822,6 +842,8 @@ fn replace_unicode_range_wildcards(source: &str, replacement: char) -> String {
     source.chars().map(|c| if c == '?' { replacement } else { c }).collect()
 }
 
+// A `[]`-block of component values (a `<simple-block>` opened by `[`).
+// https://drafts.csswg.org/css-syntax-3/#simple-block
 impl<'a> Parse<'a> for BracketBlock<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let start = input.cursor.expect_l_bracket()?.1.start;
@@ -837,6 +859,10 @@ impl<'a> Parse<'a> for BracketBlock<'a> {
     }
 }
 
+// https://drafts.csswg.org/css-syntax-3/#component-value
+//
+// <component-value> = <preserved-token> | <function> | <simple-block>
+// (Scss/Sass and Less parse a full operator expression at this position instead.)
 impl<'a> Parse<'a> for ComponentValue<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.syntax {
@@ -849,6 +875,7 @@ impl<'a> Parse<'a> for ComponentValue<'a> {
     }
 }
 
+// A list of `<component-value>` (public entry point; a `;` is kept as a Delimiter).
 impl<'a> Parse<'a> for ComponentValues<'a> {
     /// This is for public-use only. For internal code of oxc-css-parser, **DO NOT** use.
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
@@ -874,6 +901,7 @@ impl<'a> Parse<'a> for ComponentValues<'a> {
     }
 }
 
+// A preserved delimiter token: '/' | ',' | ';'
 impl<'a> Parse<'a> for Delimiter {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         use crate::tokenizer::token::*;
@@ -892,6 +920,7 @@ impl<'a> Parse<'a> for Delimiter {
     }
 }
 
+// <dimension> = <number> <unit>   (a <dimension-token>: length, angle, time, …)
 impl<'a> Parse<'a> for Dimension<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (dimension, span) = input.cursor.expect_dimension()?;
@@ -899,6 +928,9 @@ impl<'a> Parse<'a> for Dimension<'a> {
     }
 }
 
+// https://drafts.csswg.org/css-syntax-3/#function
+//
+// <function> = <function-token> <component-value>* ')'
 impl<'a> Parse<'a> for Function<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let name = input.parse::<FunctionName>()?;
@@ -923,6 +955,8 @@ impl<'a> Parse<'a> for Function<'a> {
     }
 }
 
+// The name before a function's `(`: an <ident-token>. Sass also allows a
+// module-qualified `module.member`; Less adds `%`/`~` function forms.
 impl<'a> Parse<'a> for FunctionName<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.cursor.peek()?.token {
@@ -956,6 +990,7 @@ impl<'a> Parse<'a> for FunctionName<'a> {
     }
 }
 
+// <hex-color> = '#' [ 3 | 4 | 6 | 8 hex digits ]   (a <hash-token>)
 impl<'a> Parse<'a> for HexColor<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (token, span) = input.cursor.expect_hash()?;
@@ -965,6 +1000,7 @@ impl<'a> Parse<'a> for HexColor<'a> {
     }
 }
 
+// <ident-token>
 impl<'a> Parse<'a> for Ident<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (ident, span) = input.cursor.expect_ident()?;
@@ -972,6 +1008,8 @@ impl<'a> Parse<'a> for Ident<'a> {
     }
 }
 
+// An <ident-token>, or a preprocessor-interpolated ident (Sass `#{}`, Less `@{}`)
+// / css-in-js placeholder standing in for one.
 impl<'a> Parse<'a> for InterpolableIdent<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         // A css-in-js placeholder stands in for an interpolated ident anywhere one
@@ -998,6 +1036,7 @@ impl<'a> Parse<'a> for InterpolableIdent<'a> {
     }
 }
 
+// A <string-token>, or a Sass/Less interpolated string template.
 impl<'a> Parse<'a> for InterpolableStr<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.cursor.peek()? {
@@ -1018,6 +1057,7 @@ impl<'a> Parse<'a> for InterpolableStr<'a> {
     }
 }
 
+// <number-token>
 impl<'a> Parse<'a> for Number<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (number, span) = input.cursor.expect_number()?;
@@ -1029,6 +1069,7 @@ impl<'a> Parse<'a> for Number<'a> {
     }
 }
 
+// <percentage> = <percentage-token>   (a <number> immediately followed by '%')
 impl<'a> Parse<'a> for Percentage<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (token, span) = input.cursor.expect_percentage()?;
@@ -1039,6 +1080,7 @@ impl<'a> Parse<'a> for Percentage<'a> {
     }
 }
 
+// <string-token>
 impl<'a> Parse<'a> for Str<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (str, span) = input.cursor.expect_str()?;
@@ -1046,6 +1088,10 @@ impl<'a> Parse<'a> for Str<'a> {
     }
 }
 
+// https://drafts.csswg.org/css-values-4/#urls
+//
+// <url> = url( <string> <url-modifier>* ) | <url-token>
+// (also accepts the Gecko `url-prefix(…)` / `domain(…)` @document matchers)
 impl<'a> Parse<'a> for Url<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (prefix, prefix_span) = input.cursor.expect_ident()?;
@@ -1125,6 +1171,7 @@ impl<'a> Parse<'a> for Url<'a> {
     }
 }
 
+// <url-modifier> = <ident> | <function>
 impl<'a> Parse<'a> for UrlModifier<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let ident = input.parse::<InterpolableIdent>()?;
@@ -1137,6 +1184,7 @@ impl<'a> Parse<'a> for UrlModifier<'a> {
     }
 }
 
+// The unquoted URL body of a <url-token> (raw text up to the closing `)`).
 impl<'a> Parse<'a> for UrlRaw<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.cursor.tokenizer.scan_url_raw_or_template()? {

--- a/crates/oxc_css_parser/src/tokenizer/mod.rs
+++ b/crates/oxc_css_parser/src/tokenizer/mod.rs
@@ -272,6 +272,7 @@ impl<'a> Tokenizer<'a> {
         }
     }
 
+    // Sass indented-syntax layout tokens: Indent / Dedent / Linebreak (no CSS equivalent).
     fn scan_indent(&mut self) -> Option<TokenWithSpan<'a>> {
         debug_assert_eq!(self.syntax, Syntax::Sass);
         let mut start = None;
@@ -310,6 +311,8 @@ impl<'a> Tokenizer<'a> {
         Some(TokenWithSpan { token: Token::Eof(Eof {}), span: Span { start: offset, end: offset } })
     }
 
+    // A comment: '/*' ... '*/'
+    // https://drafts.csswg.org/css-syntax-3/#consume-comment
     fn scan_block_comment(&mut self) {
         let (start, c) = self.state.chars.next().unwrap();
         debug_assert_eq!(c, '/');
@@ -342,6 +345,7 @@ impl<'a> Tokenizer<'a> {
         }
     }
 
+    // A '//' line comment (Sass/Less; not valid in plain CSS).
     fn scan_line_comment(&mut self) {
         let (start, c) = self.state.chars.next().unwrap();
         debug_assert_eq!(c, '/');
@@ -445,6 +449,8 @@ impl<'a> Tokenizer<'a> {
         }
     }
 
+    // <ident-sequence> (a run of name code points / escapes).
+    // https://drafts.csswg.org/css-syntax-3/#consume-name
     pub(crate) fn scan_ident_sequence(
         &mut self,
         allow_leading_digit: bool,
@@ -506,6 +512,8 @@ impl<'a> Tokenizer<'a> {
         Ok((Ident { raw, escaped }, Span { start, end }))
     }
 
+    // An escaped code point: '\' followed by a hex digits run or any character.
+    // https://drafts.csswg.org/css-syntax-3/#consume-escaped-code-point
     fn scan_escape(&mut self, backslash_consumed: bool) -> PResult<usize> {
         if !backslash_consumed {
             self.state.chars.next(); // consume `\\`
@@ -537,6 +545,8 @@ impl<'a> Tokenizer<'a> {
         }
     }
 
+    // <number-token> = [ '+' | '-' ]? <digits> [ '.' <digits> ]? [ e [ '+' | '-' ]? <digits> ]?
+    // https://drafts.csswg.org/css-syntax-3/#consume-number
     fn scan_number(&mut self) -> PResult<(Number<'a>, Span)> {
         let start;
         let mut end;
@@ -634,6 +644,7 @@ impl<'a> Tokenizer<'a> {
         Ok((Number { raw }, Span { start, end }))
     }
 
+    // A number followed by a unit or '%': <dimension-token> | <percentage-token>.
     fn scan_dimension_or_percentage(
         &mut self,
         number: Number<'a>,
@@ -652,6 +663,7 @@ impl<'a> Tokenizer<'a> {
         }
     }
 
+    // <dimension-token> = <number-token> <ident-sequence>
     fn scan_dimension(
         &mut self,
         value: Number<'a>,
@@ -664,6 +676,7 @@ impl<'a> Tokenizer<'a> {
         })
     }
 
+    // <percentage-token> = <number-token> '%'
     fn scan_percentage(&mut self, value: Number<'a>, span: Span) -> PResult<TokenWithSpan<'a>> {
         self.state.chars.next();
         Ok(TokenWithSpan {
@@ -672,6 +685,8 @@ impl<'a> Tokenizer<'a> {
         })
     }
 
+    // <string-token> = '"' ... '"' | '\'' ... '\''
+    // https://drafts.csswg.org/css-syntax-3/#consume-string-token
     pub(crate) fn scan_string_only(&mut self) -> PResult<(Str<'a>, Span)> {
         let (start, quote) = match self.state.chars.next() {
             Some((index, c @ '\'' | c @ '"')) => (index, c),
@@ -717,6 +732,8 @@ impl<'a> Tokenizer<'a> {
         Ok((Str { raw, escaped }, Span { start, end }))
     }
 
+    // A <string-token>, or a dialect interpolated-string template (Sass/Less)
+    // when the string contains `#{…}` / `@{…}`.
     fn scan_string_or_template(&mut self) -> PResult<TokenWithSpan<'a>> {
         // '\'' or '"' is checked (but not consumed) before
         let (start, quote) = self.state.chars.next().unwrap();
@@ -787,6 +804,8 @@ impl<'a> Tokenizer<'a> {
         Ok(TokenWithSpan { token: Token::Str(Str { raw, escaped }), span: Span { start, end } })
     }
 
+    // Resume a string template after an interpolation, yielding the next static
+    // piece up to the following `#{`/`@{` or the closing quote.
     pub(crate) fn scan_string_template(&mut self, quote: char) -> PResult<(StrTemplate<'a>, Span)> {
         let start = self.current_offset();
         let end;
@@ -838,11 +857,14 @@ impl<'a> Tokenizer<'a> {
         }
     }
 
+    // An ident-like token: <ident-token>, <function-token> (`name(`), or <url-token>.
+    // https://drafts.csswg.org/css-syntax-3/#consume-ident-like-token
     fn scan_ident(&mut self) -> PResult<TokenWithSpan<'a>> {
         self.scan_ident_sequence(false)
             .map(|(ident, span)| TokenWithSpan { token: Token::Ident(ident), span })
     }
 
+    // The next static piece of an ident interleaved with interpolation (Sass/Less).
     pub(crate) fn scan_ident_template(&mut self) -> PResult<Option<(Ident<'a>, Span)>> {
         let start = self.current_offset();
         let mut escaped = false;
@@ -877,6 +899,7 @@ impl<'a> Tokenizer<'a> {
         }
     }
 
+    // Sass: a lone '-' consumed as an <ident-token>.
     fn scan_sass_single_hyphen_as_ident(&mut self) -> PResult<TokenWithSpan<'a>> {
         debug_assert!(matches!(self.syntax, Syntax::Scss | Syntax::Sass));
         match self.state.chars.next() {
@@ -891,6 +914,8 @@ impl<'a> Tokenizer<'a> {
         }
     }
 
+    // The unquoted body of a <url-token> (or an interpolated url template in Sass/Less).
+    // https://drafts.csswg.org/css-syntax-3/#consume-url-token
     pub(crate) fn scan_url_raw_or_template(&mut self) -> PResult<TokenWithSpan<'a>> {
         self.skip_ws();
         let start = self.current_offset();
@@ -950,6 +975,7 @@ impl<'a> Tokenizer<'a> {
         Ok(TokenWithSpan { token: Token::UrlRaw(UrlRaw { raw, escaped }), span })
     }
 
+    // The next static piece of an unquoted url() body interleaved with interpolation.
     pub(crate) fn scan_url_template(&mut self) -> PResult<(UrlTemplate<'a>, Span)> {
         let start = self.current_offset();
         let mut escaped = false;
@@ -1014,6 +1040,8 @@ impl<'a> Tokenizer<'a> {
         }
     }
 
+    // <hash-token> = '#' <ident-sequence>
+    // https://drafts.csswg.org/css-syntax-3/#consume-token
     fn scan_hash(&mut self) -> PResult<TokenWithSpan<'a>> {
         let (start, c) = self.state.chars.next().unwrap();
         debug_assert_eq!(c, '#');
@@ -1063,6 +1091,7 @@ impl<'a> Tokenizer<'a> {
         Ok(TokenWithSpan { token: Token::Hash(Hash { escaped, raw }), span: Span { start, end } })
     }
 
+    // A '$'-prefixed variable token: '$' <ident-sequence> (Sass var / Less property).
     fn scan_dollar_var(&mut self) -> PResult<TokenWithSpan<'a>> {
         let (start, c) = self.state.chars.next().expect("expect char `$`");
         debug_assert_eq!(c, '$');
@@ -1073,6 +1102,7 @@ impl<'a> Tokenizer<'a> {
         })
     }
 
+    // A Less interpolation opener: '@{' or '${' <ident-sequence> '}'
     fn scan_less_lbrace_var(&mut self) -> PResult<TokenWithSpan<'a>> {
         let (start, first_char) = self.state.chars.next().expect("expect char `@` or `$`");
         debug_assert!(matches!(first_char, '@' | '$'));
@@ -1101,6 +1131,8 @@ impl<'a> Tokenizer<'a> {
         }
     }
 
+    // <at-keyword-token> = '@' <ident-sequence>
+    // https://drafts.csswg.org/css-syntax-3/#consume-token
     fn scan_at_keyword(&mut self) -> PResult<TokenWithSpan<'a>> {
         let (start, c) = self.state.chars.next().expect("expect char `@`");
         debug_assert_eq!(c, '@');
@@ -1181,6 +1213,7 @@ impl<'a> Tokenizer<'a> {
         Some(TokenWithSpan { token: Token::Placeholder(placeholder), span: Span { start, end } })
     }
 
+    // A Less inline-JavaScript token: '`' ... '`' (deprecated).
     fn scan_backtick_code(&mut self) -> PResult<TokenWithSpan<'a>> {
         debug_assert!(self.syntax == Syntax::Less);
 
@@ -1209,6 +1242,8 @@ impl<'a> Tokenizer<'a> {
         })
     }
 
+    // Delimiter and punctuation tokens: '(' ')' '[' ']' '{' '}' ',' ':' ';' plus
+    // the multi-char operators (`<=`, `>=`, `||`, `~=`, `|=`, `^=`, `$=`, `*=`, …).
     fn scan_punc(&mut self) -> PResult<TokenWithSpan<'a>> {
         match self.state.chars.next() {
             Some((start, '.')) => {


### PR DESCRIPTION
## Summary

Annotates every grammar-producing site in the parser and tokenizer with its formal grammar production plus a spec/reference link, placed directly above the `Parse` impl / parse helper / token scanner. Comments only — no behavior change.

This extends the handful of bare spec-URL comments already in the tree into consistent, grammar-by-grammar documentation.

## Coverage

Audited complete: **0 uncovered `Parse` impls of 159**, 0 uncovered tokenizer scanners.

| Layer | Productions | Source cited |
|---|---|---|
| Statements (`stmt.rs`) | `<stylesheet>`, `<qualified-rule>`, `<declaration>`, `<simple-block>` + helpers | css-syntax-3, css-nesting |
| Values (`value.rs`) | `<component-value>`, `<function>`, `<url>`, `<ratio>`, calc, `<urange>`, … | css-syntax-3, css-values-4 |
| Selectors (`selector.rs`) | complex/compound/attribute/pseudo/type + `<an+b>`, combinators | selectors-4 |
| At-rules (15 files) | media, container, supports, import, layer, scope, keyframes, page, … | per-rule CSSWG drafts |
| Sass (`sass.rs`) | 30 impls + 13 helpers (`@each`/`@for`/`@mixin`/`@use`/maps/lists/operators…) | dart-sass docs |
| Less (`less.rs`) | 34 impls + 15 helpers (mixins/guards/lookups/interpolation/operations…) | lesscss.org |
| postcss / general-enclosed | simple-vars, `parse_tokens_in_parens` | postcss-simple-vars, mediaqueries-4 |
| Tokenizer (`tokenizer/mod.rs`) | 23 scanners (`<ident-token>`, `<number-token>`, `<string-token>`, `<url-token>`, `<hash-token>`, `<at-keyword-token>`, …) | css-syntax-3 §4 |

## Example

```rust
// https://www.w3.org/TR/selectors-4/#attribute-selectors
//
// <attribute-selector> = '[' <wq-name> ']'
//                      | '[' <wq-name> <attr-matcher> [ <string-token> | <ident-token> ] <attr-modifier>? ']'
// <attr-matcher>  = [ '~' | '|' | '^' | '$' | '*' ]? '='
// <attr-modifier> = i | s
impl<'a> Parse<'a> for AttributeSelector<'a> {
```

## Notes

- Preprocessor grammars have no W3C spec, so those cite the dart-sass / less.js / postcss reference docs and give the grammar **as implemented** (flagged as such in the comments).
- Comment style is plain `//`, matching the existing spec-URL comments already in the codebase.

Verified: `cargo check`, `cargo clippy`, `rustdoc -D warnings`, `cargo fmt --check`, and `cargo test --all-features` all pass.
