### PR TITLE
chore: restore copyright notices in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,8 @@
 MIT License
 
+Copyright (c) July 2026-present VoidZero Inc. & Contributors
+Copyright (c) 2022-June 2026 Pig Fang
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights


### PR DESCRIPTION
Restores the original MIT copyright notice for Pig Fang — author of [raffia](https://github.com/g-plane/raffia), which this project is forked from — that was removed in 6517b49. The MIT license requires the copyright notice to be retained in copies, so this is a compliance fix.

Also adds `VoidZero Inc. & Contributors` to the notice, split at the June/July 2026 fork boundary.

Closes #92
