### PR TITLE
refactor(parser): compact CSS token data

### DIFF
--- a/crates/oxc_css_parser/src/parser/at_rule/container.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/container.rs
@@ -15,43 +15,38 @@ use crate::{
 //                   | <query-in-parens> [ [ and <query-in-parens> ]* | [ or <query-in-parens> ]* ]
 impl<'a> Parse<'a> for ContainerCondition<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match &input.cursor.peek()?.token {
-            Token::Ident(ident) if ident.name().eq_ignore_ascii_case("not") => {
-                let container_condition_not = input.parse::<ContainerConditionNot>()?;
-                let span = container_condition_not.span.clone();
-                Ok(ContainerCondition {
-                    conditions: input.vec1(ContainerConditionKind::Not(container_condition_not)),
-                    span,
-                })
+        if input.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(input.source, "not") {
+            let container_condition_not = input.parse::<ContainerConditionNot>()?;
+            let span = container_condition_not.span.clone();
+            Ok(ContainerCondition {
+                conditions: input.vec1(ContainerConditionKind::Not(container_condition_not)),
+                span,
+            })
+        } else {
+            let first = input.parse::<QueryInParens>()?;
+            let mut span = first.span.clone();
+            let mut conditions = input.vec1(ContainerConditionKind::QueryInParens(first));
+            // formally `and`/`or` may not mix without parens and `not`
+            // is leading-only, but real-world code (less.js) chains them
+            // freely: `(a) or (b) and (c)`, `(a) not (b)`.
+            loop {
+                let peek = input.cursor.peek()?;
+                let kind = if peek.is_ident_name_eq_ignore_ascii_case(input.source, "and") {
+                    ContainerConditionKind::And(input.parse()?)
+                } else if peek.is_ident_name_eq_ignore_ascii_case(input.source, "or") {
+                    ContainerConditionKind::Or(input.parse()?)
+                } else if peek.is_ident_name_eq_ignore_ascii_case(input.source, "not") {
+                    ContainerConditionKind::Not(input.parse()?)
+                } else {
+                    break;
+                };
+                conditions.push(kind);
             }
-            _ => {
-                let first = input.parse::<QueryInParens>()?;
-                let mut span = first.span.clone();
-                let mut conditions = input.vec1(ContainerConditionKind::QueryInParens(first));
-                // formally `and`/`or` may not mix without parens and `not`
-                // is leading-only, but real-world code (less.js) chains them
-                // freely: `(a) or (b) and (c)`, `(a) not (b)`.
-                loop {
-                    let kind = match &input.cursor.peek()?.token {
-                        Token::Ident(ident) if ident.name().eq_ignore_ascii_case("and") => {
-                            ContainerConditionKind::And(input.parse()?)
-                        }
-                        Token::Ident(ident) if ident.name().eq_ignore_ascii_case("or") => {
-                            ContainerConditionKind::Or(input.parse()?)
-                        }
-                        Token::Ident(ident) if ident.name().eq_ignore_ascii_case("not") => {
-                            ContainerConditionKind::Not(input.parse()?)
-                        }
-                        _ => break,
-                    };
-                    conditions.push(kind);
-                }
 
-                if let Some(last) = conditions.last() {
-                    span.end = last.span().end;
-                }
-                Ok(ContainerCondition { conditions, span })
+            if let Some(last) = conditions.last() {
+                span.end = last.span().end;
             }
+            Ok(ContainerCondition { conditions, span })
         }
     }
 }
@@ -142,46 +137,48 @@ impl<'a> Parse<'a> for QueryInParens<'a> {
 //                   | <style-in-parens> [ [ and <style-in-parens> ]* | [ or <style-in-parens> ]* ]
 impl<'a> Parse<'a> for StyleCondition<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match &input.cursor.peek()?.token {
-            Token::Ident(ident) if ident.name().eq_ignore_ascii_case("not") => {
-                let style_condition_not = input.parse::<StyleConditionNot>()?;
-                let span = style_condition_not.span.clone();
-                Ok(StyleCondition {
-                    conditions: input.vec1(StyleConditionKind::Not(style_condition_not)),
-                    span,
-                })
-            }
-            _ => {
-                let first = input.parse::<StyleInParens>()?;
-                let mut span = first.span.clone();
-                let mut conditions = input.vec1(StyleConditionKind::StyleInParens(first));
-                if let Token::Ident(ident) = &input.cursor.peek()?.token {
-                    let name = ident.name();
-                    if name.eq_ignore_ascii_case("and") {
-                        loop {
-                            conditions.push(StyleConditionKind::And(input.parse()?));
-                            match &input.cursor.peek()?.token {
-                                Token::Ident(ident) if ident.name().eq_ignore_ascii_case("and") => {
-                                }
-                                _ => break,
-                            }
+        if input.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(input.source, "not") {
+            let style_condition_not = input.parse::<StyleConditionNot>()?;
+            let span = style_condition_not.span.clone();
+            Ok(StyleCondition {
+                conditions: input.vec1(StyleConditionKind::Not(style_condition_not)),
+                span,
+            })
+        } else {
+            let first = input.parse::<StyleInParens>()?;
+            let mut span = first.span.clone();
+            let mut conditions = input.vec1(StyleConditionKind::StyleInParens(first));
+            let peek = input.cursor.peek()?;
+            if peek.ident(input.source).is_some() {
+                if peek.is_ident_name_eq_ignore_ascii_case(input.source, "and") {
+                    loop {
+                        conditions.push(StyleConditionKind::And(input.parse()?));
+                        if !input
+                            .cursor
+                            .peek()?
+                            .is_ident_name_eq_ignore_ascii_case(input.source, "and")
+                        {
+                            break;
                         }
-                    } else if name.eq_ignore_ascii_case("or") {
-                        loop {
-                            conditions.push(StyleConditionKind::Or(input.parse()?));
-                            match &input.cursor.peek()?.token {
-                                Token::Ident(ident) if ident.name().eq_ignore_ascii_case("or") => {}
-                                _ => break,
-                            }
+                    }
+                } else if peek.is_ident_name_eq_ignore_ascii_case(input.source, "or") {
+                    loop {
+                        conditions.push(StyleConditionKind::Or(input.parse()?));
+                        if !input
+                            .cursor
+                            .peek()?
+                            .is_ident_name_eq_ignore_ascii_case(input.source, "or")
+                        {
+                            break;
                         }
                     }
                 }
-
-                if let Some(last) = conditions.last() {
-                    span.end = last.span().end;
-                }
-                Ok(StyleCondition { conditions, span })
             }
+
+            if let Some(last) = conditions.last() {
+                span.end = last.span().end;
+            }
+            Ok(StyleCondition { conditions, span })
         }
     }
 }

--- a/crates/oxc_css_parser/src/parser/at_rule/custom_media.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/custom_media.rs
@@ -1,5 +1,5 @@
 use super::Parser;
-use crate::{Parse, ast::*, error::PResult, pos::Span, tokenizer::Token};
+use crate::{Parse, ast::*, error::PResult, pos::Span};
 
 // https://www.w3.org/TR/mediaqueries-5/#custom-mq
 //
@@ -17,18 +17,17 @@ impl<'a> Parse<'a> for CustomMedia<'a> {
 // <custom-media-value> = <media-query-list> | true | false
 impl<'a> Parse<'a> for CustomMediaValue<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match &input.cursor.peek()?.token {
-            Token::Ident(ident) => {
-                let name = ident.name();
-                if name.eq_ignore_ascii_case("true") {
-                    input.parse().map(CustomMediaValue::True)
-                } else if name.eq_ignore_ascii_case("false") {
-                    input.parse().map(CustomMediaValue::False)
-                } else {
-                    input.parse().map(CustomMediaValue::MediaQueryList)
-                }
+        let peek = input.cursor.peek()?;
+        if peek.ident(input.source).is_some() {
+            if peek.is_ident_name_eq_ignore_ascii_case(input.source, "true") {
+                input.parse().map(CustomMediaValue::True)
+            } else if peek.is_ident_name_eq_ignore_ascii_case(input.source, "false") {
+                input.parse().map(CustomMediaValue::False)
+            } else {
+                input.parse().map(CustomMediaValue::MediaQueryList)
             }
-            _ => input.parse().map(CustomMediaValue::MediaQueryList),
+        } else {
+            input.parse().map(CustomMediaValue::MediaQueryList)
         }
     }
 }

--- a/crates/oxc_css_parser/src/parser/at_rule/import.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/import.rs
@@ -115,8 +115,8 @@ impl<'a> ImportPrelude<'a> {
         Option<ImportPreludeSupports<'a>>,
         Option<MediaQueryList<'a>>,
     )> {
-        let layer = match &input.cursor.peek()?.token {
-            Token::Ident(ident) if ident.name().eq_ignore_ascii_case("layer") => {
+        let layer =
+            if input.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(input.source, "layer") {
                 let ident = input.parse::<Ident>()?;
                 let layer = match input.cursor.peek()? {
                     TokenWithSpan { token: Token::LParen(..), span }
@@ -136,9 +136,9 @@ impl<'a> ImportPrelude<'a> {
                     _ => ImportPreludeLayer::Empty(ident),
                 };
                 Some(layer)
-            }
-            _ => None,
-        };
+            } else {
+                None
+            };
 
         let supports = input.try_parse(|parser| {
             // (kept as its own try so a non-`supports` ident rolls back)

--- a/crates/oxc_css_parser/src/parser/at_rule/media.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/media.rs
@@ -25,15 +25,13 @@ impl<'a> Parse<'a> for MediaAnd<'a> {
 // [ and <media-condition-without-or> ]
 impl<'a> Parse<'a> for MediaConditionAfterMediaType<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        let and: Ident = match input.cursor.bump()? {
-            TokenWithSpan { token: Token::Ident(ident), span }
-                if ident.name().eq_ignore_ascii_case("and") =>
-            {
-                input.ident(ident, span)
-            }
-            TokenWithSpan { span, .. } => {
-                return Err(Error { kind: ErrorKind::ExpectMediaAnd, span });
-            }
+        let token = input.cursor.bump()?;
+        let and: Ident = if let Some(ident) = token.ident(input.source)
+            && ident.name().eq_ignore_ascii_case("and")
+        {
+            input.ident(ident, token.span)
+        } else {
+            return Err(Error { kind: ErrorKind::ExpectMediaAnd, span: token.span });
         };
 
         let condition = input.parse_media_condition(
@@ -273,15 +271,15 @@ impl<'a> Parse<'a> for MediaQueryList<'a> {
 // <media-type> = <ident>   (not `only` / `not` / `and` / `or` / `layer`)
 impl<'a> Parse<'a> for MediaQueryWithType<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        let modifier = if let Token::Ident(ident) = &input.cursor.peek()?.token {
-            let name = ident.name();
-            if name.eq_ignore_ascii_case("not") || name.eq_ignore_ascii_case("only") {
+        let modifier = {
+            let peek = input.cursor.peek()?;
+            if peek.is_ident_name_eq_ignore_ascii_case(input.source, "not")
+                || peek.is_ident_name_eq_ignore_ascii_case(input.source, "only")
+            {
                 Some(input.parse::<Ident>()?)
             } else {
                 None
             }
-        } else {
-            None
         };
         let media_type = input.parse::<InterpolableIdent>()?;
         if let InterpolableIdent::Literal(Ident { name, span, .. }) = &media_type
@@ -296,12 +294,12 @@ impl<'a> Parse<'a> for MediaQueryWithType<'a> {
                 span: span.clone(),
             });
         }
-        let condition = match &input.cursor.peek()?.token {
-            Token::Ident(ident) if ident.name().eq_ignore_ascii_case("and") => {
+        let condition =
+            if input.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(input.source, "and") {
                 input.parse::<MediaConditionAfterMediaType>().map(Some)?
-            }
-            _ => None,
-        };
+            } else {
+                None
+            };
 
         let mut span = media_type.span().clone();
         if let Some(modifier) = &modifier {
@@ -321,11 +319,14 @@ impl<'a> Parser<'a> {
     /// it like `<general-enclosed>` raw tokens. Only this position is safe to
     /// relax: elsewhere an ident is a media type (`@media print`).
     fn parse_media_in_parens_after_logic(&mut self) -> PResult<MediaInParens<'a>> {
-        if self.syntax == Syntax::Css
-            && let TokenWithSpan { token: Token::Ident(ident), span } = self.cursor.peek()?
-            && !ident.name().eq_ignore_ascii_case("not")
-            && self.source.as_bytes().get(span.end) != Some(&b'(')
-        {
+        let relax_bare_ident = {
+            let peek = self.cursor.peek()?;
+            self.syntax == Syntax::Css
+                && peek.ident(self.source).is_some()
+                && !peek.is_ident_name_eq_ignore_ascii_case(self.source, "not")
+                && self.source.as_bytes().get(peek.span.end) != Some(&b'(')
+        };
+        if relax_bare_ident {
             let token = self.cursor.bump()?;
             let span = token.span.clone();
             return Ok(MediaInParens {
@@ -346,50 +347,49 @@ impl<'a> Parser<'a> {
         allow_or: bool,
         after_logic_keyword: bool,
     ) -> PResult<MediaCondition<'a>> {
-        match &self.cursor.peek()?.token {
-            Token::Ident(ident) if ident.name().eq_ignore_ascii_case("not") => {
-                let media_not = self.parse::<MediaNot>()?;
-                let span = media_not.span.clone();
-                Ok(MediaCondition {
-                    conditions: self.vec1(MediaConditionKind::Not(media_not)),
-                    span,
-                })
-            }
-            _ => {
-                let first = if after_logic_keyword {
-                    self.parse_media_in_parens_after_logic()?
-                } else {
-                    self.parse::<MediaInParens>()?
-                };
-                let mut span = first.span.clone();
-                let mut conditions = self.vec1(MediaConditionKind::MediaInParens(first));
-                if let Token::Ident(ident) = &self.cursor.peek()?.token {
-                    let name = ident.name();
-                    if name.eq_ignore_ascii_case("and") {
-                        loop {
-                            conditions.push(MediaConditionKind::And(self.parse()?));
-                            match &self.cursor.peek()?.token {
-                                Token::Ident(ident) if ident.name().eq_ignore_ascii_case("and") => {
-                                }
-                                _ => break,
-                            }
+        if self.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(self.source, "not") {
+            let media_not = self.parse::<MediaNot>()?;
+            let span = media_not.span.clone();
+            Ok(MediaCondition { conditions: self.vec1(MediaConditionKind::Not(media_not)), span })
+        } else {
+            let first = if after_logic_keyword {
+                self.parse_media_in_parens_after_logic()?
+            } else {
+                self.parse::<MediaInParens>()?
+            };
+            let mut span = first.span.clone();
+            let mut conditions = self.vec1(MediaConditionKind::MediaInParens(first));
+            let peek = self.cursor.peek()?;
+            if peek.ident(self.source).is_some() {
+                if peek.is_ident_name_eq_ignore_ascii_case(self.source, "and") {
+                    loop {
+                        conditions.push(MediaConditionKind::And(self.parse()?));
+                        if !self
+                            .cursor
+                            .peek()?
+                            .is_ident_name_eq_ignore_ascii_case(self.source, "and")
+                        {
+                            break;
                         }
-                    } else if allow_or && name.eq_ignore_ascii_case("or") {
-                        loop {
-                            conditions.push(MediaConditionKind::Or(self.parse()?));
-                            match &self.cursor.peek()?.token {
-                                Token::Ident(ident) if ident.name().eq_ignore_ascii_case("or") => {}
-                                _ => break,
-                            }
+                    }
+                } else if allow_or && peek.is_ident_name_eq_ignore_ascii_case(self.source, "or") {
+                    loop {
+                        conditions.push(MediaConditionKind::Or(self.parse()?));
+                        if !self
+                            .cursor
+                            .peek()?
+                            .is_ident_name_eq_ignore_ascii_case(self.source, "or")
+                        {
+                            break;
                         }
                     }
                 }
-
-                if let Some(last) = conditions.last() {
-                    span.end = last.span().end;
-                }
-                Ok(MediaCondition { conditions, span })
             }
+
+            if let Some(last) = conditions.last() {
+                span.end = last.span().end;
+            }
+            Ok(MediaCondition { conditions, span })
         }
     }
 

--- a/crates/oxc_css_parser/src/parser/at_rule/mod.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/mod.rs
@@ -409,7 +409,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
             let end = prelude.span.end;
             (Some(AtRulePrelude::LessPlugin(input.alloc(prelude))), None, end)
         } else if at_rule_name.eq_ignore_ascii_case("function")
-            && matches!(&input.cursor.peek()?.token, Token::Ident(ident) if ident.raw.starts_with("--"))
+            && input.cursor.peek()?.is_ident_raw_starts_with(input.source, "--")
         {
             // A CSS custom function (css-mixins spec): `@function --name(params)
             // returns <type> { declarations }`. dart-sass parses this as plain

--- a/crates/oxc_css_parser/src/parser/at_rule/namespace.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/namespace.rs
@@ -7,15 +7,15 @@ use crate::{Parse, ast::*, error::PResult, tokenizer::Token};
 // <namespace-prefix> = <ident>
 impl<'a> Parse<'a> for NamespacePrelude<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        let prefix = match &input.cursor.peek()?.token {
-            Token::Ident(ident) => {
-                if ident.name().eq_ignore_ascii_case("url") {
+        let prefix = match input.cursor.peek()? {
+            token if token.ident(input.source).is_some() => {
+                if token.is_ident_name_eq_ignore_ascii_case(input.source, "url") {
                     None
                 } else {
                     Some(InterpolableIdent::Literal(input.parse::<Ident>()?))
                 }
             }
-            Token::HashLBrace(..) | Token::AtLBraceVar(..) => {
+            token if matches!(token.token, Token::HashLBrace(..) | Token::AtLBraceVar(..)) => {
                 input.parse::<InterpolableIdent>().map(Some)?
             }
             _ => None,

--- a/crates/oxc_css_parser/src/parser/at_rule/scope.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/scope.rs
@@ -10,15 +10,11 @@ use crate::{
 // to ( <scope-end> ) where <scope-end> = <selector-list>
 impl<'a> Parse<'a> for ScopeEnd<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        let to_span = match input.cursor.bump()? {
-            TokenWithSpan { token: Token::Ident(ident), span }
-                if ident.name().eq_ignore_ascii_case("to") =>
-            {
-                span
-            }
-            TokenWithSpan { span, .. } => {
-                return Err(Error { kind: ErrorKind::ExpectScopeTo, span });
-            }
+        let token = input.cursor.bump()?;
+        let to_span = if token.is_ident_name_eq_ignore_ascii_case(input.source, "to") {
+            token.span
+        } else {
+            return Err(Error { kind: ErrorKind::ExpectScopeTo, span: token.span });
         };
 
         let (_, lparen_span) = input.cursor.expect_l_paren()?;
@@ -42,11 +38,10 @@ impl<'a> Parse<'a> for ScopePrelude<'a> {
         } else {
             None
         };
-        let end = match &input.cursor.peek()?.token {
-            Token::Ident(ident) if ident.name().eq_ignore_ascii_case("to") => {
-                Some(input.parse::<ScopeEnd>()?)
-            }
-            _ => None,
+        let end = if input.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(input.source, "to") {
+            Some(input.parse::<ScopeEnd>()?)
+        } else {
+            None
         };
 
         match (start, end) {

--- a/crates/oxc_css_parser/src/parser/at_rule/supports.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/supports.rs
@@ -14,53 +14,53 @@ use crate::{
 //                      | <supports-in-parens> [ or <supports-in-parens> ]*
 impl<'a> Parse<'a> for SupportsCondition<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match &input.cursor.peek()?.token {
-            Token::Ident(token) if token.name().eq_ignore_ascii_case("not") => {
-                let keyword = input.parse::<Ident>()?;
-                let condition = input.parse::<SupportsInParens>()?;
-                let span = Span { start: keyword.span.start, end: condition.span().end };
-                Ok(SupportsCondition {
-                    conditions: input.vec1(SupportsConditionKind::Not(SupportsNot {
-                        keyword,
+        if input.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(input.source, "not") {
+            let keyword = input.parse::<Ident>()?;
+            let condition = input.parse::<SupportsInParens>()?;
+            let span = Span { start: keyword.span.start, end: condition.span().end };
+            Ok(SupportsCondition {
+                conditions: input.vec1(SupportsConditionKind::Not(SupportsNot {
+                    keyword,
+                    condition,
+                    span: span.clone(),
+                })),
+                span,
+            })
+        } else {
+            let first = input.parse::<SupportsInParens>()?;
+            let mut span = first.span().clone();
+            let mut conditions = input.vec1(SupportsConditionKind::SupportsInParens(first));
+            while input.cursor.peek()?.ident(input.source).is_some() {
+                if input.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(input.source, "and") {
+                    let ident = input.parse::<Ident>()?;
+                    let condition = input.parse::<SupportsInParens>()?;
+                    let span = Span { start: ident.span.start, end: condition.span().end };
+                    conditions.push(SupportsConditionKind::And(SupportsAnd {
+                        keyword: ident,
                         condition,
-                        span: span.clone(),
-                    })),
-                    span,
-                })
-            }
-            _ => {
-                let first = input.parse::<SupportsInParens>()?;
-                let mut span = first.span().clone();
-                let mut conditions = input.vec1(SupportsConditionKind::SupportsInParens(first));
-                while let Token::Ident(ident) = &input.cursor.peek()?.token {
-                    let name = ident.name();
-                    if name.eq_ignore_ascii_case("and") {
-                        let ident = input.parse::<Ident>()?;
-                        let condition = input.parse::<SupportsInParens>()?;
-                        let span = Span { start: ident.span.start, end: condition.span().end };
-                        conditions.push(SupportsConditionKind::And(SupportsAnd {
-                            keyword: ident,
-                            condition,
-                            span,
-                        }));
-                    } else if name.eq_ignore_ascii_case("or") {
-                        let ident = input.parse::<Ident>()?;
-                        let condition = input.parse::<SupportsInParens>()?;
-                        let span = Span { start: ident.span.start, end: condition.span().end };
-                        conditions.push(SupportsConditionKind::Or(SupportsOr {
-                            keyword: ident,
-                            condition,
-                            span,
-                        }));
-                    } else {
-                        break;
-                    }
+                        span,
+                    }));
+                } else if input
+                    .cursor
+                    .peek()?
+                    .is_ident_name_eq_ignore_ascii_case(input.source, "or")
+                {
+                    let ident = input.parse::<Ident>()?;
+                    let condition = input.parse::<SupportsInParens>()?;
+                    let span = Span { start: ident.span.start, end: condition.span().end };
+                    conditions.push(SupportsConditionKind::Or(SupportsOr {
+                        keyword: ident,
+                        condition,
+                        span,
+                    }));
+                } else {
+                    break;
                 }
-                if let Some(last) = conditions.last() {
-                    span.end = last.span().end;
-                }
-                Ok(SupportsCondition { conditions, span })
             }
+            if let Some(last) = conditions.last() {
+                span.end = last.span().end;
+            }
+            Ok(SupportsCondition { conditions, span })
         }
     }
 }

--- a/crates/oxc_css_parser/src/parser/builder.rs
+++ b/crates/oxc_css_parser/src/parser/builder.rs
@@ -70,13 +70,16 @@ impl<'a> ParserBuilder<'a> {
             source: self.source,
             syntax: self.syntax,
             options,
-            cursor: ParserCursor::new(Tokenizer::new(
-                self.allocator,
+            cursor: ParserCursor::new(
+                Tokenizer::new(
+                    self.allocator,
+                    self.source,
+                    self.syntax,
+                    options.template_placeholder,
+                    self.collect_comments,
+                ),
                 self.source,
-                self.syntax,
-                options.template_placeholder,
-                self.collect_comments,
-            )),
+            ),
             state: Default::default(),
             recoverable_errors: vec![],
             sass_pending_indents: 0,

--- a/crates/oxc_css_parser/src/parser/less.rs
+++ b/crates/oxc_css_parser/src/parser/less.rs
@@ -156,40 +156,34 @@ impl<'a> Parser<'a> {
         precedence: u8,
     ) -> PResult<LessCondition<'a>> {
         let mut left = if precedence >= PRECEDENCE_AND {
-            match &self.cursor.peek()?.token {
-                Token::LParen(..) => {
-                    let Span { start, .. } = self.cursor.bump()?.span;
-                    let (condition, end) = self.parse_less_guard_paren_condition(needs_parens)?;
-                    LessCondition::Parenthesized(LessParenthesizedCondition {
-                        condition: self.alloc(condition),
-                        span: Span { start, end },
-                    })
-                }
-                Token::Ident(ident) if ident.raw == "not" => {
-                    let Span { start, .. } = self.cursor.bump()?.span;
-                    let (condition, end) = if self.cursor.eat_l_paren()?.is_some() {
-                        self.parse_less_guard_paren_condition(needs_parens)?
-                    } else {
-                        // less.js also accepts a bare operand: `when not @a`
-                        let condition = self.parse_less_condition_atom()?;
-                        let end = condition.span().end;
-                        (condition, end)
-                    };
-                    LessCondition::Negated(LessNegatedCondition {
-                        condition: self.alloc(condition),
-                        span: Span { start, end },
-                    })
-                }
-                _ => {
-                    if needs_parens {
-                        let TokenWithSpan { token, span } = self.cursor.bump()?;
-                        return Err(Error {
-                            kind: ErrorKind::Unexpected("(", token.symbol()),
-                            span,
-                        });
-                    } else {
-                        self.parse_less_condition_atom()?
-                    }
+            let peek = self.cursor.peek()?;
+            if matches!(peek.token, Token::LParen(..)) {
+                let Span { start, .. } = self.cursor.bump()?.span;
+                let (condition, end) = self.parse_less_guard_paren_condition(needs_parens)?;
+                LessCondition::Parenthesized(LessParenthesizedCondition {
+                    condition: self.alloc(condition),
+                    span: Span { start, end },
+                })
+            } else if peek.is_ident_raw(self.source, "not") {
+                let Span { start, .. } = self.cursor.bump()?.span;
+                let (condition, end) = if self.cursor.eat_l_paren()?.is_some() {
+                    self.parse_less_guard_paren_condition(needs_parens)?
+                } else {
+                    // less.js also accepts a bare operand: `when not @a`
+                    let condition = self.parse_less_condition_atom()?;
+                    let end = condition.span().end;
+                    (condition, end)
+                };
+                LessCondition::Negated(LessNegatedCondition {
+                    condition: self.alloc(condition),
+                    span: Span { start, end },
+                })
+            } else {
+                if needs_parens {
+                    let TokenWithSpan { token, span } = self.cursor.bump()?;
+                    return Err(Error { kind: ErrorKind::Unexpected("(", token.symbol()), span });
+                } else {
+                    self.parse_less_condition_atom()?
                 }
             }
         } else {
@@ -197,20 +191,19 @@ impl<'a> Parser<'a> {
         };
 
         loop {
-            let op = match &self.cursor.peek()?.token {
-                Token::Ident(token) if token.raw == "and" && precedence == PRECEDENCE_AND => {
-                    LessBinaryConditionOperator {
-                        kind: LessBinaryConditionOperatorKind::And,
-                        span: self.cursor.bump()?.span,
-                    }
+            let peek = self.cursor.peek()?;
+            let op = if peek.is_ident_raw(self.source, "and") && precedence == PRECEDENCE_AND {
+                LessBinaryConditionOperator {
+                    kind: LessBinaryConditionOperatorKind::And,
+                    span: self.cursor.bump()?.span,
                 }
-                Token::Ident(token) if token.raw == "or" && precedence == PRECEDENCE_OR => {
-                    LessBinaryConditionOperator {
-                        kind: LessBinaryConditionOperatorKind::Or,
-                        span: self.cursor.bump()?.span,
-                    }
+            } else if peek.is_ident_raw(self.source, "or") && precedence == PRECEDENCE_OR {
+                LessBinaryConditionOperator {
+                    kind: LessBinaryConditionOperatorKind::Or,
+                    span: self.cursor.bump()?.span,
                 }
-                _ => break,
+            } else {
+                break;
             };
 
             // multiple conditions in Less are right-associated
@@ -479,10 +472,12 @@ impl<'a> Parser<'a> {
                         span: self.cursor.bump()?.span,
                     }
                 }
-                TokenWithSpan { token: Token::Number(token), span }
+                token @ TokenWithSpan { token: Token::Number(..), span }
                     if precedence == PRECEDENCE_PLUS
-                        && (token.raw.starts_with('+')
-                            || token.raw.starts_with('-') && span.start == left.span().end) =>
+                        && token.number_raw(self.source).is_some_and(|raw| {
+                            raw.starts_with('+')
+                                || raw.starts_with('-') && span.start == left.span().end
+                        }) =>
                 {
                     let (number, number_span) = self.cursor.expect_number()?;
                     let op = LessOperationOperator {
@@ -512,11 +507,12 @@ impl<'a> Parser<'a> {
                     });
                     continue;
                 }
-                TokenWithSpan { token: Token::Dimension(token), span }
+                token @ TokenWithSpan { token: Token::Dimension(..), span }
                     if precedence == PRECEDENCE_PLUS
-                        && (token.value.raw.starts_with('+')
-                            || token.value.raw.starts_with('-')
-                                && span.start == left.span().end) =>
+                        && token.dimension_value_raw(self.source).is_some_and(|raw| {
+                            raw.starts_with('+')
+                                || raw.starts_with('-') && span.start == left.span().end
+                        }) =>
                 {
                     let (dimension, dimension_span) = self.cursor.expect_dimension()?;
                     let op = LessOperationOperator {
@@ -626,29 +622,23 @@ impl<'a> Parser<'a> {
             })
             .parse::<SelectorList>()?;
 
-        match &self.cursor.peek()?.token {
-            Token::Ident(ident) if ident.raw == "when" => {
-                // less.js: "Guards are only currently allowed on a single
-                // selector." — a guard on a selector list is rejected whether
-                // the comma comes before or after the `when`.
-                if selector_list.selectors.len() > 1 {
-                    let span = self.cursor.peek()?.span.clone();
-                    return Err(Error {
-                        kind: ErrorKind::LessGuardOnMultipleComplexSelectors,
-                        span,
-                    });
-                }
-                let guard = self.parse::<LessConditions>()?;
-                let block = self.parse::<SimpleBlock>()?;
-                let span = Span { start: selector_list.span.start, end: block.span.end };
-                return Ok(Statement::LessConditionalQualifiedRule(LessConditionalQualifiedRule {
-                    selector: selector_list,
-                    guard,
-                    block,
-                    span,
-                }));
+        if self.cursor.peek()?.is_ident_raw(self.source, "when") {
+            // less.js: "Guards are only currently allowed on a single
+            // selector." — a guard on a selector list is rejected whether
+            // the comma comes before or after the `when`.
+            if selector_list.selectors.len() > 1 {
+                let span = self.cursor.peek()?.span.clone();
+                return Err(Error { kind: ErrorKind::LessGuardOnMultipleComplexSelectors, span });
             }
-            _ => {}
+            let guard = self.parse::<LessConditions>()?;
+            let block = self.parse::<SimpleBlock>()?;
+            let span = Span { start: selector_list.span.start, end: block.span.end };
+            return Ok(Statement::LessConditionalQualifiedRule(LessConditionalQualifiedRule {
+                selector: selector_list,
+                guard,
+                block,
+                span,
+            }));
         }
 
         let block = self.parse::<SimpleBlock>()?;
@@ -779,11 +769,11 @@ impl<'a> Parser<'a> {
 // A guard: when <condition> [ , <condition> ]*
 impl<'a> Parse<'a> for LessConditions<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        let when_span = match input.cursor.bump()? {
-            TokenWithSpan { token: Token::Ident(ident), span } if ident.raw == "when" => span,
-            TokenWithSpan { span, .. } => {
-                return Err(Error { kind: ErrorKind::ExpectLessKeyword("when"), span });
-            }
+        let token = input.cursor.bump()?;
+        let when_span = if token.is_ident_raw(input.source, "when") {
+            token.span
+        } else {
+            return Err(Error { kind: ErrorKind::ExpectLessKeyword("when"), span: token.span });
         };
 
         let first = input.parse_less_condition(true)?;
@@ -957,11 +947,12 @@ impl<'a> Parse<'a> for LessImportOptions<'a> {
 
         let mut names = input.vec_with_capacity(1);
         let mut comma_spans = input.vec();
-        while let Token::Ident(crate::token::Ident {
-            raw: "less" | "css" | "multiple" | "once" | "inline" | "reference" | "optional",
-            ..
-        }) = input.cursor.peek()?.token
-        {
+        while input.cursor.peek()?.ident_raw(input.source).is_some_and(|raw| {
+            matches!(
+                raw,
+                "less" | "css" | "multiple" | "once" | "inline" | "reference" | "optional"
+            )
+        }) {
             names.push(input.parse()?);
             if !matches!(input.cursor.peek()?.token, Token::RParen(..)) {
                 comma_spans.push(input.cursor.expect_comma()?.1);
@@ -1536,9 +1527,10 @@ impl<'a> Parse<'a> for LessMixinDefinition<'a> {
 
         let params = input.parse_less_mixin_parameters()?;
 
-        let guard = match &input.cursor.peek()?.token {
-            Token::Ident(ident) if ident.raw == "when" => Some(input.parse()?),
-            _ => None,
+        let guard = if input.cursor.peek()?.is_ident_raw(input.source, "when") {
+            Some(input.parse()?)
+        } else {
+            None
         };
 
         let block = input
@@ -1579,7 +1571,8 @@ impl<'a> Parse<'a> for LessMixinName<'a> {
                     span,
                 }))
             }
-            TokenWithSpan { token: Token::Hash(hash), span } => {
+            token @ TokenWithSpan { token: Token::Hash(..), span } => {
+                let hash = token.hash(input.source).unwrap();
                 let raw = hash.raw;
                 if raw.starts_with(|c: char| c.is_ascii_digit())
                     || matches!(raw.as_bytes(), [b'-'] | [b'-', b'0'..=b'9', ..])

--- a/crates/oxc_css_parser/src/parser/mod.rs
+++ b/crates/oxc_css_parser/src/parser/mod.rs
@@ -33,12 +33,13 @@ pub trait Parse<'a>: Sized {
 pub(in crate::parser) struct ParserCursor<'a> {
     tokenizer: Tokenizer<'a>,
     cached_token: Option<TokenWithSpan<'a>>,
+    source: &'a str,
 }
 
 impl<'a> ParserCursor<'a> {
     #[inline]
-    fn new(tokenizer: Tokenizer<'a>) -> Self {
-        Self { tokenizer, cached_token: None }
+    fn new(tokenizer: Tokenizer<'a>, source: &'a str) -> Self {
+        Self { tokenizer, cached_token: None, source }
     }
 
     #[inline]
@@ -64,15 +65,14 @@ impl<'a> ParserCursor<'a> {
     #[inline]
     fn eat_token<T>(
         &mut self,
-        extract: impl FnOnce(Token<'a>) -> Result<T, Token<'a>>,
+        extract: impl FnOnce(&TokenWithSpan<'a>, &'a str) -> Option<T>,
     ) -> PResult<Option<(T, Span)>> {
-        let TokenWithSpan { token, span } = self.bump()?;
-        match extract(token) {
-            Ok(token) => Ok(Some((token, span))),
-            Err(token) => {
-                self.cached_token = Some(TokenWithSpan { token, span });
-                Ok(None)
-            }
+        let token_with_span = self.bump()?;
+        if let Some(token) = extract(&token_with_span, self.source) {
+            Ok(Some((token, token_with_span.span)))
+        } else {
+            self.cached_token = Some(token_with_span);
+            Ok(None)
         }
     }
 
@@ -80,294 +80,274 @@ impl<'a> ParserCursor<'a> {
     fn expect_token<T>(
         &mut self,
         expected: &'static str,
-        extract: impl FnOnce(Token<'a>) -> Result<T, Token<'a>>,
+        extract: impl FnOnce(&TokenWithSpan<'a>, &'a str) -> Option<T>,
     ) -> PResult<(T, Span)> {
-        let TokenWithSpan { token, span } = self.bump()?;
-        match extract(token) {
-            Ok(token) => Ok((token, span)),
-            Err(token) => {
-                Err(Error { kind: ErrorKind::Unexpected(expected, token.symbol()), span })
-            }
+        let token_with_span = self.bump()?;
+        if let Some(token) = extract(&token_with_span, self.source) {
+            Ok((token, token_with_span.span))
+        } else {
+            Err(Error {
+                kind: ErrorKind::Unexpected(expected, token_with_span.token.symbol()),
+                span: token_with_span.span,
+            })
         }
     }
 
     #[inline]
+    fn eat_kind<T>(
+        &mut self,
+        extract: impl FnOnce(Token<'a>) -> Option<T>,
+    ) -> PResult<Option<(T, Span)>> {
+        self.eat_token(|token, _| extract(token.token))
+    }
+
+    #[inline]
+    fn expect_kind<T>(
+        &mut self,
+        expected: &'static str,
+        extract: impl FnOnce(Token<'a>) -> Option<T>,
+    ) -> PResult<(T, Span)> {
+        self.expect_token(expected, |token, _| extract(token.token))
+    }
+
+    #[inline]
     fn expect_ampersand(&mut self) -> PResult<(token::Ampersand, Span)> {
-        self.expect_token("&", |token| match token {
-            Token::Ampersand(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind("&", |token| match token {
+            Token::Ampersand(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_at(&mut self) -> PResult<(token::At, Span)> {
-        self.expect_token("@", |token| match token {
-            Token::At(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind("@", |token| match token {
+            Token::At(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_at_keyword(&mut self) -> PResult<(token::AtKeyword<'a>, Span)> {
-        self.expect_token("<at-keyword>", |token| match token {
-            Token::AtKeyword(token) => Ok(token),
-            token => Err(token),
-        })
+        self.expect_token("<at-keyword>", |token, source| token.at_keyword(source))
     }
 
     #[inline]
     fn expect_at_l_brace_var(&mut self) -> PResult<(token::AtLBraceVar<'a>, Span)> {
-        self.expect_token("@{", |token| match token {
-            Token::AtLBraceVar(token) => Ok(token),
-            token => Err(token),
-        })
+        self.expect_token("@{", |token, source| token.at_l_brace_var(source))
     }
 
     #[inline]
     fn expect_backtick_code(&mut self) -> PResult<(token::BacktickCode<'a>, Span)> {
-        self.expect_token("<backtick code>", |token| match token {
-            Token::BacktickCode(token) => Ok(token),
-            token => Err(token),
-        })
+        self.expect_token("<backtick code>", |token, source| token.backtick_code(source))
     }
 
     #[inline]
     fn expect_bar(&mut self) -> PResult<(token::Bar, Span)> {
-        self.expect_token("|", |token| match token {
-            Token::Bar(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind("|", |token| match token {
+            Token::Bar(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_colon(&mut self) -> PResult<(token::Colon, Span)> {
-        self.expect_token(":", |token| match token {
-            Token::Colon(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind(":", |token| match token {
+            Token::Colon(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_colon_colon(&mut self) -> PResult<(token::ColonColon, Span)> {
-        self.expect_token("::", |token| match token {
-            Token::ColonColon(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind("::", |token| match token {
+            Token::ColonColon(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_comma(&mut self) -> PResult<(token::Comma, Span)> {
-        self.expect_token(",", |token| match token {
-            Token::Comma(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind(",", |token| match token {
+            Token::Comma(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_dimension(&mut self) -> PResult<(token::Dimension<'a>, Span)> {
-        self.expect_token("<dimension>", |token| match token {
-            Token::Dimension(token) => Ok(token),
-            token => Err(token),
-        })
+        self.expect_token("<dimension>", |token, source| token.dimension(source))
     }
 
     #[inline]
     fn expect_dollar_l_brace_var(&mut self) -> PResult<(token::DollarLBraceVar<'a>, Span)> {
-        self.expect_token("${", |token| match token {
-            Token::DollarLBraceVar(token) => Ok(token),
-            token => Err(token),
-        })
+        self.expect_token("${", |token, source| token.dollar_l_brace_var(source))
     }
 
     #[inline]
     fn expect_dollar_var(&mut self) -> PResult<(token::DollarVar<'a>, Span)> {
-        self.expect_token("$var", |token| match token {
-            Token::DollarVar(token) => Ok(token),
-            token => Err(token),
-        })
+        self.expect_token("$var", |token, source| token.dollar_var(source))
     }
 
     #[inline]
     fn expect_dot(&mut self) -> PResult<(token::Dot, Span)> {
-        self.expect_token(".", |token| match token {
-            Token::Dot(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind(".", |token| match token {
+            Token::Dot(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_eof(&mut self) -> PResult<(token::Eof, Span)> {
-        self.expect_token("<eof>", |token| match token {
-            Token::Eof(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind("<eof>", |token| match token {
+            Token::Eof(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_exclamation(&mut self) -> PResult<(token::Exclamation, Span)> {
-        self.expect_token("!", |token| match token {
-            Token::Exclamation(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind("!", |token| match token {
+            Token::Exclamation(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_hash(&mut self) -> PResult<(token::Hash<'a>, Span)> {
-        self.expect_token("<hash>", |token| match token {
-            Token::Hash(token) => Ok(token),
-            token => Err(token),
-        })
+        self.expect_token("<hash>", |token, source| token.hash(source))
     }
 
     #[inline]
     fn expect_hash_l_brace(&mut self) -> PResult<(token::HashLBrace, Span)> {
-        self.expect_token("#{", |token| match token {
-            Token::HashLBrace(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind("#{", |token| match token {
+            Token::HashLBrace(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_ident(&mut self) -> PResult<(token::Ident<'a>, Span)> {
-        self.expect_token("<ident>", |token| match token {
-            Token::Ident(token) => Ok(token),
-            token => Err(token),
-        })
+        self.expect_token("<ident>", |token, source| token.ident(source))
     }
 
     #[inline]
     fn expect_l_brace(&mut self) -> PResult<(token::LBrace, Span)> {
-        self.expect_token("{", |token| match token {
-            Token::LBrace(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind("{", |token| match token {
+            Token::LBrace(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_l_bracket(&mut self) -> PResult<(token::LBracket, Span)> {
-        self.expect_token("[", |token| match token {
-            Token::LBracket(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind("[", |token| match token {
+            Token::LBracket(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_linebreak(&mut self) -> PResult<(token::Linebreak, Span)> {
-        self.expect_token("<linebreak>", |token| match token {
-            Token::Linebreak(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind("<linebreak>", |token| match token {
+            Token::Linebreak(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_l_paren(&mut self) -> PResult<(token::LParen, Span)> {
-        self.expect_token("(", |token| match token {
-            Token::LParen(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind("(", |token| match token {
+            Token::LParen(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_minus(&mut self) -> PResult<(token::Minus, Span)> {
-        self.expect_token("-", |token| match token {
-            Token::Minus(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind("-", |token| match token {
+            Token::Minus(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_number(&mut self) -> PResult<(token::Number<'a>, Span)> {
-        self.expect_token("<number>", |token| match token {
-            Token::Number(token) => Ok(token),
-            token => Err(token),
-        })
+        self.expect_token("<number>", |token, source| token.number(source))
     }
 
     #[inline]
     fn expect_percent(&mut self) -> PResult<(token::Percent, Span)> {
-        self.expect_token("%", |token| match token {
-            Token::Percent(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind("%", |token| match token {
+            Token::Percent(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_percentage(&mut self) -> PResult<(token::Percentage<'a>, Span)> {
-        self.expect_token("<percentage>", |token| match token {
-            Token::Percentage(token) => Ok(token),
-            token => Err(token),
-        })
+        self.expect_token("<percentage>", |token, source| token.percentage(source))
     }
 
     #[inline]
     fn expect_placeholder(&mut self) -> PResult<(token::Placeholder<'a>, Span)> {
-        self.expect_token("<placeholder>", |token| match token {
-            Token::Placeholder(token) => Ok(token),
-            token => Err(token),
-        })
+        self.expect_token("<placeholder>", |token, source| token.placeholder(source))
     }
 
     #[inline]
     fn expect_r_brace(&mut self) -> PResult<(token::RBrace, Span)> {
-        self.expect_token("}", |token| match token {
-            Token::RBrace(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind("}", |token| match token {
+            Token::RBrace(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_r_bracket(&mut self) -> PResult<(token::RBracket, Span)> {
-        self.expect_token("]", |token| match token {
-            Token::RBracket(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind("]", |token| match token {
+            Token::RBracket(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_r_paren(&mut self) -> PResult<(token::RParen, Span)> {
-        self.expect_token(")", |token| match token {
-            Token::RParen(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind(")", |token| match token {
+            Token::RParen(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_semicolon(&mut self) -> PResult<(token::Semicolon, Span)> {
-        self.expect_token(";", |token| match token {
-            Token::Semicolon(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind(";", |token| match token {
+            Token::Semicolon(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_solidus(&mut self) -> PResult<(token::Solidus, Span)> {
-        self.expect_token("/", |token| match token {
-            Token::Solidus(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind("/", |token| match token {
+            Token::Solidus(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_str(&mut self) -> PResult<(token::Str<'a>, Span)> {
-        self.expect_token("<string>", |token| match token {
-            Token::Str(token) => Ok(token),
-            token => Err(token),
-        })
+        self.expect_token("<string>", |token, source| token.str(source))
     }
 
     #[inline]
     fn expect_str_template(&mut self) -> PResult<(token::StrTemplate<'a>, Span)> {
-        self.expect_token("<string template>", |token| match token {
-            Token::StrTemplate(token) => Ok(token),
-            token => Err(token),
-        })
+        self.expect_token("<string template>", |token, source| token.str_template(source))
     }
 
     #[inline]
     fn expect_tilde(&mut self) -> PResult<(token::Tilde, Span)> {
-        self.expect_token("~", |token| match token {
-            Token::Tilde(token) => Ok(token),
-            token => Err(token),
+        self.expect_kind("~", |token| match token {
+            Token::Tilde(token) => Some(token),
+            _ => None,
         })
     }
 
@@ -375,15 +355,14 @@ impl<'a> ParserCursor<'a> {
     fn expect_without_ws_or_comments<T>(
         &mut self,
         expected: &'static str,
-        extract: impl FnOnce(Token<'a>) -> Result<T, Token<'a>>,
+        extract: impl FnOnce(Token<'a>) -> Option<T>,
     ) -> PResult<(T, Span)> {
         debug_assert!(self.cached_token.is_none());
         let TokenWithSpan { token, span } = self.tokenizer.bump_without_ws_or_comments()?;
-        match extract(token) {
-            Ok(token) => Ok((token, span)),
-            Err(token) => {
-                Err(Error { kind: ErrorKind::Unexpected(expected, token.symbol()), span })
-            }
+        if let Some(token) = extract(token) {
+            Ok((token, span))
+        } else {
+            Err(Error { kind: ErrorKind::Unexpected(expected, token.symbol()), span })
         }
     }
 
@@ -406,128 +385,125 @@ impl<'a> ParserCursor<'a> {
     #[inline]
     fn expect_asterisk_without_ws_or_comments(&mut self) -> PResult<(token::Asterisk, Span)> {
         self.expect_without_ws_or_comments("*", |token| match token {
-            Token::Asterisk(token) => Ok(token),
-            token => Err(token),
+            Token::Asterisk(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_l_paren_without_ws_or_comments(&mut self) -> PResult<(token::LParen, Span)> {
         self.expect_without_ws_or_comments("(", |token| match token {
-            Token::LParen(token) => Ok(token),
-            token => Err(token),
+            Token::LParen(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn expect_solidus_without_ws_or_comments(&mut self) -> PResult<(token::Solidus, Span)> {
         self.expect_without_ws_or_comments("/", |token| match token {
-            Token::Solidus(token) => Ok(token),
-            token => Err(token),
+            Token::Solidus(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn eat_bar(&mut self) -> PResult<Option<(token::Bar, Span)>> {
-        self.eat_token(|token| match token {
-            Token::Bar(token) => Ok(token),
-            token => Err(token),
+        self.eat_kind(|token| match token {
+            Token::Bar(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn eat_colon(&mut self) -> PResult<Option<(token::Colon, Span)>> {
-        self.eat_token(|token| match token {
-            Token::Colon(token) => Ok(token),
-            token => Err(token),
+        self.eat_kind(|token| match token {
+            Token::Colon(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn eat_comma(&mut self) -> PResult<Option<(token::Comma, Span)>> {
-        self.eat_token(|token| match token {
-            Token::Comma(token) => Ok(token),
-            token => Err(token),
+        self.eat_kind(|token| match token {
+            Token::Comma(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn eat_dot_dot_dot(&mut self) -> PResult<Option<(token::DotDotDot, Span)>> {
-        self.eat_token(|token| match token {
-            Token::DotDotDot(token) => Ok(token),
-            token => Err(token),
+        self.eat_kind(|token| match token {
+            Token::DotDotDot(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn eat_exclamation(&mut self) -> PResult<Option<(token::Exclamation, Span)>> {
-        self.eat_token(|token| match token {
-            Token::Exclamation(token) => Ok(token),
-            token => Err(token),
+        self.eat_kind(|token| match token {
+            Token::Exclamation(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn eat_greater_than(&mut self) -> PResult<Option<(token::GreaterThan, Span)>> {
-        self.eat_token(|token| match token {
-            Token::GreaterThan(token) => Ok(token),
-            token => Err(token),
+        self.eat_kind(|token| match token {
+            Token::GreaterThan(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn eat_ident(&mut self) -> PResult<Option<(token::Ident<'a>, Span)>> {
-        self.eat_token(|token| match token {
-            Token::Ident(token) => Ok(token),
-            token => Err(token),
-        })
+        self.eat_token(|token, source| token.ident(source))
     }
 
     #[inline]
     fn eat_indent(&mut self) -> PResult<Option<(token::Indent, Span)>> {
-        self.eat_token(|token| match token {
-            Token::Indent(token) => Ok(token),
-            token => Err(token),
+        self.eat_kind(|token| match token {
+            Token::Indent(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn eat_linebreak(&mut self) -> PResult<Option<(token::Linebreak, Span)>> {
-        self.eat_token(|token| match token {
-            Token::Linebreak(token) => Ok(token),
-            token => Err(token),
+        self.eat_kind(|token| match token {
+            Token::Linebreak(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn eat_l_paren(&mut self) -> PResult<Option<(token::LParen, Span)>> {
-        self.eat_token(|token| match token {
-            Token::LParen(token) => Ok(token),
-            token => Err(token),
+        self.eat_kind(|token| match token {
+            Token::LParen(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn eat_r_paren(&mut self) -> PResult<Option<(token::RParen, Span)>> {
-        self.eat_token(|token| match token {
-            Token::RParen(token) => Ok(token),
-            token => Err(token),
+        self.eat_kind(|token| match token {
+            Token::RParen(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn eat_semicolon(&mut self) -> PResult<Option<(token::Semicolon, Span)>> {
-        self.eat_token(|token| match token {
-            Token::Semicolon(token) => Ok(token),
-            token => Err(token),
+        self.eat_kind(|token| match token {
+            Token::Semicolon(token) => Some(token),
+            _ => None,
         })
     }
 
     #[inline]
     fn eat_tilde(&mut self) -> PResult<Option<(token::Tilde, Span)>> {
-        self.eat_token(|token| match token {
-            Token::Tilde(token) => Ok(token),
-            token => Err(token),
+        self.eat_kind(|token| match token {
+            Token::Tilde(token) => Some(token),
+            _ => None,
         })
     }
 }
@@ -559,7 +535,10 @@ impl<'a> Parser<'a> {
             source,
             syntax,
             options: Default::default(),
-            cursor: ParserCursor::new(Tokenizer::new(allocator, source, syntax, None, false)),
+            cursor: ParserCursor::new(
+                Tokenizer::new(allocator, source, syntax, None, false),
+                source,
+            ),
             state: Default::default(),
             recoverable_errors: vec![],
             sass_pending_indents: 0,

--- a/crates/oxc_css_parser/src/parser/sass.rs
+++ b/crates/oxc_css_parser/src/parser/sass.rs
@@ -192,9 +192,11 @@ impl<'a> Parser<'a> {
         loop {
             if PRECEDENCE_PLUS >= min_precedence {
                 match self.cursor.peek()? {
-                    TokenWithSpan { token: Token::Number(token), span }
-                        if token.raw.starts_with('+')
-                            || token.raw.starts_with('-') && span.start == left.span().end =>
+                    token @ TokenWithSpan { token: Token::Number(..), span }
+                        if token.number_raw(self.source).is_some_and(|raw| {
+                            raw.starts_with('+')
+                                || raw.starts_with('-') && span.start == left.span().end
+                        }) =>
                     {
                         let (number, number_span) = self.cursor.expect_number()?;
                         let op = SassBinaryOperator {
@@ -224,10 +226,11 @@ impl<'a> Parser<'a> {
                         });
                         continue;
                     }
-                    TokenWithSpan { token: Token::Dimension(token), span }
-                        if token.value.raw.starts_with('+')
-                            || token.value.raw.starts_with('-')
-                                && span.start == left.span().end =>
+                    token @ TokenWithSpan { token: Token::Dimension(..), span }
+                        if token.dimension_value_raw(self.source).is_some_and(|raw| {
+                            raw.starts_with('+')
+                                || raw.starts_with('-') && span.start == left.span().end
+                        }) =>
                     {
                         let (dimension, dimension_span) = self.cursor.expect_dimension()?;
                         let op = SassBinaryOperator {
@@ -424,8 +427,9 @@ impl<'a> Parser<'a> {
                         PRECEDENCE_EQUALITY,
                     )
                 }
-                TokenWithSpan { token: Token::Ident(token), .. }
-                    if token.raw == "and" && PRECEDENCE_AND >= min_precedence =>
+                token @ TokenWithSpan { token: Token::Ident(..), .. }
+                    if token.is_ident_raw(self.source, "and")
+                        && PRECEDENCE_AND >= min_precedence =>
                 {
                     (
                         SassBinaryOperator {
@@ -435,8 +439,8 @@ impl<'a> Parser<'a> {
                         PRECEDENCE_AND,
                     )
                 }
-                TokenWithSpan { token: Token::Ident(token), .. }
-                    if token.raw == "or" && PRECEDENCE_OR >= min_precedence =>
+                token @ TokenWithSpan { token: Token::Ident(..), .. }
+                    if token.is_ident_raw(self.source, "or") && PRECEDENCE_OR >= min_precedence =>
                 {
                     (
                         SassBinaryOperator {
@@ -639,47 +643,46 @@ impl<'a> Parser<'a> {
         &mut self,
         allow_overridable: bool,
     ) -> PResult<Option<SassModuleConfig<'a>>> {
-        match &self.cursor.peek()?.token {
-            Token::Ident(ident) if ident.name().eq_ignore_ascii_case("with") => {
-                let TokenWithSpan { span: with_span, .. } = self.cursor.bump()?;
-                let start = with_span.start;
-                let end;
-                self.eat_sass_line_continuation()?;
-                let (_, lparen_span) = self.cursor.expect_l_paren()?;
+        if self.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(self.source, "with") {
+            let TokenWithSpan { span: with_span, .. } = self.cursor.bump()?;
+            let start = with_span.start;
+            let end;
+            self.eat_sass_line_continuation()?;
+            let (_, lparen_span) = self.cursor.expect_l_paren()?;
 
-                let item = self.parse_sass_module_config_item(allow_overridable)?;
-                let mut items = self.vec1(item);
-                let mut comma_spans = self.vec();
-                if let Some((_, span)) = self.cursor.eat_r_paren()? {
-                    end = span.end;
-                } else {
-                    comma_spans.push(self.cursor.expect_comma()?.1);
-                    loop {
-                        if let Some((_, span)) = self.cursor.eat_r_paren()? {
-                            end = span.end;
-                            break;
-                        }
+            let item = self.parse_sass_module_config_item(allow_overridable)?;
+            let mut items = self.vec1(item);
+            let mut comma_spans = self.vec();
+            if let Some((_, span)) = self.cursor.eat_r_paren()? {
+                end = span.end;
+            } else {
+                comma_spans.push(self.cursor.expect_comma()?.1);
+                loop {
+                    if let Some((_, span)) = self.cursor.eat_r_paren()? {
+                        end = span.end;
+                        break;
+                    }
 
-                        items.push(self.parse_sass_module_config_item(allow_overridable)?);
-                        if let Some((_, span)) = self.cursor.eat_r_paren()? {
-                            end = span.end;
-                            break;
-                        } else {
-                            comma_spans.push(self.cursor.expect_comma()?.1);
-                        }
+                    items.push(self.parse_sass_module_config_item(allow_overridable)?);
+                    if let Some((_, span)) = self.cursor.eat_r_paren()? {
+                        end = span.end;
+                        break;
+                    } else {
+                        comma_spans.push(self.cursor.expect_comma()?.1);
                     }
                 }
-                debug_assert!(items.len() - comma_spans.len() <= 1);
-
-                Ok(Some(SassModuleConfig {
-                    with_span,
-                    lparen_span,
-                    items,
-                    comma_spans,
-                    span: Span { start, end },
-                }))
             }
-            _ => Ok(None),
+            debug_assert!(items.len() - comma_spans.len() <= 1);
+
+            Ok(Some(SassModuleConfig {
+                with_span,
+                lparen_span,
+                items,
+                comma_spans,
+                span: Span { start, end },
+            }))
+        } else {
+            Ok(None)
         }
     }
 
@@ -807,16 +810,16 @@ impl<'a> Parser<'a> {
         if let Token::Percent(..) = &self.cursor.peek()?.token {
             return Ok(ComponentValue::TokenWithSpan(self.cursor.bump()?));
         }
-        let op = match &self.cursor.peek()?.token {
-            Token::Plus(..) => SassUnaryOperator {
+        let op = match self.cursor.peek()? {
+            TokenWithSpan { token: Token::Plus(..), .. } => SassUnaryOperator {
                 kind: SassUnaryOperatorKind::Plus,
                 span: self.cursor.bump()?.span,
             },
-            Token::Minus(..) => SassUnaryOperator {
+            TokenWithSpan { token: Token::Minus(..), .. } => SassUnaryOperator {
                 kind: SassUnaryOperatorKind::Minus,
                 span: self.cursor.bump()?.span,
             },
-            Token::Ident(token) if token.raw == "not" => SassUnaryOperator {
+            token if token.is_ident_raw(self.source, "not") => SassUnaryOperator {
                 kind: SassUnaryOperatorKind::Not,
                 span: self.cursor.bump()?.span,
             },
@@ -1032,22 +1035,20 @@ impl<'a> Parse<'a> for SassForward<'a> {
         let path = input.parse::<InterpolableStr>()?;
         let mut span = path.span().clone();
 
-        let prefix = match &input.cursor.peek()?.token {
-            Token::Ident(ident) if ident.name().eq_ignore_ascii_case("as") => {
-                let TokenWithSpan { span: as_span, .. } = input.cursor.bump()?;
-                input.eat_sass_line_continuation()?;
-                let name = input.parse()?;
-                let (_, Span { end, .. }) =
-                    input.cursor.expect_asterisk_without_ws_or_comments()?;
-                let span = Span { start: as_span.start, end };
-                Some(SassForwardPrefix { as_span, name, span })
-            }
-            _ => None,
+        let prefix = if input.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(input.source, "as")
+        {
+            let TokenWithSpan { span: as_span, .. } = input.cursor.bump()?;
+            input.eat_sass_line_continuation()?;
+            let name = input.parse()?;
+            let (_, Span { end, .. }) = input.cursor.expect_asterisk_without_ws_or_comments()?;
+            let span = Span { start: as_span.start, end };
+            Some(SassForwardPrefix { as_span, name, span })
+        } else {
+            None
         };
 
-        let visibility = if let TokenWithSpan { token: Token::Ident(keyword), span: keyword_span } =
-            input.cursor.peek()?
-        {
+        let visibility = if let Some(keyword) = input.cursor.peek()?.ident(input.source) {
+            let keyword_span = input.cursor.peek()?.span;
             let start = keyword_span.start;
             let name = keyword.name();
             if name.eq_ignore_ascii_case("hide") {
@@ -1162,15 +1163,18 @@ impl<'a> Parse<'a> for SassIfAtRule<'a> {
             fn else_keyword<'a>(p: &mut Parser<'a>) -> PResult<(Span, bool)> {
                 while p.cursor.eat_linebreak()?.is_some() {}
                 let is_else = match &p.cursor.peek()?.token {
-                    Token::AtKeyword(at_keyword) => match &*at_keyword.ident.name() {
-                        "else" => true,
-                        // `elseif` is deprecated by Sass
-                        "elseif" => false,
-                        _ => {
-                            let span = p.cursor.peek()?.span.clone();
-                            return Err(Error { kind: ErrorKind::TryParseError, span });
+                    Token::AtKeyword(..) => {
+                        let at_keyword = p.cursor.peek()?.at_keyword(p.source).unwrap();
+                        match &*at_keyword.ident.name() {
+                            "else" => true,
+                            // `elseif` is deprecated by Sass
+                            "elseif" => false,
+                            _ => {
+                                let span = p.cursor.peek()?.span.clone();
+                                return Err(Error { kind: ErrorKind::TryParseError, span });
+                            }
                         }
-                    },
+                    }
                     _ => {
                         let span = p.cursor.peek()?.span.clone();
                         return Err(Error { kind: ErrorKind::TryParseError, span });
@@ -1187,15 +1191,12 @@ impl<'a> Parse<'a> for SassIfAtRule<'a> {
             else_spans.push(else_span);
             if is_else {
                 input.eat_sass_line_continuation()?;
-                match &input.cursor.peek()?.token {
-                    Token::Ident(ident) if ident.name() == "if" => {
-                        input.cursor.bump()?;
-                        else_if_clauses.push(input.parse()?);
-                    }
-                    _ => {
-                        else_clause = Some(input.parse()?);
-                        break;
-                    }
+                if input.cursor.peek()?.is_ident_raw(input.source, "if") {
+                    input.cursor.bump()?;
+                    else_if_clauses.push(input.parse()?);
+                } else {
+                    else_clause = Some(input.parse()?);
+                    break;
                 }
             } else {
                 else_if_clauses.push(input.parse()?);
@@ -1257,14 +1258,14 @@ impl<'a> Parse<'a> for SassInclude<'a> {
             None
         };
 
-        let content_block_params = match &input.cursor.peek()?.token {
-            Token::Ident(ident) if ident.name().eq_ignore_ascii_case("using") => {
+        let content_block_params =
+            if input.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(input.source, "using") {
                 let content_block_params = input.parse::<SassIncludeContentBlockParams>()?;
                 span.end = content_block_params.span.end;
                 Some(content_block_params)
-            }
-            _ => None,
-        };
+            } else {
+                None
+            };
 
         Ok(SassInclude { name, arguments, content_block_params, span })
     }
@@ -1283,18 +1284,15 @@ impl<'a> Parse<'a> for SassIncludeArgs<'a> {
 // using ( <parameters> )   (parameters the mixin passes to its @content block)
 impl<'a> Parse<'a> for SassIncludeContentBlockParams<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match input.cursor.bump()? {
-            TokenWithSpan { token: Token::Ident(ident), span: using_span }
-                if ident.name().eq_ignore_ascii_case("using") =>
-            {
-                input.eat_sass_line_continuation()?;
-                let params = input.parse::<SassParameters>()?;
-                let span = Span { start: using_span.start, end: params.span.end };
-                Ok(SassIncludeContentBlockParams { using_span, params, span })
-            }
-            TokenWithSpan { span, .. } => {
-                Err(Error { kind: ErrorKind::ExpectSassKeyword("using"), span })
-            }
+        let token = input.cursor.bump()?;
+        if token.is_ident_name_eq_ignore_ascii_case(input.source, "using") {
+            let using_span = token.span;
+            input.eat_sass_line_continuation()?;
+            let params = input.parse::<SassParameters>()?;
+            let span = Span { start: using_span.start, end: params.span.end };
+            Ok(SassIncludeContentBlockParams { using_span, params, span })
+        } else {
+            Err(Error { kind: ErrorKind::ExpectSassKeyword("using"), span: token.span })
         }
     }
 }
@@ -1343,12 +1341,13 @@ impl<'a> Parse<'a> for SassInterpolatedUrl<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         debug_assert!(matches!(input.syntax, Syntax::Scss | Syntax::Sass));
 
-        let (first, first_span) = match input.cursor.tokenizer.scan_url_raw_or_template()? {
-            TokenWithSpan { token: Token::UrlTemplate(template), span } => (template, span),
-            TokenWithSpan { token, span } => {
+        let token_with_span = input.cursor.tokenizer.scan_url_raw_or_template()?;
+        let (first, first_span) = match token_with_span.url_template(input.source) {
+            Some(template) => (template, token_with_span.span),
+            None => {
                 return Err(Error {
-                    kind: ErrorKind::Unexpected("<url template>", token.symbol()),
-                    span,
+                    kind: ErrorKind::Unexpected("<url template>", token_with_span.token.symbol()),
+                    span: token_with_span.span,
                 });
             }
         };
@@ -1531,14 +1530,14 @@ impl<'a> Parse<'a> for SassUse<'a> {
         let path = input.parse::<InterpolableStr>()?;
         let mut span = path.span().clone();
 
-        let namespace = match &input.cursor.peek()?.token {
-            Token::Ident(ident) if ident.name().eq_ignore_ascii_case("as") => {
+        let namespace =
+            if input.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(input.source, "as") {
                 let namespace = input.parse::<SassUseNamespace>()?;
                 span.end = namespace.span.end;
                 Some(namespace)
-            }
-            _ => None,
-        };
+            } else {
+                None
+            };
 
         let config = input.parse_sass_module_config(/* allow_overridable */ false)?;
         if let Some(config) = &config {
@@ -1552,15 +1551,11 @@ impl<'a> Parse<'a> for SassUse<'a> {
 // as [ <ident> | '*' ]   ('*' loads members without a namespace prefix)
 impl<'a> Parse<'a> for SassUseNamespace<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        let as_span = match input.cursor.peek()? {
-            TokenWithSpan { token: Token::Ident(ident), .. }
-                if ident.name().eq_ignore_ascii_case("as") =>
-            {
-                input.cursor.bump()?.span
-            }
-            TokenWithSpan { span, .. } => {
-                return Err(Error { kind: ErrorKind::ExpectSassKeyword("as"), span: span.clone() });
-            }
+        let token = input.cursor.peek()?;
+        let as_span = if token.is_ident_name_eq_ignore_ascii_case(input.source, "as") {
+            input.cursor.bump()?.span
+        } else {
+            return Err(Error { kind: ErrorKind::ExpectSassKeyword("as"), span: token.span });
         };
         input.eat_sass_line_continuation()?;
         match input.cursor.bump()? {
@@ -1574,7 +1569,8 @@ impl<'a> Parse<'a> for SassUseNamespace<'a> {
                     span,
                 })
             }
-            TokenWithSpan { token: Token::Ident(ident), span: ident_span } => {
+            token @ TokenWithSpan { token: Token::Ident(..), span: ident_span } => {
+                let ident = token.ident(input.source).unwrap();
                 let span = Span { start: as_span.start, end: ident_span.end };
                 Ok(SassUseNamespace {
                     as_span,

--- a/crates/oxc_css_parser/src/parser/selector.rs
+++ b/crates/oxc_css_parser/src/parser/selector.rs
@@ -527,9 +527,9 @@ impl<'a> Parse<'a> for ClassSelector<'a> {
         } else {
             None
         };
-        let name = if let Some(TokenWithSpan { token: Token::Placeholder(placeholder), span }) =
-            placeholder
-        {
+        let name = if let Some(token) = placeholder {
+            let placeholder = token.placeholder(input.source).unwrap();
+            let span = token.span;
             end = span.end;
             InterpolableIdent::Placeholder((placeholder, span).into())
         } else if input.syntax == Syntax::Css {
@@ -613,9 +613,8 @@ impl<'a> Parse<'a> for ComplexSelector<'a> {
                 children.push(ComplexSelectorChild::CompoundSelector(compound_selector));
             } else if let Some(combinator) = input.parse_combinator(end)? {
                 if is_less && combinator.kind == CombinatorKind::Descendant {
-                    match &input.cursor.peek()?.token {
-                        Token::Ident(ident) if ident.raw == "when" => break,
-                        _ => {}
+                    if input.cursor.peek()?.is_ident_raw(input.source, "when") {
+                        break;
                     }
                 }
                 children.push(ComplexSelectorChild::Combinator(combinator));
@@ -713,7 +712,8 @@ impl<'a> Parse<'a> for CompoundSelectorList<'a> {
 impl<'a> Parse<'a> for IdSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.cursor.bump()? {
-            TokenWithSpan { token: Token::Hash(token), span } => {
+            token @ TokenWithSpan { token: Token::Hash(..), span } => {
+                let token = token.hash(input.source).unwrap();
                 let first_span = Span { start: span.start + 1, end: span.end };
                 let raw = token.raw;
                 if raw.starts_with(|c: char| c.is_ascii_digit())
@@ -846,13 +846,13 @@ impl<'a> Parse<'a> for Nth<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let index = input.parse::<NthIndex>()?;
         let mut span = index.span().clone();
-        let matcher = match &input.cursor.peek()?.token {
-            Token::Ident(ident) if ident.name().eq_ignore_ascii_case("of") => {
-                let matcher = input.parse::<NthMatcher>()?;
-                span.end = matcher.span.end;
-                Some(matcher)
-            }
-            _ => None,
+        let matcher = if input.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(input.source, "of")
+        {
+            let matcher = input.parse::<NthMatcher>()?;
+            span.end = matcher.span.end;
+            Some(matcher)
+        } else {
+            None
         };
 
         Ok(Nth { index, matcher, span })
@@ -862,26 +862,24 @@ impl<'a> Parse<'a> for Nth<'a> {
 // <nth> = <an+b> | even | odd   (plus a plain <integer>)
 impl<'a> Parse<'a> for NthIndex<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match &input.cursor.peek()?.token {
-            Token::Ident(ident) => {
-                let name = ident.name();
-                if name.eq_ignore_ascii_case("odd") {
-                    input.parse().map(NthIndex::Odd)
-                } else if name.eq_ignore_ascii_case("even") {
-                    input.parse().map(NthIndex::Even)
-                } else {
-                    input.parse().map(NthIndex::AnPlusB)
-                }
+        let peek = input.cursor.peek()?;
+        if peek.ident(input.source).is_some() {
+            if peek.is_ident_name_eq_ignore_ascii_case(input.source, "odd") {
+                input.parse().map(NthIndex::Odd)
+            } else if peek.is_ident_name_eq_ignore_ascii_case(input.source, "even") {
+                input.parse().map(NthIndex::Even)
+            } else {
+                input.parse().map(NthIndex::AnPlusB)
             }
-            Token::Number(..) => {
-                let number = input.parse::<Number>()?;
-                if number.value.fract() == 0.0 {
-                    Ok(NthIndex::Integer(number))
-                } else {
-                    Err(Error { kind: ErrorKind::ExpectInteger, span: number.span })
-                }
+        } else if matches!(peek.token, Token::Number(..)) {
+            let number = input.parse::<Number>()?;
+            if number.value.fract() == 0.0 {
+                Ok(NthIndex::Integer(number))
+            } else {
+                Err(Error { kind: ErrorKind::ExpectInteger, span: number.span })
             }
-            _ => input.parse().map(NthIndex::AnPlusB),
+        } else {
+            input.parse().map(NthIndex::AnPlusB)
         }
     }
 }

--- a/crates/oxc_css_parser/src/parser/stmt.rs
+++ b/crates/oxc_css_parser/src/parser/stmt.rs
@@ -47,11 +47,11 @@ impl<'a> Parse<'a> for Declaration<'a> {
             InterpolableIdent::Placeholder((placeholder, span).into())
         } else if input.state.allow_ie_star_hack
             && input.syntax == Syntax::Less
-            && let TokenWithSpan { token: Token::Number(number), span } = input.cursor.peek()?
-            && number.raw.bytes().all(|b| b.is_ascii_digit())
+            && let token = input.cursor.peek()?
+            && let Some(raw) = token.number_raw(input.source)
+            && raw.bytes().all(|b| b.is_ascii_digit())
         {
-            let raw = number.raw;
-            let span = span.clone();
+            let span = token.span;
             input.cursor.bump()?;
             InterpolableIdent::Literal(Ident { name: raw, raw, span })
         } else if name_prefix.is_none()
@@ -60,9 +60,11 @@ impl<'a> Parse<'a> for Declaration<'a> {
             && matches!(input.cursor.peek()?.token, Token::Hash(..))
         {
             // `#x: y` — the `#` and the name arrive as one <hash-token>.
-            let TokenWithSpan { token: Token::Hash(hash), span } = input.cursor.bump()? else {
+            let token @ TokenWithSpan { token: Token::Hash(..), span } = input.cursor.bump()?
+            else {
                 unreachable!()
             };
+            let hash = token.hash(input.source).unwrap();
             name_prefix = Some((span.start, '#'));
             let name = if hash.escaped {
                 crate::util::handle_escape_in(hash.raw, input.allocator)
@@ -105,16 +107,14 @@ impl<'a> Parse<'a> for Declaration<'a> {
                 qualified_rule_ctx: Some(QualifiedRuleContext::DeclarationValue),
                 ..input.state
             });
+            // For IE-compatibility, regardless of the property name (`filter`,
+            // `-ms-filter`, vendor variants...): `filter: progid:...`.
+            let source = parser.source;
+            let starts_with_progid =
+                parser.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(source, "progid");
             match &name {
                 InterpolableIdent::Literal(ident)
-                    if ident.name.starts_with("--")
-                        || matches!(
-                            &parser.cursor.peek()?.token,
-                            // for IE-compatibility, regardless of the property
-                            // name (`filter`, `-ms-filter`, vendor variants...):
-                            // filter: progid:DXImageTransform.Microsoft...
-                            Token::Ident(ident) if ident.name().eq_ignore_ascii_case("progid")
-                        ) =>
+                    if ident.name.starts_with("--") || starts_with_progid =>
                 'value: {
                     if parser.options.try_parsing_value_in_custom_property
                         && let Ok(values) = parser.try_parse(Parser::parse_declaration_value)
@@ -644,14 +644,15 @@ impl<'a> Parser<'a> {
                         is_block_element = true;
                     }
                 }
-                Token::AtKeyword(at_keyword) => match self.syntax {
+                Token::AtKeyword(..) => match self.syntax {
                     Syntax::Css => {
                         let at_rule = self.parse::<AtRule>()?;
                         is_block_element = at_rule.block.is_some();
                         statements.push(Statement::AtRule(at_rule));
                     }
                     Syntax::Scss | Syntax::Sass => {
-                        let at_keyword_name = at_keyword.ident.name();
+                        let at_keyword_name =
+                            self.cursor.peek()?.at_keyword(self.source).unwrap().ident.name();
                         match &*at_keyword_name {
                             "if" => {
                                 let sass_if_at_rule = self.parse()?;

--- a/crates/oxc_css_parser/src/parser/token_seq.rs
+++ b/crates/oxc_css_parser/src/parser/token_seq.rs
@@ -92,7 +92,14 @@ impl<'a> Parser<'a> {
             }
             let (template, span) = self.cursor.tokenizer.scan_string_template(quote)?;
             tail = template.tail;
-            tokens.push(TokenWithSpan { token: Token::StrTemplate(template), span });
+            tokens.push(TokenWithSpan {
+                token: Token::StrTemplate(crate::token::StrTemplateMeta {
+                    escaped: template.escaped,
+                    head: template.head,
+                    tail: template.tail,
+                }),
+                span,
+            });
         }
         Ok(())
     }

--- a/crates/oxc_css_parser/src/parser/value.rs
+++ b/crates/oxc_css_parser/src/parser/value.rs
@@ -140,8 +140,9 @@ impl<'a> Parser<'a> {
     pub(super) fn parse_component_value_atom(&mut self) -> PResult<ComponentValue<'a>> {
         let token_with_span = self.cursor.peek()?;
         match &token_with_span.token {
-            Token::Ident(token) => {
-                if unvendored(&token.name()).eq_ignore_ascii_case("url") {
+            Token::Ident(..) => {
+                let ident = token_with_span.ident(self.source).unwrap();
+                if unvendored(&ident.name()).eq_ignore_ascii_case("url") {
                     match self.try_parse(Url::parse) {
                         Ok(url) => return Ok(ComponentValue::Url(self.alloc(url))),
                         Err(Error { kind: ErrorKind::TryParseError, .. }) => {}
@@ -262,13 +263,19 @@ impl<'a> Parser<'a> {
                             {
                                 self.parse_unicode_range(ident).map(ComponentValue::UnicodeRange)
                             }
-                            TokenWithSpan { token: Token::Number(token), span }
-                                if token.raw.starts_with('+') && span.start == ident_end =>
+                            token @ TokenWithSpan { token: Token::Number(..), span }
+                                if token
+                                    .number_raw(self.source)
+                                    .is_some_and(|raw| raw.starts_with('+'))
+                                    && span.start == ident_end =>
                             {
                                 self.parse_unicode_range(ident).map(ComponentValue::UnicodeRange)
                             }
-                            TokenWithSpan { token: Token::Dimension(token), span }
-                                if token.value.raw.starts_with('+') && span.start == ident_end =>
+                            token @ TokenWithSpan { token: Token::Dimension(..), span }
+                                if token
+                                    .dimension_value_raw(self.source)
+                                    .is_some_and(|raw| raw.starts_with('+'))
+                                    && span.start == ident_end =>
                             {
                                 self.parse_unicode_range(ident).map(ComponentValue::UnicodeRange)
                             }
@@ -1217,8 +1224,10 @@ impl<'a> Parse<'a> for UrlModifier<'a> {
 // The unquoted URL body of a <url-token> (raw text up to the closing `)`).
 impl<'a> Parse<'a> for UrlRaw<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match input.cursor.tokenizer.scan_url_raw_or_template()? {
-            TokenWithSpan { token: Token::UrlRaw(url), span } => {
+        let token = input.cursor.tokenizer.scan_url_raw_or_template()?;
+        match token.url_raw(input.source) {
+            Some(url) => {
+                let span = token.span;
                 let value = if url.escaped {
                     util::handle_escape_in(url.raw, input.allocator)
                 } else {
@@ -1226,9 +1235,10 @@ impl<'a> Parse<'a> for UrlRaw<'a> {
                 };
                 Ok(UrlRaw { value, raw: url.raw, span })
             }
-            TokenWithSpan { token, span } => {
-                Err(Error { kind: ErrorKind::Unexpected("<url>", token.symbol()), span })
-            }
+            None => Err(Error {
+                kind: ErrorKind::Unexpected("<url>", token.token.symbol()),
+                span: token.span,
+            }),
         }
     }
 }

--- a/crates/oxc_css_parser/src/pos.rs
+++ b/crates/oxc_css_parser/src/pos.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 
 /// Span represents a range of a piece of source code.
 /// It counts by offset, so it's 0-based.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct Span {
     /// Start offset. (Inclusive)

--- a/crates/oxc_css_parser/src/tokenizer/mod.rs
+++ b/crates/oxc_css_parser/src/tokenizer/mod.rs
@@ -698,28 +698,31 @@ impl<'a> Tokenizer<'a> {
                 self.scan_dimension(number, span)
             }
             (Some((_, b'%')), ..) => self.scan_percentage(number, span),
-            _ => Ok(TokenWithSpan { token: Token::Number(number), span }),
+            _ => Ok(TokenWithSpan { token: Token::Number(NumberMeta {}), span }),
         }
     }
 
     // <dimension-token> = <number-token> <ident-sequence>
     fn scan_dimension(
         &mut self,
-        value: Number<'a>,
+        _value: Number<'a>,
         value_span: Span,
     ) -> PResult<TokenWithSpan<'a>> {
         let (unit, unit_span) = self.scan_ident_sequence(false)?;
         Ok(TokenWithSpan {
-            token: Token::Dimension(Dimension { value, unit }),
+            token: Token::Dimension(DimensionMeta {
+                number_end: compact_offset(value_span.end),
+                unit_escaped: unit.escaped,
+            }),
             span: Span { start: value_span.start, end: unit_span.end },
         })
     }
 
     // <percentage-token> = <number-token> '%'
-    fn scan_percentage(&mut self, value: Number<'a>, span: Span) -> PResult<TokenWithSpan<'a>> {
+    fn scan_percentage(&mut self, _value: Number<'a>, span: Span) -> PResult<TokenWithSpan<'a>> {
         self.state.chars.next();
         Ok(TokenWithSpan {
-            token: Token::Percentage(Percentage { value }),
+            token: Token::Percentage(PercentageMeta {}),
             span: Span { start: span.start, end: span.end + 1 },
         })
     }
@@ -792,11 +795,9 @@ impl<'a> Tokenizer<'a> {
                 Some((end, c @ b'#' | c @ b'@' | c @ b'$'))
                     if self.is_start_of_interpolation_in_str_template(c) =>
                 {
-                    let raw = unsafe { self.source.get_unchecked(start..end) };
                     let span = Span { start, end };
                     return Ok(TokenWithSpan {
-                        token: Token::StrTemplate(StrTemplate {
-                            raw,
+                        token: Token::StrTemplate(StrTemplateMeta {
                             escaped,
                             head: true,
                             tail: false,
@@ -809,9 +810,8 @@ impl<'a> Tokenizer<'a> {
                     // `<bad-string-token>` (parse error, not a lexer failure);
                     // the dialects' reference compilers reject it outright.
                     if self.syntax == Syntax::Css {
-                        let raw = unsafe { self.source.get_unchecked(start..end) };
                         return Ok(TokenWithSpan {
-                            token: Token::BadStr(BadStr { raw }),
+                            token: Token::BadStr(BadStrMeta {}),
                             span: Span { start, end },
                         });
                     }
@@ -824,9 +824,8 @@ impl<'a> Tokenizer<'a> {
                 None => {
                     let end = self.source.len();
                     if self.syntax == Syntax::Css {
-                        let raw = unsafe { self.source.get_unchecked(start..end) };
                         return Ok(TokenWithSpan {
-                            token: Token::BadStr(BadStr { raw }),
+                            token: Token::BadStr(BadStrMeta {}),
                             span: Span { start, end },
                         });
                     }
@@ -839,8 +838,7 @@ impl<'a> Tokenizer<'a> {
         }
 
         debug_assert!(start + 1 < end);
-        let raw = unsafe { self.source.get_unchecked(start..end) };
-        Ok(TokenWithSpan { token: Token::Str(Str { raw, escaped }), span: Span { start, end } })
+        Ok(TokenWithSpan { token: Token::Str(StrMeta { escaped }), span: Span { start, end } })
     }
 
     // Resume a string template after an interpolation, yielding the next static
@@ -899,8 +897,10 @@ impl<'a> Tokenizer<'a> {
     // An ident-like token: <ident-token>, <function-token> (`name(`), or <url-token>.
     // https://drafts.csswg.org/css-syntax-3/#consume-ident-like-token
     fn scan_ident(&mut self) -> PResult<TokenWithSpan<'a>> {
-        self.scan_ident_sequence(false)
-            .map(|(ident, span)| TokenWithSpan { token: Token::Ident(ident), span })
+        self.scan_ident_sequence(false).map(|(ident, span)| TokenWithSpan {
+            token: Token::Ident(IdentMeta { escaped: ident.escaped }),
+            span,
+        })
     }
 
     // The next static piece of an ident interleaved with interpolation (Sass/Less).
@@ -945,7 +945,7 @@ impl<'a> Tokenizer<'a> {
             Some((start, c)) => {
                 debug_assert_eq!(c, b'-');
                 Ok(TokenWithSpan {
-                    token: Token::Ident(Ident { escaped: false, raw: "-" }),
+                    token: Token::Ident(IdentMeta { escaped: false }),
                     span: Span { start, end: start + 1 },
                 })
             }
@@ -973,10 +973,9 @@ impl<'a> Tokenizer<'a> {
                     break;
                 }
                 Some((end, b'#')) if self.is_start_of_interpolation_in_url_template() => {
-                    let raw = unsafe { self.source.get_unchecked(start..end) };
                     let span = Span { start, end };
                     return Ok(TokenWithSpan {
-                        token: Token::UrlTemplate(UrlTemplate { raw, escaped, tail: false }),
+                        token: Token::UrlTemplate(UrlTemplateMeta { escaped, tail: false }),
                         span,
                     });
                 }
@@ -1009,9 +1008,8 @@ impl<'a> Tokenizer<'a> {
         }
 
         debug_assert!(start <= end);
-        let raw = unsafe { self.source.get_unchecked(start..end) };
         let span = Span { start, end };
-        Ok(TokenWithSpan { token: Token::UrlRaw(UrlRaw { raw, escaped }), span })
+        Ok(TokenWithSpan { token: Token::UrlRaw(UrlRawMeta { escaped }), span })
     }
 
     // The next static piece of an unquoted url() body interleaved with interpolation.
@@ -1127,8 +1125,7 @@ impl<'a> Tokenizer<'a> {
         }
 
         debug_assert!(end > start + 1);
-        let raw = unsafe { self.source.get_unchecked(start + 1..end) };
-        Ok(TokenWithSpan { token: Token::Hash(Hash { escaped, raw }), span: Span { start, end } })
+        Ok(TokenWithSpan { token: Token::Hash(HashMeta { escaped }), span: Span { start, end } })
     }
 
     // A '$'-prefixed variable token: '$' <ident-sequence> (Sass var / Less property).
@@ -1137,7 +1134,7 @@ impl<'a> Tokenizer<'a> {
         debug_assert_eq!(c, b'$');
         let (ident, span) = self.scan_ident_sequence(false)?;
         Ok(TokenWithSpan {
-            token: Token::DollarVar(DollarVar { ident }),
+            token: Token::DollarVar(IdentMeta { escaped: ident.escaped }),
             span: Span { start, end: span.end },
         })
     }
@@ -1155,10 +1152,13 @@ impl<'a> Tokenizer<'a> {
             Some((i, b'}')) => {
                 let span = Span { start, end: i + 1 };
                 if first_char == b'@' {
-                    Ok(TokenWithSpan { token: Token::AtLBraceVar(AtLBraceVar { ident }), span })
+                    Ok(TokenWithSpan {
+                        token: Token::AtLBraceVar(IdentMeta { escaped: ident.escaped }),
+                        span,
+                    })
                 } else {
                     Ok(TokenWithSpan {
-                        token: Token::DollarLBraceVar(DollarLBraceVar { ident }),
+                        token: Token::DollarLBraceVar(IdentMeta { escaped: ident.escaped }),
                         span,
                     })
                 }
@@ -1180,7 +1180,7 @@ impl<'a> Tokenizer<'a> {
         // Less allows digit-led variable names like `@3`.
         let (ident, span) = self.scan_ident_sequence(self.syntax == Syntax::Less)?;
         Ok(TokenWithSpan {
-            token: Token::AtKeyword(AtKeyword { ident }),
+            token: Token::AtKeyword(IdentMeta { escaped: ident.escaped }),
             span: Span { start, end: span.end },
         })
     }
@@ -1208,11 +1208,8 @@ impl<'a> Tokenizer<'a> {
     /// the closing backtick and any glued suffix), or `None` when the option is
     /// unset or the shape doesn't match. An index that overflows `u32` doesn't
     /// match (so the caller errors) instead of panicking. Does not advance.
-    fn match_placeholder(&self, at: usize) -> Option<(Placeholder<'a>, usize)> {
-        // Bind `source` as `&'a str` so the suffix slice has lifetime `'a`
-        // (independent of `&self`), letting callers mutate the tokenizer while
-        // holding the returned token.
-        let source: &'a str = self.source;
+    fn match_placeholder(&self, at: usize) -> Option<(PlaceholderMeta, usize)> {
+        let source = self.source;
         let ph = self.template_placeholder?;
         // `at` is the opening backtick.
         let after_open = source[at + 1..].strip_prefix(ph.prefix)?;
@@ -1233,7 +1230,7 @@ impl<'a> Tokenizer<'a> {
             .take_while(|&b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b >= 0x80)
             .count();
         let end = close_end + suffix_len;
-        Some((Placeholder { index, suffix: &source[close_end..end] }, end))
+        Some((PlaceholderMeta { index, suffix_start: compact_offset(close_end) }, end))
     }
 
     /// If a placeholder begins exactly at the current position, scan and return
@@ -1275,9 +1272,8 @@ impl<'a> Tokenizer<'a> {
         }
 
         debug_assert!(start + 1 < end);
-        let raw = unsafe { self.source.get_unchecked(start..end) };
         Ok(TokenWithSpan {
-            token: Token::BacktickCode(BacktickCode { raw }),
+            token: Token::BacktickCode(BacktickCodeMeta {}),
             span: Span { start, end },
         })
     }
@@ -1628,6 +1624,11 @@ impl<'a> Tokenizer<'a> {
 #[inline]
 fn is_start_of_ident(c: u8) -> bool {
     c.is_ascii_alphabetic() || c == b'-' || c == b'_' || !c.is_ascii() || c == b'\\'
+}
+
+#[inline]
+fn compact_offset(offset: usize) -> u32 {
+    u32::try_from(offset).expect("source is too large for compact token offsets")
 }
 
 /// Whether an identifier starts at byte offset `at` of `source`, using the

--- a/crates/oxc_css_parser/src/tokenizer/symbol.rs
+++ b/crates/oxc_css_parser/src/tokenizer/symbol.rs
@@ -2,7 +2,7 @@ use super::token::*;
 
 impl Token<'_> {
     pub(crate) fn symbol(&self) -> &'static str {
-        use Token::*;
+        use TokenData::*;
         match self {
             Eof(..) => "<eof>",
             Ampersand(..) => "&",

--- a/crates/oxc_css_parser/src/tokenizer/token.rs
+++ b/crates/oxc_css_parser/src/tokenizer/token.rs
@@ -4,7 +4,7 @@ use crate::pos::Span;
 #[cfg(feature = "serialize")]
 use serde::Serialize;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 pub struct Comment<'s> {
@@ -13,25 +13,25 @@ pub struct Comment<'s> {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 pub enum CommentKind {
     Block,
     Line,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
-pub enum Token<'s> {
+pub enum TokenData {
     Eof(Eof),
     Ampersand(Ampersand),
-    BadStr(BadStr<'s>),
+    BadStr(BadStrMeta),
     Asterisk(Asterisk),
     AsteriskEqual(AsteriskEqual),
     At(At),
-    AtKeyword(AtKeyword<'s>),
-    AtLBraceVar(AtLBraceVar<'s>),
-    BacktickCode(BacktickCode<'s>),
+    AtKeyword(IdentMeta),
+    AtLBraceVar(IdentMeta),
+    BacktickCode(BacktickCodeMeta),
     Bar(Bar),
     BarBar(BarBar),
     BarEqual(BarEqual),
@@ -42,10 +42,10 @@ pub enum Token<'s> {
     ColonColon(ColonColon),
     Comma(Comma),
     Dedent(Dedent),
-    Dimension(Dimension<'s>),
+    Dimension(DimensionMeta),
     DollarEqual(DollarEqual),
-    DollarLBraceVar(DollarLBraceVar<'s>),
-    DollarVar(DollarVar<'s>),
+    DollarLBraceVar(IdentMeta),
+    DollarVar(IdentMeta),
     Dot(Dot),
     DotDotDot(DotDotDot),
     Equal(Equal),
@@ -54,9 +54,9 @@ pub enum Token<'s> {
     ExclamationEqual(ExclamationEqual),
     GreaterThan(GreaterThan),
     GreaterThanEqual(GreaterThanEqual),
-    Hash(Hash<'s>),
+    Hash(HashMeta),
     HashLBrace(HashLBrace),
-    Ident(Ident<'s>),
+    Ident(IdentMeta),
     Indent(Indent),
     LBrace(LBrace),
     LBracket(LBracket),
@@ -65,11 +65,11 @@ pub enum Token<'s> {
     Linebreak(Linebreak),
     LParen(LParen),
     Minus(Minus),
-    Number(Number<'s>),
+    Number(NumberMeta),
     NumberSign(NumberSign),
     Percent(Percent),
-    Percentage(Percentage<'s>),
-    Placeholder(Placeholder<'s>),
+    Percentage(PercentageMeta),
+    Placeholder(PlaceholderMeta),
     Plus(Plus),
     PlusUnderscore(PlusUnderscore),
     Question(Question),
@@ -78,34 +78,318 @@ pub enum Token<'s> {
     RParen(RParen),
     Semicolon(Semicolon),
     Solidus(Solidus),
-    Str(Str<'s>),
-    StrTemplate(StrTemplate<'s>),
+    Str(StrMeta),
+    StrTemplate(StrTemplateMeta),
     Tilde(Tilde),
     TildeEqual(TildeEqual),
     Unknown(Unknown),
-    UrlRaw(UrlRaw<'s>),
-    UrlTemplate(UrlTemplate<'s>),
+    UrlRaw(UrlRawMeta),
+    UrlTemplate(UrlTemplateMeta),
 }
 
-#[derive(Clone, Debug, PartialEq)]
+pub type Token<'s> = TokenData;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
-pub struct TokenWithSpan<'s> {
-    pub token: Token<'s>,
+pub struct TokenWithSpanData {
+    pub token: TokenData,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+pub type TokenWithSpan<'s> = TokenWithSpanData;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+pub struct BadStrMeta {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+pub struct BacktickCodeMeta {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+pub struct IdentMeta {
+    pub escaped: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+pub struct HashMeta {
+    pub escaped: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+pub struct NumberMeta {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+pub struct DimensionMeta {
+    pub number_end: u32,
+    pub unit_escaped: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+pub struct PercentageMeta {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+pub struct PlaceholderMeta {
+    pub index: u32,
+    pub suffix_start: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+pub struct StrMeta {
+    pub escaped: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+pub struct StrTemplateMeta {
+    pub escaped: bool,
+    pub head: bool,
+    pub tail: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+pub struct UrlMeta {
+    pub escaped: bool,
+}
+
+pub type UrlRawMeta = UrlMeta;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+pub struct UrlTemplateMeta {
+    pub escaped: bool,
+    pub tail: bool,
+}
+
+impl TokenWithSpanData {
+    #[inline]
+    pub fn raw<'s>(&self, source: &'s str) -> &'s str {
+        &source[self.span.start..self.span.end]
+    }
+
+    #[inline]
+    pub fn bad_str<'s>(&self, source: &'s str) -> Option<BadStr<'s>> {
+        matches!(self.token, TokenData::BadStr(..)).then(|| BadStr { raw: self.raw(source) })
+    }
+
+    #[inline]
+    pub fn at_keyword<'s>(&self, source: &'s str) -> Option<AtKeyword<'s>> {
+        match self.token {
+            TokenData::AtKeyword(meta) => Some(AtKeyword {
+                ident: Ident {
+                    raw: &source[self.span.start + 1..self.span.end],
+                    escaped: meta.escaped,
+                },
+            }),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn at_l_brace_var<'s>(&self, source: &'s str) -> Option<AtLBraceVar<'s>> {
+        match self.token {
+            TokenData::AtLBraceVar(meta) => Some(AtLBraceVar {
+                ident: Ident {
+                    raw: &source[self.span.start + 2..self.span.end - 1],
+                    escaped: meta.escaped,
+                },
+            }),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn backtick_code<'s>(&self, source: &'s str) -> Option<BacktickCode<'s>> {
+        matches!(self.token, TokenData::BacktickCode(..))
+            .then(|| BacktickCode { raw: self.raw(source) })
+    }
+
+    #[inline]
+    pub fn dimension<'s>(&self, source: &'s str) -> Option<Dimension<'s>> {
+        match self.token {
+            TokenData::Dimension(meta) => {
+                let number_end = meta.number_end as usize;
+                Some(Dimension {
+                    value: Number { raw: &source[self.span.start..number_end] },
+                    unit: Ident {
+                        raw: &source[number_end..self.span.end],
+                        escaped: meta.unit_escaped,
+                    },
+                })
+            }
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn dimension_value_raw<'s>(&self, source: &'s str) -> Option<&'s str> {
+        match self.token {
+            TokenData::Dimension(meta) => Some(&source[self.span.start..meta.number_end as usize]),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn dollar_l_brace_var<'s>(&self, source: &'s str) -> Option<DollarLBraceVar<'s>> {
+        match self.token {
+            TokenData::DollarLBraceVar(meta) => Some(DollarLBraceVar {
+                ident: Ident {
+                    raw: &source[self.span.start + 2..self.span.end - 1],
+                    escaped: meta.escaped,
+                },
+            }),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn dollar_var<'s>(&self, source: &'s str) -> Option<DollarVar<'s>> {
+        match self.token {
+            TokenData::DollarVar(meta) => Some(DollarVar {
+                ident: Ident {
+                    raw: &source[self.span.start + 1..self.span.end],
+                    escaped: meta.escaped,
+                },
+            }),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn hash<'s>(&self, source: &'s str) -> Option<Hash<'s>> {
+        match self.token {
+            TokenData::Hash(meta) => Some(Hash {
+                raw: &source[self.span.start + 1..self.span.end],
+                escaped: meta.escaped,
+            }),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn hash_raw<'s>(&self, source: &'s str) -> Option<&'s str> {
+        matches!(self.token, TokenData::Hash(..))
+            .then(|| &source[self.span.start + 1..self.span.end])
+    }
+
+    #[inline]
+    pub fn ident<'s>(&self, source: &'s str) -> Option<Ident<'s>> {
+        match self.token {
+            TokenData::Ident(meta) => Some(Ident { raw: self.raw(source), escaped: meta.escaped }),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn ident_raw<'s>(&self, source: &'s str) -> Option<&'s str> {
+        matches!(self.token, TokenData::Ident(..)).then(|| self.raw(source))
+    }
+
+    #[inline]
+    pub fn is_ident_raw(&self, source: &str, expected: &str) -> bool {
+        self.ident_raw(source).is_some_and(|raw| raw == expected)
+    }
+
+    #[inline]
+    pub fn is_ident_raw_starts_with(&self, source: &str, prefix: &str) -> bool {
+        self.ident_raw(source).is_some_and(|raw| raw.starts_with(prefix))
+    }
+
+    #[inline]
+    pub fn is_ident_name_eq_ignore_ascii_case(&self, source: &str, expected: &str) -> bool {
+        self.ident(source).is_some_and(|ident| ident.name().eq_ignore_ascii_case(expected))
+    }
+
+    #[inline]
+    pub fn number<'s>(&self, source: &'s str) -> Option<Number<'s>> {
+        matches!(self.token, TokenData::Number(..)).then(|| Number { raw: self.raw(source) })
+    }
+
+    #[inline]
+    pub fn number_raw<'s>(&self, source: &'s str) -> Option<&'s str> {
+        matches!(self.token, TokenData::Number(..)).then(|| self.raw(source))
+    }
+
+    #[inline]
+    pub fn percentage<'s>(&self, source: &'s str) -> Option<Percentage<'s>> {
+        matches!(self.token, TokenData::Percentage(..)).then(|| Percentage {
+            value: Number { raw: &source[self.span.start..self.span.end - 1] },
+        })
+    }
+
+    #[inline]
+    pub fn placeholder<'s>(&self, source: &'s str) -> Option<Placeholder<'s>> {
+        match self.token {
+            TokenData::Placeholder(meta) => Some(Placeholder {
+                index: meta.index,
+                suffix: &source[meta.suffix_start as usize..self.span.end],
+            }),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn str<'s>(&self, source: &'s str) -> Option<Str<'s>> {
+        match self.token {
+            TokenData::Str(meta) => Some(Str { raw: self.raw(source), escaped: meta.escaped }),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn str_template<'s>(&self, source: &'s str) -> Option<StrTemplate<'s>> {
+        match self.token {
+            TokenData::StrTemplate(meta) => Some(StrTemplate {
+                raw: self.raw(source),
+                escaped: meta.escaped,
+                head: meta.head,
+                tail: meta.tail,
+            }),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn url_raw<'s>(&self, source: &'s str) -> Option<UrlRaw<'s>> {
+        match self.token {
+            TokenData::UrlRaw(meta) => {
+                Some(UrlRaw { raw: self.raw(source), escaped: meta.escaped })
+            }
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn url_template<'s>(&self, source: &'s str) -> Option<UrlTemplate<'s>> {
+        match self.token {
+            TokenData::UrlTemplate(meta) => {
+                Some(UrlTemplate { raw: self.raw(source), escaped: meta.escaped, tail: meta.tail })
+            }
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Ampersand {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Asterisk {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct AsteriskEqual {}
@@ -113,19 +397,19 @@ pub struct AsteriskEqual {}
 /// CSS Syntax `<bad-string-token>`: a string terminated by a newline or EOF
 /// instead of its quote. Not a tokenizer error in CSS — it is a preserved
 /// token that raw component-value contexts keep verbatim.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct BadStr<'s> {
     pub raw: &'s str,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct At {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct AtKeyword<'s> {
@@ -146,73 +430,73 @@ pub struct Placeholder<'s> {
     pub suffix: &'s str,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct AtLBraceVar<'s> {
     pub ident: Ident<'s>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct BacktickCode<'s> {
     pub raw: &'s str,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Bar {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct BarBar {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct BarEqual {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct CaretEqual {}
 
 /// `-->`
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Cdc {}
 
 /// `<!--`
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Cdo {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Colon {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct ColonColon {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Comma {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Dedent {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Dimension<'s> {
@@ -220,71 +504,71 @@ pub struct Dimension<'s> {
     pub unit: Ident<'s>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct DollarEqual {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct DollarLBraceVar<'s> {
     pub ident: Ident<'s>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct DollarVar<'s> {
     pub ident: Ident<'s>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Dot {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct DotDotDot {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Eof {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Equal {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct EqualEqual {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Exclamation {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct ExclamationEqual {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct GreaterThan {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct GreaterThanEqual {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Hash<'s> {
@@ -293,12 +577,12 @@ pub struct Hash<'s> {
     pub escaped: bool,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct HashLBrace {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Ident<'s> {
@@ -306,47 +590,47 @@ pub struct Ident<'s> {
     pub raw: &'s str,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Indent {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct LBrace {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct LBracket {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct LessThan {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct LessThanEqual {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Linebreak {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct LParen {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Minus {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Number<'s> {
@@ -354,64 +638,64 @@ pub struct Number<'s> {
 }
 
 /// U+0023 `#`
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct NumberSign {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Percent {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Percentage<'s> {
     pub value: Number<'s>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Plus {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct PlusUnderscore {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Question {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct RBrace {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct RBracket {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct RParen {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Semicolon {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Solidus {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Str<'s> {
@@ -419,7 +703,7 @@ pub struct Str<'s> {
     pub escaped: bool,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct StrTemplate<'s> {
@@ -429,12 +713,12 @@ pub struct StrTemplate<'s> {
     pub tail: bool,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Tilde {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct TildeEqual {}
@@ -443,12 +727,12 @@ pub struct TildeEqual {}
 /// character, ...). CSS Syntax calls this a `<delim-token>`: it is not an
 /// error at the tokenizer level, and raw component-value contexts (custom
 /// property values, unparsable declaration values) preserve it verbatim.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct Unknown {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct UrlRaw<'s> {
@@ -456,11 +740,19 @@ pub struct UrlRaw<'s> {
     pub escaped: bool,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "kind", rename_all = "camelCase"))]
 pub struct UrlTemplate<'s> {
     pub raw: &'s str,
     pub escaped: bool,
     pub tail: bool,
+}
+
+#[cfg(test)]
+mod test {
+    use super::{TokenData, TokenWithSpanData};
+
+    const _: () = assert!(size_of::<TokenData>() <= 12);
+    const _: () = assert!(size_of::<TokenWithSpanData>() <= 32);
 }


### PR DESCRIPTION
Compacts CSS parser tokens into span-backed metadata and materializes rich token payloads from source when needed.

Validated with `cargo check -p oxc-css-parser`, `cargo test -p oxc-css-parser --lib --tests`, `cargo test -p oxc-css-parser --features serialize`, and `cargo check -p oxc-css-parser --features serialize --examples`.