### PR TITLE
fix(parser): formatter v0.0.4 update follow-ups

### DIFF
--- a/crates/oxc_css_parser/src/parser/at_rule/import.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/import.rs
@@ -59,6 +59,9 @@ impl<'a> Parse<'a> for ImportPrelude<'a> {
             // Reference compilers accept arbitrary import modifiers (idents,
             // unknown functions, media-ish parens, further comma-chained
             // imports); keep the whole tail as raw component values.
+            // NOTE: Scss/Sass multi-path imports (`@import 'a', 'b';`) never
+            // get here — the at-rule dispatch claims them as
+            // `SassImportPrelude` before trying `ImportPrelude`.
             Err(_) => {
                 let start = input.cursor.peek()?.span.start;
                 let values = input.parse_declaration_value_tokens(true)?;

--- a/crates/oxc_css_parser/src/parser/at_rule/mod.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/mod.rs
@@ -126,7 +126,28 @@ impl<'a> Parse<'a> for AtRule<'a> {
                     (prelude.span.end, AtRulePrelude::Import(input.alloc(prelude)))
                 }
                 Syntax::Scss | Syntax::Sass => {
-                    if let Ok(prelude) = input.try_parse(ImportPrelude::parse) {
+                    // A multi-path import (`@import 'a', 'b';`) is
+                    // Sass-specific and must win over `ImportPrelude`'s
+                    // lenient raw-modifiers tail so each path stays typed.
+                    // Claim it only on a full-prelude match with more than
+                    // one path: a single path keeps the standard
+                    // `ImportPrelude` shape, and any unparsed tail
+                    // (`@import 'a', 'b' screen;`) falls through to
+                    // `ImportPrelude`'s leniency.
+                    let multi_path = input.try_parse(|parser| {
+                        let prelude = parser.try_parse_full_prelude(SassImportPrelude::parse)?;
+                        if prelude.paths.len() > 1 {
+                            Ok(prelude)
+                        } else {
+                            Err(Error {
+                                kind: ErrorKind::TryParseError,
+                                span: prelude.span.clone(),
+                            })
+                        }
+                    });
+                    if let Ok(prelude) = multi_path {
+                        (prelude.span.end, AtRulePrelude::SassImport(prelude))
+                    } else if let Ok(prelude) = input.try_parse(ImportPrelude::parse) {
                         (prelude.span.end, AtRulePrelude::Import(input.alloc(prelude)))
                     } else {
                         let prelude = input.parse::<SassImportPrelude>()?;

--- a/crates/oxc_css_parser/src/parser/selector.rs
+++ b/crates/oxc_css_parser/src/parser/selector.rs
@@ -1176,8 +1176,12 @@ impl<'a> Parse<'a> for SimpleSelector<'a> {
             TokenWithSpan { token: Token::Ampersand(..), .. } => {
                 input.parse().map(SimpleSelector::Nesting)
             }
+            // Css too: postcss-extend-rule uses Sass-style placeholders in
+            // plain CSS (`%thick-border {}` + `@extend %thick-border;`), and
+            // postcss parses `%x` as an ordinary selector. A selector-position
+            // `%` is invalid per spec, so accepting it is purely additive.
             TokenWithSpan { token: Token::Percent(..), .. }
-                if matches!(input.syntax, Syntax::Scss | Syntax::Sass) =>
+                if matches!(input.syntax, Syntax::Scss | Syntax::Sass | Syntax::Css) =>
             {
                 input.parse().map(SimpleSelector::SassPlaceholder)
             }

--- a/crates/oxc_css_parser/src/parser/stmt.rs
+++ b/crates/oxc_css_parser/src/parser/stmt.rs
@@ -696,7 +696,11 @@ impl<'a> Parser<'a> {
                         is_block_element = true;
                     }
                 }
-                Token::Percent(..) if matches!(self.syntax, Syntax::Scss | Syntax::Sass) => {
+                // Css too: postcss-extend-rule's `%thick-border {}`
+                // (see the placeholder arm in `SimpleSelector`'s parser).
+                Token::Percent(..)
+                    if matches!(self.syntax, Syntax::Scss | Syntax::Sass | Syntax::Css) =>
+                {
                     statements.push(Statement::QualifiedRule(self.parse()?));
                     is_block_element = true;
                 }

--- a/crates/oxc_css_parser/src/parser/value.rs
+++ b/crates/oxc_css_parser/src/parser/value.rs
@@ -200,25 +200,45 @@ impl<'a> Parser<'a> {
                         if matches!(self.syntax, Syntax::Scss | Syntax::Sass)
                             && span.start == ident_end =>
                     {
-                        if let InterpolableIdent::Literal(module) = ident {
-                            let name = self.parse_sass_qualified_name(module)?;
-                            return if let SassQualifiedName {
-                                member: SassModuleMemberName::Ident(..),
-                                ..
-                            } = name
-                            {
-                                let (_, lparen_span) = self.cursor.expect_l_paren()?;
-                                util::assert_no_ws_or_comment(&name.span, &lparen_span)?;
-                                let args = self.parse_function_args()?;
-                                let (_, Span { end, .. }) = self.cursor.expect_r_paren()?;
-                                let span = Span { start: name.span.start, end };
-                                Ok(ComponentValue::Function(Function {
-                                    name: FunctionName::SassQualifiedName(self.alloc(name)),
-                                    args,
-                                    span,
-                                }))
-                            } else {
-                                Ok(ComponentValue::SassQualifiedName(self.alloc(name)))
+                        if let InterpolableIdent::Literal(module) = &ident {
+                            let module = Ident {
+                                name: module.name,
+                                raw: module.raw,
+                                span: module.span.clone(),
+                            };
+                            // A namespaced member is `foo.$var` or a glued
+                            // call `foo.bar(...)`.
+                            let qualified = self.try_parse(|parser| {
+                                let name = parser.parse_sass_qualified_name(module)?;
+                                if let SassQualifiedName {
+                                    member: SassModuleMemberName::Ident(..),
+                                    ..
+                                } = name
+                                {
+                                    let (_, lparen_span) = parser.cursor.expect_l_paren()?;
+                                    util::assert_no_ws_or_comment(&name.span, &lparen_span)?;
+                                    let args = parser.parse_function_args()?;
+                                    let (_, Span { end, .. }) = parser.cursor.expect_r_paren()?;
+                                    let span = Span { start: name.span.start, end };
+                                    Ok(ComponentValue::Function(Function {
+                                        name: FunctionName::SassQualifiedName(parser.alloc(name)),
+                                        args,
+                                        span,
+                                    }))
+                                } else {
+                                    Ok(ComponentValue::SassQualifiedName(parser.alloc(name)))
+                                }
+                            });
+                            return match qualified {
+                                Ok(value) => Ok(value),
+                                // `foo.bar` with no call: dart-sass rejects a
+                                // plain ident member at compile time, but
+                                // postcss-scss lexes the dotted run as ONE
+                                // word (xstyled / tailwind-theme tokens).
+                                // Keep the plain ident; the `.ident` tail
+                                // parses as raw tokens (the Css-mode shape)
+                                // via the `Token::Dot` atom arm.
+                                Err(_) => Ok(ComponentValue::InterpolableIdent(ident)),
                             };
                         }
                     }
@@ -320,6 +340,22 @@ impl<'a> Parser<'a> {
             }
             Token::Dot(..) if self.syntax == Syntax::Less => {
                 self.parse_less_maybe_mixin_call_or_with_lookups()
+            }
+            // Not Sass on its own — dart-sass has no bare `.` in values — but
+            // the ident atom declines the namespaced parse for postcss-word
+            // runs like `foo.bar.baz` (xstyled / tailwind-theme tokens),
+            // whose `.` then lands here. Accept it when glued to a following
+            // ident, keeping the Css-mode raw-token shape.
+            Token::Dot(..) if matches!(self.syntax, Syntax::Scss | Syntax::Sass) => {
+                let dot = self.cursor.bump()?;
+                match self.cursor.peek()? {
+                    TokenWithSpan { token: Token::Ident(..), span }
+                        if span.start == dot.span.end =>
+                    {
+                        Ok(ComponentValue::TokenWithSpan(dot))
+                    }
+                    _ => Err(Error { kind: ErrorKind::ExpectComponentValue, span: dot.span }),
+                }
             }
             Token::StrTemplate(..) if self.syntax == Syntax::Less => self
                 .parse()

--- a/crates/oxc_css_parser/src/tokenizer/mod.rs
+++ b/crates/oxc_css_parser/src/tokenizer/mod.rs
@@ -573,30 +573,34 @@ impl<'a> Tokenizer<'a> {
                 }
             }
         }
-        if !is_start_with_dot {
-            let chars = self.state.chars.clone();
-            match self.state.chars.peek() {
-                // next token can be a `DotDotDot` token
-                Some((_, '.')) if !matches!(chars.clone().nth(1), Some((_, '.'))) => {
-                    // bump '.'
-                    self.state.chars.next();
-                    loop {
-                        match self.state.chars.peek() {
-                            Some((_, c)) if c.is_ascii_digit() => {
-                                self.state.chars.next();
-                            }
-                            Some((i, _)) => {
-                                end = *i;
-                                break;
-                            }
-                            None => {
-                                end = self.source.len();
-                                break;
-                            }
+        if !is_start_with_dot && matches!(self.state.chars.peek(), Some((_, '.'))) {
+            // Length of the dot run right after the digits decides who owns
+            // the first `.`:
+            // - 1 dot: a fraction (possibly empty: `50.` is one number)
+            // - 2-3 dots: leave them all (`..`; a `...` spread marker)
+            // - 4 dots: `50....` is `50.` + `...` — the number takes the
+            //   first dot (postcss lexes the word `50.`) and a spread marker
+            //   still follows, e.g. `rgba(50 50 50 50....)`
+            // (capped at 5: any longer run behaves like 2-3)
+            let dot_run = self.state.chars.clone().take(5).take_while(|(_, c)| *c == '.').count();
+            if dot_run == 1 || dot_run == 4 {
+                // bump '.'
+                self.state.chars.next();
+                loop {
+                    match self.state.chars.peek() {
+                        Some((_, c)) if c.is_ascii_digit() => {
+                            self.state.chars.next();
+                        }
+                        Some((i, _)) => {
+                            end = *i;
+                            break;
+                        }
+                        None => {
+                            end = self.source.len();
+                            break;
                         }
                     }
                 }
-                _ => {}
             }
         }
 

--- a/crates/oxc_css_parser/tests/css_placeholder_selector.rs
+++ b/crates/oxc_css_parser/tests/css_placeholder_selector.rs
@@ -1,0 +1,55 @@
+use oxc_css_parser::{Allocator, ParserBuilder, Syntax, ast::*};
+
+fn parse_css(code: &'static str) -> Stylesheet<'static> {
+    let allocator = Box::leak(Box::new(Allocator::default()));
+    let mut parser = ParserBuilder::new(allocator, code).syntax(Syntax::Css).build();
+    let ss = parser.parse::<Stylesheet>().unwrap();
+    assert!(
+        parser.recoverable_errors().is_empty(),
+        "recoverable errors: {:?}",
+        parser.recoverable_errors()
+    );
+    ss
+}
+
+// postcss-extend-rule: Sass-style placeholders in plain CSS
+// (`%thick-border {}` + `@extend %thick-border;`).
+#[test]
+fn css_placeholder_selector_parses() {
+    let ss = parse_css("%thick-border { border: thick dotted red; }");
+    let Statement::QualifiedRule(rule) = &ss.statements[0] else {
+        panic!("expected qualified rule");
+    };
+    let ComplexSelectorChild::CompoundSelector(compound) = &rule.selector.selectors[0].children[0]
+    else {
+        panic!("expected compound selector");
+    };
+    assert!(matches!(compound.children[0], SimpleSelector::SassPlaceholder(..)));
+}
+
+#[test]
+fn css_placeholder_in_selector_list_and_compound() {
+    let ss = parse_css("%a, .b %c:hover { x: y; }");
+    let Statement::QualifiedRule(rule) = &ss.statements[0] else {
+        panic!("expected qualified rule");
+    };
+    assert_eq!(rule.selector.selectors.len(), 2);
+}
+
+// `@extend %x;` is an unknown at-rule in Css; its prelude stays verbatim.
+#[test]
+fn css_extend_at_rule_parses() {
+    let ss = parse_css(".modal { @extend %thick-border; color: red; }");
+    let Statement::QualifiedRule(rule) = &ss.statements[0] else {
+        panic!("expected qualified rule");
+    };
+    assert!(matches!(rule.block.statements[0], Statement::AtRule(..)));
+}
+
+// A `%` NOT glued to an ident is still an error.
+#[test]
+fn css_bare_percent_selector_is_still_an_error() {
+    let allocator = Allocator::default();
+    let mut parser = ParserBuilder::new(&allocator, "% { x: y; }").syntax(Syntax::Css).build();
+    assert!(parser.parse::<Stylesheet>().is_err());
+}

--- a/crates/oxc_css_parser/tests/import_prelude.rs
+++ b/crates/oxc_css_parser/tests/import_prelude.rs
@@ -1,0 +1,97 @@
+use oxc_css_parser::{Allocator, ParserBuilder, Syntax, ast::*};
+
+fn parse(code: &'static str, syntax: Syntax) -> Stylesheet<'static> {
+    let allocator = Box::leak(Box::new(Allocator::default()));
+    let mut parser = ParserBuilder::new(allocator, code).syntax(syntax).build();
+    let ss = parser.parse::<Stylesheet>().unwrap();
+    assert!(
+        parser.recoverable_errors().is_empty(),
+        "recoverable errors: {:?}",
+        parser.recoverable_errors()
+    );
+    ss
+}
+
+fn at_rule_prelude<'a>(ss: &'a Stylesheet<'static>) -> &'a AtRulePrelude<'static> {
+    let Statement::AtRule(at_rule) = &ss.statements[0] else {
+        panic!("expected at-rule");
+    };
+    at_rule.prelude.as_ref().expect("expected prelude")
+}
+
+// A pure `'a', 'b', ...` import is a Sass multi-path import: each path stays
+// typed (`SassImportPrelude`), never flattened into raw modifier tokens.
+#[test]
+fn scss_multi_path_import_is_sass_import_prelude() {
+    let ss = parse("@import 'mixins', 'variables', 'reset';", Syntax::Scss);
+    let AtRulePrelude::SassImport(import) = at_rule_prelude(&ss) else {
+        panic!("expected SassImportPrelude");
+    };
+    assert_eq!(import.paths.len(), 3);
+    assert_eq!(import.paths[0].raw, "'mixins'");
+    assert_eq!(import.comma_spans.len(), 2);
+}
+
+// Comments between the paths must not break the typed-path shape
+// (Prettier keeps them: `@import // Comment\n  "mixins", ...`).
+#[test]
+fn scss_multi_path_import_with_comments() {
+    let ss = parse("@import // Comment\n  'mixins',\n  // Comment\n  'reset';", Syntax::Scss);
+    let AtRulePrelude::SassImport(import) = at_rule_prelude(&ss) else {
+        panic!("expected SassImportPrelude");
+    };
+    assert_eq!(import.paths.len(), 2);
+}
+
+// A tail that is NOT just strings keeps the lenient raw-modifiers shape.
+#[test]
+fn scss_non_string_tail_stays_import_modifiers() {
+    let ss = parse("@import 'a' b c(d), 'e' supports(f: g);", Syntax::Scss);
+    let AtRulePrelude::Import(import) = at_rule_prelude(&ss) else {
+        panic!("expected ImportPrelude");
+    };
+    assert!(import.modifiers.is_some());
+}
+
+// A url() href cannot be a Sass path list; the comma tail stays raw.
+#[test]
+fn scss_url_href_with_comma_tail_stays_import_modifiers() {
+    let ss = parse("@import url(a), 'b';", Syntax::Scss);
+    let AtRulePrelude::Import(import) = at_rule_prelude(&ss) else {
+        panic!("expected ImportPrelude");
+    };
+    assert!(import.modifiers.is_some());
+}
+
+// A path list followed by anything else is not a full-prelude match;
+// the whole tail keeps the lenient raw-modifiers shape.
+#[test]
+fn scss_path_list_with_trailing_media_stays_import_modifiers() {
+    let ss = parse("@import 'a', 'b' screen;", Syntax::Scss);
+    let AtRulePrelude::Import(import) = at_rule_prelude(&ss) else {
+        panic!("expected ImportPrelude");
+    };
+    assert!(import.modifiers.is_some());
+}
+
+// An interpolated href can't be a Sass path (`SassImportPrelude` takes only
+// plain strings); the comma tail stays raw instead of hard-failing.
+#[test]
+fn scss_interpolated_href_with_comma_tail_stays_import_modifiers() {
+    let ss = parse("@import \"a#{$x}\", 'b';", Syntax::Scss);
+    let AtRulePrelude::Import(import) = at_rule_prelude(&ss) else {
+        panic!("expected ImportPrelude");
+    };
+    assert!(import.modifiers.is_some());
+}
+
+// Plain CSS has no Sass import; the comma-chained tail stays raw modifiers.
+#[test]
+fn css_multi_path_import_stays_import_modifiers() {
+    let ss = parse("@import 'one.css', 'two.css';", Syntax::Css);
+    let AtRulePrelude::Import(import) = at_rule_prelude(&ss) else {
+        panic!("expected ImportPrelude");
+    };
+    let modifiers = import.modifiers.as_ref().expect("expected modifiers");
+    assert_eq!(modifiers.values.len(), 2);
+}

--- a/crates/oxc_css_parser/tests/number_trailing_dot.rs
+++ b/crates/oxc_css_parser/tests/number_trailing_dot.rs
@@ -1,0 +1,61 @@
+use oxc_css_parser::{Allocator, ParserBuilder, Syntax, ast::*};
+
+fn parse_scss(code: &'static str) -> Stylesheet<'static> {
+    let allocator = Box::leak(Box::new(Allocator::default()));
+    let mut parser = ParserBuilder::new(allocator, code).syntax(Syntax::Scss).build();
+    let ss = parser.parse::<Stylesheet>().unwrap();
+    assert!(
+        parser.recoverable_errors().is_empty(),
+        "recoverable errors: {:?}",
+        parser.recoverable_errors()
+    );
+    ss
+}
+
+fn first_declaration_value<'a>(ss: &'a Stylesheet<'static>) -> &'a [ComponentValue<'static>] {
+    let Statement::QualifiedRule(rule) = &ss.statements[0] else {
+        panic!("expected qualified rule");
+    };
+    let Statement::Declaration(decl) = &rule.block.statements[0] else {
+        panic!("expected declaration");
+    };
+    &decl.value
+}
+
+// `50....` is `50.` + `...`: the number owns the first dot (postcss lexes the
+// word `50.`) and a spread marker still follows — no stray `.` token.
+#[test]
+fn four_dots_after_number_split_as_trailing_dot_plus_spread() {
+    let ss = parse_scss("a { color: rgba(50 50 50 50....); }");
+    let [ComponentValue::Function(func)] = first_declaration_value(&ss) else {
+        panic!("expected function value");
+    };
+    let Some(ComponentValue::SassArbitraryArgument(arg)) = func.args.last() else {
+        panic!("expected arbitrary argument, got {:?}", func.args.last());
+    };
+    let ComponentValue::Number(number) = &*arg.value else {
+        panic!("expected number");
+    };
+    assert_eq!(number.raw, "50.");
+    // The spread consumed the remaining three dots; nothing is left over.
+    assert_eq!(func.args.len(), 4);
+}
+
+// The 1-3 dot runs keep their existing split.
+#[test]
+fn spread_after_number_is_untouched() {
+    let ss = parse_scss("a { width: min(50px 20px 30px...); }");
+    let [ComponentValue::Function(func)] = first_declaration_value(&ss) else {
+        panic!("expected function value");
+    };
+    assert!(matches!(func.args.last(), Some(ComponentValue::SassArbitraryArgument(_))));
+}
+
+#[test]
+fn fraction_still_parses() {
+    let ss = parse_scss("a { width: 50.5px; }");
+    let [ComponentValue::Dimension(dimension)] = first_declaration_value(&ss) else {
+        panic!("expected dimension value");
+    };
+    assert_eq!(dimension.value.raw, "50.5");
+}

--- a/crates/oxc_css_parser/tests/scss_dotted_words.rs
+++ b/crates/oxc_css_parser/tests/scss_dotted_words.rs
@@ -1,0 +1,95 @@
+use oxc_css_parser::{Allocator, ParserBuilder, Syntax, ast::*, token::Token};
+
+fn parse_scss(code: &'static str) -> Stylesheet<'static> {
+    let allocator = Box::leak(Box::new(Allocator::default()));
+    let mut parser = ParserBuilder::new(allocator, code).syntax(Syntax::Scss).build();
+    let ss = parser.parse::<Stylesheet>().unwrap();
+    assert!(
+        parser.recoverable_errors().is_empty(),
+        "recoverable errors: {:?}",
+        parser.recoverable_errors()
+    );
+    ss
+}
+
+fn first_declaration_value<'a>(ss: &'a Stylesheet<'static>) -> &'a [ComponentValue<'static>] {
+    let Statement::QualifiedRule(rule) = &ss.statements[0] else {
+        panic!("expected qualified rule");
+    };
+    let Statement::Declaration(decl) = &rule.block.statements[0] else {
+        panic!("expected declaration");
+    };
+    &decl.value
+}
+
+// `foo.bar` with no glued call is not Sass (dart-sass rejects a plain ident
+// member at compile time), but postcss-scss lexes the dotted run as ONE word
+// (xstyled / tailwind-theme tokens). It parses as ident + raw `.` + ident,
+// the same shape Css mode produces.
+#[test]
+fn dotted_word_parses_as_raw_tokens() {
+    let ss = parse_scss("a { color: foo.bar; }");
+    let [
+        ComponentValue::InterpolableIdent(_),
+        ComponentValue::TokenWithSpan(dot),
+        ComponentValue::InterpolableIdent(_),
+    ] = first_declaration_value(&ss)
+    else {
+        panic!("expected ident/dot/ident, got {:?}", first_declaration_value(&ss));
+    };
+    assert!(matches!(dot.token, Token::Dot(..)));
+}
+
+#[test]
+fn dotted_word_chain_parses() {
+    let ss = parse_scss("a { color: colors.modes.dark; }");
+    assert_eq!(first_declaration_value(&ss).len(), 5);
+}
+
+#[test]
+fn dotted_word_with_number_tail_parses() {
+    // `.10` lexes as a number, so the run is ident + number (no dot token).
+    let ss = parse_scss("a { color: sandstone.10; }");
+    let [ComponentValue::InterpolableIdent(_), ComponentValue::Number(number)] =
+        first_declaration_value(&ss)
+    else {
+        panic!("expected ident/number, got {:?}", first_declaration_value(&ss));
+    };
+    assert_eq!(number.raw, ".10");
+}
+
+// The real namespaced forms keep their typed shapes.
+#[test]
+fn namespaced_function_call_stays_function() {
+    let ss = parse_scss("@use \"sass:math\";\na { b: math.div(10, 2); }");
+    let Statement::QualifiedRule(rule) = &ss.statements[1] else {
+        panic!("expected qualified rule");
+    };
+    let Statement::Declaration(decl) = &rule.block.statements[0] else {
+        panic!("expected declaration");
+    };
+    let [ComponentValue::Function(func)] = &decl.value[..] else {
+        panic!("expected function");
+    };
+    assert!(matches!(func.name, FunctionName::SassQualifiedName(..)));
+}
+
+#[test]
+fn namespaced_variable_stays_qualified_name() {
+    let ss = parse_scss("@use \"sass:math\";\na { b: math.$pi; }");
+    let Statement::QualifiedRule(rule) = &ss.statements[1] else {
+        panic!("expected qualified rule");
+    };
+    let Statement::Declaration(decl) = &rule.block.statements[0] else {
+        panic!("expected declaration");
+    };
+    assert!(matches!(&decl.value[..], [ComponentValue::SassQualifiedName(..)]));
+}
+
+// A `.` NOT glued to a following ident is still an error.
+#[test]
+fn lone_dot_is_still_an_error() {
+    let allocator = Allocator::default();
+    let mut parser = ParserBuilder::new(&allocator, "a { b: foo. ; }").syntax(Syntax::Scss).build();
+    assert!(parser.parse::<Stylesheet>().is_err());
+}

--- a/tasks/conformance/snapshots/sass-spec.snap
+++ b/tasks/conformance/snapshots/sass-spec.snap
@@ -1,7 +1,7 @@
 suite: sass-spec
 sha: a2ead9225786d49e91f5cc36755b7713596a2338
-files: 26787   success: 26492   failed: 2   expected: 293
-clean: 26492  recovered: 0  hard_error: 2  panic: 0
+files: 26787   success: 26493   failed: 2   expected: 292
+clean: 26493  recovered: 0  hard_error: 2  panic: 0
 
 failures:
 ERROR    spec/non_conformant/extend-tests/selector_list.hrx::input.scss    expect token `;`, but found `#{`
@@ -62,7 +62,6 @@ ERROR    spec/css/plain/error/statement/style_rule.hrx::interpolation/declaratio
 ERROR    spec/css/plain/error/statement/style_rule.hrx::interpolation/selector/plain.css    expect token `<ident>`, but found `{`
 ERROR    spec/css/plain/error/statement/style_rule.hrx::nested_property/no_value/plain.css    component value is expected
 ERROR    spec/css/plain/error/statement/style_rule.hrx::nested_property/value/plain.css    component value is expected
-ERROR    spec/css/plain/error/statement/style_rule.hrx::placeholder_selector/plain.css    CSS rule is expected
 ERROR    spec/css/plain/import/whitespace.hrx::error/after_import/sass/input.sass    expect token `<string>`, but found `<linebreak>`
 ERROR    spec/css/plain/import/whitespace.hrx::error/after_import_indented/sass/input.sass    expect token `<string>`, but found `<indent>`
 ERROR    spec/css/propset.hrx::error/value_after_propset/input.scss    expect token `:`, but found `}`

--- a/tasks/conformance/snapshots/sass-spec.snap
+++ b/tasks/conformance/snapshots/sass-spec.snap
@@ -1,7 +1,7 @@
 suite: sass-spec
 sha: a2ead9225786d49e91f5cc36755b7713596a2338
-files: 26787   success: 26490   failed: 2   expected: 295
-clean: 26490  recovered: 0  hard_error: 2  panic: 0
+files: 26787   success: 26492   failed: 2   expected: 293
+clean: 26492  recovered: 0  hard_error: 2  panic: 0
 
 failures:
 ERROR    spec/non_conformant/extend-tests/selector_list.hrx::input.scss    expect token `;`, but found `#{`
@@ -148,14 +148,12 @@ ERROR    spec/directives/use/error/syntax/as_invalid.hrx::input.scss    `*` or i
 ERROR    spec/directives/use/error/syntax/as_nothing.hrx::input.scss    `*` or ident for Sass namespace is expected
 ERROR    spec/directives/use/error/syntax/empty.hrx::input.scss    string is expected
 ERROR    spec/directives/use/error/syntax/member.hrx::function/definition/input.scss    expect token `(`, but found `.`
-ERROR    spec/directives/use/error/syntax/member.hrx::function/no_member/input.scss    expect token `<ident>`, but found `(`
-ERROR    spec/directives/use/error/syntax/member.hrx::function/no_namespace/input.scss    component value is expected
-ERROR    spec/directives/use/error/syntax/member.hrx::identifier_only/input.scss    expect token `(`, but found `}`
+ERROR    spec/directives/use/error/syntax/member.hrx::function/no_member/input.scss    component value is expected
 ERROR    spec/directives/use/error/syntax/member.hrx::mixin/definition/input.scss    expect token `{`, but found `.`
 ERROR    spec/directives/use/error/syntax/member.hrx::mixin/no_member/input.scss    expect token `<ident>`, but found `}`
 ERROR    spec/directives/use/error/syntax/member.hrx::mixin/no_namespace/input.scss    expect token `<ident>`, but found `.`
 RECOVER  spec/directives/use/error/syntax/member.hrx::variable/global/input.scss    Sass flag `!global` is disallowed
-ERROR    spec/directives/use/error/syntax/member.hrx::variable/no_member/input.scss    expect token `<ident>`, but found `<unknown>`
+ERROR    spec/directives/use/error/syntax/member.hrx::variable/no_member/input.scss    component value is expected
 ERROR    spec/directives/use/error/syntax/member.hrx::variable/no_namespace/input.scss    component value is expected
 ERROR    spec/directives/use/error/syntax/url.hrx::unquoted/input.scss    string is expected
 ERROR    spec/directives/use/error/syntax/with.hrx::before_as/input.scss    expect token `;`, but found `<ident>`

--- a/tasks/conformance/snapshots/summary.snap
+++ b/tasks/conformance/snapshots/summary.snap
@@ -7,14 +7,14 @@ css-parsing-tests           0        0       0         0       0      0        0
 wpt                         7        5       0         2       5      0        0      0
 webref                      0        0       0         0       0      0        0      0
 postcss-parser-tests       30       28       2         0      28      1        1      0
-sass-spec               26787    26490       2       295   26490      0        2      0
+sass-spec               26787    26492       2       293   26492      0        2      0
 less.js                   459      427       8        24     427      0        8      0
 ------------------------------------------------------------------------
-total                   27283    26950      12       321   26950      1       11      0
+total                   27283    26952      12       319   26952      1       11      0
 
 # by syntax
 syntax                  files  success  failed  expected   clean  recov  harderr  panic
 css                     11788    11756       7        25   11756      1        6      0
-scss                    14750    14517       1       232   14517      0        1      0
+scss                    14750    14519       1       230   14519      0        1      0
 sass                      439      398       1        40     398      0        1      0
 less                      306      279       3        24     279      0        3      0

--- a/tasks/conformance/snapshots/summary.snap
+++ b/tasks/conformance/snapshots/summary.snap
@@ -7,14 +7,14 @@ css-parsing-tests           0        0       0         0       0      0        0
 wpt                         7        5       0         2       5      0        0      0
 webref                      0        0       0         0       0      0        0      0
 postcss-parser-tests       30       28       2         0      28      1        1      0
-sass-spec               26787    26492       2       293   26492      0        2      0
+sass-spec               26787    26493       2       292   26493      0        2      0
 less.js                   459      427       8        24     427      0        8      0
 ------------------------------------------------------------------------
-total                   27283    26952      12       319   26952      1       11      0
+total                   27283    26953      12       318   26953      1       11      0
 
 # by syntax
 syntax                  files  success  failed  expected   clean  recov  harderr  panic
-css                     11788    11756       7        25   11756      1        6      0
+css                     11788    11757       7        24   11757      1        6      0
 scss                    14750    14519       1       230   14519      0        1      0
 sass                      439      398       1        40     398      0        1      0
 less                      306      279       3        24     279      0        3      0


### PR DESCRIPTION
Follow-up fixes for issues found while integrating the formatter with parser v0.0.4 (fewer parse-error skips in Prettier conformance: css 25 → 17 skipped, less 39/39):

- **fix(tokenizer)**: lex `50....` as `50.` + `...` instead of a single invalid token
- **fix(parser)**: keep Sass multi-path imports typed as `SassImportPrelude`
- **feat(parser)**: accept Scss dotted words like `foo.bar` as raw tokens — postcss-scss lexes the dotted run as one word (xstyled / tailwind-theme tokens: `primary.dark`, `colors.modes.dark`); the typed namespaced parse (`foo.$var` / `foo.bar(...)`) is tried first, so existing ASTs are unchanged
- **feat(parser)**: accept placeholder selectors (`%foo`) in plain CSS — postcss-extend-rule uses them, and postcss parses `%x` as an ordinary selector

## Leniency policy

Both leniencies follow the formatter-side policy (`oxc_formatter_css/AGENTS.md`): parser leniencies must be **additive** — accept only input that previously errored, never reinterpret input that already parsed. No `ParserOptions` gate: the sole consumer (the formatter) always wants postcss-level acceptance, and these reuse existing node shapes rather than introducing plugin-specific semantics.

## Conformance

sass-spec: +3 clean (26490 → 26493), no new failures. The 3 flips are expected-error specs that dart-sass rejects but postcss/Prettier format — the intended leniency, surfaced by the snapshot's expected-failures section as designed. Two other expected-error entries changed error message only.