### PR TITLE
refactor: remove redundant clones on Copy types

### DIFF
--- a/crates/oxc_css_parser/src/parser/at_rule/container.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/container.rs
@@ -17,14 +17,14 @@ impl<'a> Parse<'a> for ContainerCondition<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if input.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(input.source, "not") {
             let container_condition_not = input.parse::<ContainerConditionNot>()?;
-            let span = container_condition_not.span.clone();
+            let span = container_condition_not.span;
             Ok(ContainerCondition {
                 conditions: input.vec1(ContainerConditionKind::Not(container_condition_not)),
                 span,
             })
         } else {
             let first = input.parse::<QueryInParens>()?;
-            let mut span = first.span.clone();
+            let mut span = first.span;
             let mut conditions = input.vec1(ContainerConditionKind::QueryInParens(first));
             // formally `and`/`or` may not mix without parens and `not`
             // is leading-only, but real-world code (less.js) chains them
@@ -139,14 +139,14 @@ impl<'a> Parse<'a> for StyleCondition<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         if input.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(input.source, "not") {
             let style_condition_not = input.parse::<StyleConditionNot>()?;
-            let span = style_condition_not.span.clone();
+            let span = style_condition_not.span;
             Ok(StyleCondition {
                 conditions: input.vec1(StyleConditionKind::Not(style_condition_not)),
                 span,
             })
         } else {
             let first = input.parse::<StyleInParens>()?;
-            let mut span = first.span.clone();
+            let mut span = first.span;
             let mut conditions = input.vec1(StyleConditionKind::StyleInParens(first));
             let peek = input.cursor.peek()?;
             if peek.ident(input.source).is_some() {
@@ -262,7 +262,7 @@ impl<'a> Parse<'a> for StyleQuery<'a> {
                     Ok(name)
                 }
                 _ => {
-                    let span = p.cursor.peek()?.span.clone();
+                    let span = p.cursor.peek()?.span;
                     Err(Error { kind: ErrorKind::TryParseError, span })
                 }
             }
@@ -302,7 +302,7 @@ impl<'a> Parse<'a> for ContainerPrelude<'a> {
             ident => Ok(ident),
         });
         let condition = input.parse::<ContainerCondition>()?;
-        let mut span = condition.span().clone();
+        let mut span = *condition.span();
         if let Ok(name) = &name {
             span.start = name.span().start;
         }

--- a/crates/oxc_css_parser/src/parser/at_rule/counter_style.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/counter_style.rs
@@ -16,10 +16,8 @@ impl<'a> Parser<'a> {
                 if util::is_css_wide_keyword(ident.name)
                     || ident.name.eq_ignore_ascii_case("none") =>
             {
-                self.recoverable_errors.push(Error {
-                    kind: ErrorKind::CSSWideKeywordDisallowed,
-                    span: ident.span.clone(),
-                });
+                self.recoverable_errors
+                    .push(Error { kind: ErrorKind::CSSWideKeywordDisallowed, span: ident.span });
             }
             _ => {}
         }

--- a/crates/oxc_css_parser/src/parser/at_rule/document.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/document.rs
@@ -8,7 +8,7 @@ use crate::{Parse, ast::*, error::PResult};
 impl<'a> Parse<'a> for DocumentPrelude<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<DocumentPreludeMatcher>()?;
-        let mut span = first.span().clone();
+        let mut span = *first.span();
 
         let mut matchers = input.vec1(first);
         let mut comma_spans = input.vec();

--- a/crates/oxc_css_parser/src/parser/at_rule/font_feature_values.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/font_feature_values.rs
@@ -11,7 +11,7 @@ impl<'a> Parse<'a> for FontFamilyName<'a> {
             Token::Str(..) | Token::StrTemplate(..) => input.parse().map(FontFamilyName::Str),
             _ => {
                 let first = input.parse::<InterpolableIdent>()?;
-                let mut span = first.span().clone();
+                let mut span = *first.span();
 
                 let mut idents = input.vec1(first);
                 while let Token::Ident(..) | Token::HashLBrace(..) | Token::AtLBraceVar(..) =

--- a/crates/oxc_css_parser/src/parser/at_rule/import.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/import.rs
@@ -57,7 +57,7 @@ impl<'a> Parse<'a> for ImportPrelude<'a> {
                 Err(error) => return Err(error),
             },
         };
-        let mut span = href.span().clone();
+        let mut span = *href.span();
 
         let structured = input.try_parse(Self::parse_structured_tail);
         let (layer, supports, media, modifiers) = match structured {
@@ -78,7 +78,7 @@ impl<'a> Parse<'a> for ImportPrelude<'a> {
                     span,
                 })) = values.last()
                 {
-                    return Err(Error { kind: ErrorKind::ExpectRule, span: span.clone() });
+                    return Err(Error { kind: ErrorKind::ExpectRule, span: *span });
                 }
                 let end = values.last().map_or(start, |value| value.span().end);
                 (None, None, None, Some(ComponentValues { values, span: Span { start, end } }))
@@ -169,7 +169,7 @@ impl<'a> ImportPrelude<'a> {
         if at_import_prelude_end(&input.cursor.peek()?.token) {
             Ok((layer, supports.ok(), media))
         } else {
-            let span = input.cursor.peek()?.span.clone();
+            let span = input.cursor.peek()?.span;
             Err(Error { kind: ErrorKind::TryParseError, span })
         }
     }

--- a/crates/oxc_css_parser/src/parser/at_rule/keyframes.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/keyframes.rs
@@ -49,7 +49,7 @@ impl<'a> Parse<'a> for KeyframeSelector<'a> {
                     {
                         input.recoverable_errors.push(Error {
                             kind: ErrorKind::UnknownKeyframeSelectorIdent,
-                            span: ident.span.clone(),
+                            span: ident.span,
                         });
                     }
                     _ => {}
@@ -76,7 +76,7 @@ impl<'a> Parse<'a> for KeyframesName<'a> {
                     {
                         input.recoverable_errors.push(Error {
                             kind: ErrorKind::CSSWideKeywordDisallowed,
-                            span: ident.span.clone(),
+                            span: ident.span,
                         });
                     }
                     _ => {}

--- a/crates/oxc_css_parser/src/parser/at_rule/layer.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/layer.rs
@@ -15,7 +15,7 @@ use crate::{
 impl<'a> Parse<'a> for LayerNames<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<LayerName>()?;
-        let mut span = first.span.clone();
+        let mut span = first.span;
 
         let mut names = input.vec1(first);
         let mut comma_spans = input.vec();
@@ -60,7 +60,7 @@ impl<'a> Parse<'a> for LayerName<'a> {
         if let Some(invalid_ident) = invalid_ident {
             input.recoverable_errors.push(Error {
                 kind: crate::error::ErrorKind::CSSWideKeywordDisallowed,
-                span: invalid_ident.span().clone(),
+                span: *invalid_ident.span(),
             });
         }
 

--- a/crates/oxc_css_parser/src/parser/at_rule/media.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/media.rs
@@ -61,7 +61,7 @@ impl<'a> Parse<'a> for MediaFeature<'a> {
                     ComponentValue::InterpolableIdent(ident),
                 ),
                 _ => {
-                    let span = ident.span().clone();
+                    let span = *ident.span();
                     Ok(MediaFeature::Boolean(MediaFeatureBoolean {
                         name: MediaFeatureName::Ident(ident),
                         span,
@@ -69,14 +69,14 @@ impl<'a> Parse<'a> for MediaFeature<'a> {
                 }
             },
             ComponentValue::SassVariable(variable) => {
-                let span = variable.span.clone();
+                let span = variable.span;
                 Ok(MediaFeature::Boolean(MediaFeatureBoolean {
                     name: MediaFeatureName::SassVariable(variable),
                     span,
                 }))
             }
             ComponentValue::PostcssSimpleVar(variable) => {
-                let span = variable.span.clone();
+                let span = variable.span;
                 Ok(MediaFeature::Boolean(MediaFeatureBoolean {
                     name: MediaFeatureName::PostcssSimpleVar(variable),
                     span,
@@ -127,7 +127,7 @@ impl<'a> Parse<'a> for MediaInParens<'a> {
             && let InterpolableIdent::SassInterpolated(interpolation) =
                 input.parse_sass_interpolated_ident()?
         {
-            let span = interpolation.span.clone();
+            let span = interpolation.span;
             return Ok(MediaInParens {
                 kind: MediaInParensKind::SassInterpolation(interpolation),
                 span,
@@ -154,7 +154,7 @@ impl<'a> Parse<'a> for MediaInParensKind<'a> {
             if matches!(&parser.cursor.peek()?.token, Token::RParen(..)) {
                 Ok(media_condition)
             } else {
-                let span = parser.cursor.peek()?.span.clone();
+                let span = parser.cursor.peek()?.span;
                 Err(Error { kind: ErrorKind::ExpectMediaFeatureName, span })
             }
         }) {
@@ -164,7 +164,7 @@ impl<'a> Parse<'a> for MediaInParensKind<'a> {
             if matches!(&parser.cursor.peek()?.token, Token::RParen(..)) {
                 Ok(media_feature)
             } else {
-                let span = parser.cursor.peek()?.span.clone();
+                let span = parser.cursor.peek()?.span;
                 Err(Error { kind: ErrorKind::ExpectMediaFeatureName, span })
             }
         }) {
@@ -248,7 +248,7 @@ impl<'a> Parse<'a> for MediaQuery<'a> {
 impl<'a> Parse<'a> for MediaQueryList<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<MediaQuery>()?;
-        let mut span = first.span().clone();
+        let mut span = *first.span();
 
         let mut queries = input.vec1(first);
         let mut comma_spans = input.vec();
@@ -291,7 +291,7 @@ impl<'a> Parse<'a> for MediaQueryWithType<'a> {
         {
             input.recoverable_errors.push(Error {
                 kind: ErrorKind::MediaTypeKeywordDisallowed(name.to_string()),
-                span: span.clone(),
+                span: *span,
             });
         }
         let condition =
@@ -301,7 +301,7 @@ impl<'a> Parse<'a> for MediaQueryWithType<'a> {
                 None
             };
 
-        let mut span = media_type.span().clone();
+        let mut span = *media_type.span();
         if let Some(modifier) = &modifier {
             span.start = modifier.span.start;
         }
@@ -328,11 +328,11 @@ impl<'a> Parser<'a> {
         };
         if relax_bare_ident {
             let token = self.cursor.bump()?;
-            let span = token.span.clone();
+            let span = token.span;
             return Ok(MediaInParens {
                 kind: MediaInParensKind::GeneralEnclosed(TokenSeq {
                     tokens: self.vec1(token),
-                    span: span.clone(),
+                    span,
                 }),
                 span,
             });
@@ -349,7 +349,7 @@ impl<'a> Parser<'a> {
     ) -> PResult<MediaCondition<'a>> {
         if self.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(self.source, "not") {
             let media_not = self.parse::<MediaNot>()?;
-            let span = media_not.span.clone();
+            let span = media_not.span;
             Ok(MediaCondition { conditions: self.vec1(MediaConditionKind::Not(media_not)), span })
         } else {
             let first = if after_logic_keyword {
@@ -357,7 +357,7 @@ impl<'a> Parser<'a> {
             } else {
                 self.parse::<MediaInParens>()?
             };
-            let mut span = first.span.clone();
+            let mut span = first.span;
             let mut conditions = self.vec1(MediaConditionKind::MediaInParens(first));
             let peek = self.cursor.peek()?;
             if peek.ident(self.source).is_some() {
@@ -448,7 +448,7 @@ impl<'a> Parser<'a> {
             {
                 self.recoverable_errors.push(Error {
                     kind: ErrorKind::ExpectMediaFeatureName,
-                    span: name_or_right.span().clone(),
+                    span: *name_or_right.span(),
                 });
             }
             let span = Span { start: left.span().start, end: name_or_right.span().end };

--- a/crates/oxc_css_parser/src/parser/at_rule/mod.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/mod.rs
@@ -77,14 +77,14 @@ impl<'a> Parse<'a> for AtRule<'a> {
                             if has_substitution {
                                 Ok(raw)
                             } else {
-                                let span = p.cursor.peek()?.span.clone();
+                                let span = p.cursor.peek()?.span;
                                 Err(Error { kind: ErrorKind::TryParseError, span })
                             }
                         })
                     } else {
                         Err(Error {
                             kind: ErrorKind::TryParseError,
-                            span: input.cursor.peek()?.span.clone(),
+                            span: input.cursor.peek()?.span,
                         })
                     };
                     match raw {
@@ -146,10 +146,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
                         if prelude.paths.len() > 1 {
                             Ok(prelude)
                         } else {
-                            Err(Error {
-                                kind: ErrorKind::TryParseError,
-                                span: prelude.span.clone(),
-                            })
+                            Err(Error { kind: ErrorKind::TryParseError, span: prelude.span })
                         }
                     });
                     if let Ok(prelude) = multi_path {
@@ -224,10 +221,9 @@ impl<'a> Parse<'a> for AtRule<'a> {
             if let Some(block) = &block
                 && matches!(&prelude, Some(AtRulePrelude::Layer(names)) if names.names.len() > 1)
             {
-                input.recoverable_errors.push(Error {
-                    kind: ErrorKind::UnexpectedSimpleBlock,
-                    span: block.span.clone(),
-                });
+                input
+                    .recoverable_errors
+                    .push(Error { kind: ErrorKind::UnexpectedSimpleBlock, span: block.span });
             }
             let end = block
                 .as_ref()
@@ -250,7 +246,7 @@ impl<'a> Parse<'a> for AtRule<'a> {
                                 if matches!(p.cursor.peek()?.token, Token::Comma(..)) {
                                     Ok(())
                                 } else {
-                                    let span = p.cursor.peek()?.span.clone();
+                                    let span = p.cursor.peek()?.span;
                                     Err(Error { kind: ErrorKind::TryParseError, span })
                                 }
                             })
@@ -607,7 +603,7 @@ impl<'a> Parser<'a> {
                 | Token::Linebreak(..)
                 | Token::Eof(..) => Ok(value),
                 _ => {
-                    let span = p.cursor.peek()?.span.clone();
+                    let span = p.cursor.peek()?.span;
                     Err(Error { kind: ErrorKind::TryParseError, span })
                 }
             }

--- a/crates/oxc_css_parser/src/parser/at_rule/namespace.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/namespace.rs
@@ -27,7 +27,7 @@ impl<'a> Parse<'a> for NamespacePrelude<'a> {
             _ => input.parse().map(NamespacePreludeUri::Url)?,
         };
 
-        let mut span = uri.span().clone();
+        let mut span = *uri.span();
         if let Some(prefix) = &prefix {
             span.start = prefix.span().start;
         }

--- a/crates/oxc_css_parser/src/parser/at_rule/page.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/page.rs
@@ -50,7 +50,7 @@ impl<'a> Parse<'a> for PageSelector<'a> {
 impl<'a> Parse<'a> for PageSelectorList<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<PageSelector>()?;
-        let mut span = first.span.clone();
+        let mut span = first.span;
 
         let mut selectors = input.vec1(first);
         let mut comma_spans = input.vec();

--- a/crates/oxc_css_parser/src/parser/at_rule/supports.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/supports.rs
@@ -22,13 +22,13 @@ impl<'a> Parse<'a> for SupportsCondition<'a> {
                 conditions: input.vec1(SupportsConditionKind::Not(SupportsNot {
                     keyword,
                     condition,
-                    span: span.clone(),
+                    span,
                 })),
                 span,
             })
         } else {
             let first = input.parse::<SupportsInParens>()?;
-            let mut span = first.span().clone();
+            let mut span = *first.span();
             let mut conditions = input.vec1(SupportsConditionKind::SupportsInParens(first));
             while input.cursor.peek()?.ident(input.source).is_some() {
                 if input.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(input.source, "and") {
@@ -76,7 +76,7 @@ impl<'a> Parse<'a> for SupportsInParens<'a> {
             TokenWithSpan { token: Token::LParen(..), .. } => input
                 .try_parse(|parser| {
                     parser.parse::<SupportsDecl>().map(|supports_decl| {
-                        let span = supports_decl.span.clone();
+                        let span = supports_decl.span;
                         SupportsInParens {
                             kind: SupportsInParensKind::Feature(parser.alloc(supports_decl)),
                             span,
@@ -118,7 +118,7 @@ impl<'a> Parse<'a> for SupportsInParens<'a> {
                         input.cursor.expect_l_paren()?;
                         let selector_list = input.parse::<SelectorList>()?;
                         input.cursor.expect_r_paren()?;
-                        let span = selector_list.span.clone();
+                        let span = selector_list.span;
                         Ok(SupportsInParens {
                             kind: SupportsInParensKind::Selector(selector_list),
                             span,
@@ -145,13 +145,13 @@ impl<'a> Parse<'a> for SupportsInParens<'a> {
                             // An unknown function here is `<general-enclosed>`
                             // (css-conditional): its contents are raw tokens.
                             let function = input.parse_raw_function(name)?;
-                            let span = function.span.clone();
+                            let span = function.span;
                             Ok(SupportsInParens {
                                 kind: SupportsInParensKind::Function(function),
                                 span,
                             })
                         } else if pure_interpolation {
-                            let span = name.span().clone();
+                            let span = *name.span();
                             Ok(SupportsInParens {
                                 kind: SupportsInParensKind::Interpolation(name),
                                 span,
@@ -160,16 +160,15 @@ impl<'a> Parse<'a> for SupportsInParens<'a> {
                             let TokenWithSpan { token, span } = input.cursor.peek()?;
                             Err(Error {
                                 kind: ErrorKind::Unexpected("'('", token.symbol()),
-                                span: span.clone(),
+                                span: *span,
                             })
                         }
                     }
                 }
             }
-            TokenWithSpan { token, span } => Err(Error {
-                kind: ErrorKind::Unexpected("'('", token.symbol()),
-                span: span.clone(),
-            }),
+            TokenWithSpan { token, span } => {
+                Err(Error { kind: ErrorKind::Unexpected("'('", token.symbol()), span: *span })
+            }
         }
     }
 }

--- a/crates/oxc_css_parser/src/parser/convert.rs
+++ b/crates/oxc_css_parser/src/parser/convert.rs
@@ -116,7 +116,7 @@ impl<'a> TryFrom<(token::Number<'a>, Span)> for Number<'a> {
         token
             .raw
             .parse()
-            .map_err(|_| Error { kind: ErrorKind::InvalidNumber, span: span.clone() })
+            .map_err(|_| Error { kind: ErrorKind::InvalidNumber, span })
             .map(|value| Self { value, raw: token.raw, span })
     }
 }

--- a/crates/oxc_css_parser/src/parser/less.rs
+++ b/crates/oxc_css_parser/src/parser/less.rs
@@ -138,7 +138,7 @@ impl<'a> Parser<'a> {
                         // special case:
                         // `when ((8 + 6) > 13)`
                         // the `(8 + 6)` above is operation, not condition
-                        Err(Error { kind: ErrorKind::TryParseError, span: span.clone() })
+                        Err(Error { kind: ErrorKind::TryParseError, span: *span })
                     }
                     _ => condition,
                 },
@@ -231,14 +231,14 @@ impl<'a> Parser<'a> {
                 let (ident, ident_span) = self.cursor.expect_ident()?;
                 (
                     LessInterpolatedIdentElement::Static(
-                        self.interpolable_ident_static_part(ident, ident_span.clone()),
+                        self.interpolable_ident_static_part(ident, ident_span),
                     ),
                     ident_span,
                 )
             }
             TokenWithSpan { token: Token::AtLBraceVar(..), .. } => {
                 let interpolation = self.parse::<LessVariableInterpolation>()?;
-                let span = interpolation.span.clone();
+                let span = interpolation.span;
                 (LessInterpolatedIdentElement::Variable(interpolation), span)
             }
             TokenWithSpan { token: Token::DollarLBraceVar(..), .. }
@@ -248,13 +248,13 @@ impl<'a> Parser<'a> {
                 ) =>
             {
                 let interpolation = self.parse::<LessPropertyInterpolation>()?;
-                let span = interpolation.span.clone();
+                let span = interpolation.span;
                 (LessInterpolatedIdentElement::Property(interpolation), span)
             }
             TokenWithSpan { token, span } => {
                 return Err(Error {
                     kind: ErrorKind::ExpectOneOf(vec!["<ident>", "@{"], token.symbol()),
-                    span: span.clone(),
+                    span: *span,
                 });
             }
         };
@@ -406,7 +406,7 @@ impl<'a> Parser<'a> {
                     {
                         self.recoverable_errors.push(Error {
                             kind: ErrorKind::UnexpectedLessMixinCall,
-                            span: mixin_call.span.clone(),
+                            span: mixin_call.span,
                         });
                     }
                     value
@@ -493,10 +493,7 @@ impl<'a> Parser<'a> {
                         let span = Span { start: number_span.start + 1, end: number_span.end };
                         let raw = unsafe { number.raw.get_unchecked(1..number.raw.len()) };
                         raw.parse()
-                            .map_err(|_| Error {
-                                kind: ErrorKind::InvalidNumber,
-                                span: span.clone(),
-                            })
+                            .map_err(|_| Error { kind: ErrorKind::InvalidNumber, span })
                             .map(|value| ComponentValue::Number(Number { value, raw, span }))?
                     };
                     left = ComponentValue::LessBinaryOperation(LessBinaryOperation {
@@ -627,7 +624,7 @@ impl<'a> Parser<'a> {
             // selector." — a guard on a selector list is rejected whether
             // the comma comes before or after the `when`.
             if selector_list.selectors.len() > 1 {
-                let span = self.cursor.peek()?.span.clone();
+                let span = self.cursor.peek()?.span;
                 return Err(Error { kind: ErrorKind::LessGuardOnMultipleComplexSelectors, span });
             }
             let guard = self.parse::<LessConditions>()?;
@@ -656,13 +653,13 @@ impl<'a> Parser<'a> {
             let hex_color = parser.parse::<HexColor>()?;
             match parser.cursor.peek()? {
                 TokenWithSpan { token: Token::LParen(..), span } => {
-                    Err(Error { kind: ErrorKind::TryParseError, span: span.clone() })
+                    Err(Error { kind: ErrorKind::TryParseError, span: *span })
                 }
                 TokenWithSpan {
                     token: Token::LBracket(..) | Token::Dot(..) | Token::Hash(..),
                     span,
                 } if hex_color.span.end == span.start => {
-                    Err(Error { kind: ErrorKind::TryParseError, span: span.clone() })
+                    Err(Error { kind: ErrorKind::TryParseError, span: *span })
                 }
                 _ => Ok(hex_color),
             }
@@ -777,7 +774,7 @@ impl<'a> Parse<'a> for LessConditions<'a> {
         };
 
         let first = input.parse_less_condition(true)?;
-        let mut span = first.span().clone();
+        let mut span = *first.span();
 
         let mut conditions = input.vec1(first);
         let mut comma_spans = input.vec();
@@ -810,7 +807,7 @@ impl<'a> Parse<'a> for LessConditions<'a> {
 impl<'a> Parse<'a> for LessDetachedRuleset<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let block = input.parse::<SimpleBlock>()?;
-        let span = block.span.clone();
+        let span = block.span;
         Ok(LessDetachedRuleset { block, span })
     }
 }
@@ -837,7 +834,7 @@ impl<'a> Parse<'a> for LessExtend<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let mut selector = input.parse::<ComplexSelector>()?;
 
-        let span = selector.span.clone();
+        let span = selector.span;
         let mut all = None;
 
         if let [
@@ -860,11 +857,7 @@ impl<'a> Parse<'a> for LessExtend<'a> {
                 })),
             ] = &children[..]
         {
-            all = Some(Ident {
-                name: token_all.name,
-                raw: token_all.raw,
-                span: token_all.span.clone(),
-            });
+            all = Some(Ident { name: token_all.name, raw: token_all.raw, span: token_all.span });
             selector.span.end = complex_child.span().end;
             let len = selector.children.len();
             selector.children.truncate(len - 2);
@@ -880,7 +873,7 @@ impl<'a> Parse<'a> for LessExtendList<'a> {
         debug_assert_eq!(input.syntax, Syntax::Less);
 
         let first = input.parse::<LessExtend>()?;
-        let mut span = first.span.clone();
+        let mut span = first.span;
 
         let mut elements = input.vec1(first);
         let mut comma_spans = input.vec();
@@ -997,7 +990,7 @@ impl<'a> Parse<'a> for LessInterpolatedStr<'a> {
         let (first, first_span) = input.cursor.expect_str_template()?;
         let quote = first.raw.bytes().next().unwrap();
         debug_assert!(quote == b'\'' || quote == b'"');
-        let mut span = first_span.clone();
+        let mut span = first_span;
         let mut elements = input.vec1(LessInterpolatedStrElement::Static(
             input.interpolable_str_static_part(first, first_span),
         ));
@@ -1122,7 +1115,7 @@ impl<'a> Parse<'a> for LessLookups<'a> {
         debug_assert_eq!(input.syntax, Syntax::Less);
 
         let first = input.parse::<LessLookup>()?;
-        let mut span = first.span.clone();
+        let mut span = first.span;
 
         let mut lookups = input.vec1(first);
         while let Token::LBracket(..) = input.cursor.peek()?.token {
@@ -1252,7 +1245,7 @@ impl<'a> Parse<'a> for LessMixinCall<'a> {
                             comma_spans,
                             semicolon_comes_at,
                         )
-                        .map_err(|kind| Error { kind, span: span.clone() })?;
+                        .map_err(|kind| Error { kind, span })?;
                         semicolon_comes_at = args.len();
                         semicolon_spans.push(span);
                     }
@@ -1346,7 +1339,7 @@ impl<'a> Parser<'a> {
                                 LessMixinParameterName::PropertyVariable(property)
                             }
                             value => {
-                                let span = value.span().clone();
+                                let span = *value.span();
                                 params.push(LessMixinParameter::Unnamed(
                                     LessMixinUnnamedParameter { value, span },
                                 ));
@@ -1388,7 +1381,7 @@ impl<'a> Parser<'a> {
                         (_, rparen_span) = self.cursor.expect_r_paren()?;
                         break 'params;
                     } else {
-                        let span = name_span.clone();
+                        let span = *name_span;
                         params.push(LessMixinParameter::Named(LessMixinNamedParameter {
                             name,
                             value: None,
@@ -1434,7 +1427,7 @@ impl<'a> Parser<'a> {
                         comma_spans,
                         semicolon_comes_at,
                     )
-                    .map_err(|kind| Error { kind, span: span.clone() })?;
+                    .map_err(|kind| Error { kind, span })?;
                     semicolon_comes_at = params.len();
                     semicolon_spans.push(span);
                 }
@@ -1477,13 +1470,10 @@ impl<'a> Parser<'a> {
 impl<'a> Parse<'a> for LessMixinCallee<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first_name = input.parse::<LessMixinName>()?;
-        let mut span = first_name.span().clone();
+        let mut span = *first_name.span();
 
-        let mut children = input.vec1(LessMixinCalleeChild {
-            name: first_name,
-            combinator: None,
-            span: span.clone(),
-        });
+        let mut children =
+            input.vec1(LessMixinCalleeChild { name: first_name, combinator: None, span });
         loop {
             let combinator = input
                 .cursor
@@ -1579,7 +1569,7 @@ impl<'a> Parse<'a> for LessMixinName<'a> {
                 {
                     input
                         .recoverable_errors
-                        .push(Error { kind: ErrorKind::InvalidIdSelectorName, span: span.clone() });
+                        .push(Error { kind: ErrorKind::InvalidIdSelectorName, span });
                 }
                 let name =
                     if hash.escaped { util::handle_escape_in(raw, input.allocator) } else { raw };
@@ -1654,7 +1644,7 @@ impl<'a> Parse<'a> for LessNegativeValue<'a> {
             TokenWithSpan { token, span } => {
                 return Err(Error {
                     kind: ErrorKind::ExpectOneOf(vec!["<at-keyword>", "$var", "("], token.symbol()),
-                    span: span.clone(),
+                    span: *span,
                 });
             }
         };
@@ -1804,7 +1794,7 @@ impl<'a> Parse<'a> for LessVariableDeclaration<'a> {
                     &p.cursor.peek()?.token,
                     Token::Semicolon(..) | Token::RBrace(..) | Token::Eof(..)
                 ) {
-                    let span = p.cursor.peek()?.span.clone();
+                    let span = p.cursor.peek()?.span;
                     return Err(Error { kind: ErrorKind::TryParseError, span });
                 }
                 Ok(value)
@@ -1909,7 +1899,7 @@ fn wrap_less_mixin_params_into_less_list<'a>(
         let list = ComponentValue::LessList(LessList {
             elements,
             comma_spans: Some(comma_spans),
-            span: list_span.clone(),
+            span: list_span,
         });
         params.push(match head {
             Some((name, colon_span)) => LessMixinParameter::Named(LessMixinNamedParameter {

--- a/crates/oxc_css_parser/src/parser/mod.rs
+++ b/crates/oxc_css_parser/src/parser/mod.rs
@@ -677,7 +677,7 @@ impl<'a> Parser<'a> {
         let tokenizer_state = self.cursor.tokenizer.state.clone();
         let comments_count = self.cursor.tokenizer.comments_count();
         let recoverable_errors_count = self.recoverable_errors.len();
-        let cached_token = self.cursor.cached_token.clone();
+        let cached_token = self.cursor.cached_token;
         let sass_pending_indents = self.sass_pending_indents;
         let result = f(self);
         if result.is_err() {

--- a/crates/oxc_css_parser/src/parser/sass.rs
+++ b/crates/oxc_css_parser/src/parser/sass.rs
@@ -212,10 +212,7 @@ impl<'a> Parser<'a> {
                             let span = Span { start: number_span.start + 1, end: number_span.end };
                             let raw = unsafe { number.raw.get_unchecked(1..number.raw.len()) };
                             raw.parse()
-                                .map_err(|_| Error {
-                                    kind: ErrorKind::InvalidNumber,
-                                    span: span.clone(),
-                                })
+                                .map_err(|_| Error { kind: ErrorKind::InvalidNumber, span })
                                 .map(|value| ComponentValue::Number(Number { value, raw, span }))?
                         };
                         left = ComponentValue::SassBinaryExpression(SassBinaryExpression {
@@ -482,7 +479,7 @@ impl<'a> Parser<'a> {
         let mut end = None;
         while let Some((_, exclamation_span)) = self.cursor.eat_exclamation()? {
             let keyword = self.parse::<Ident>()?;
-            let keyword_span = keyword.span.clone();
+            let keyword_span = keyword.span;
             util::assert_no_ws_or_comment(&exclamation_span, &keyword_span)?;
             end = Some(keyword_span.end);
 
@@ -490,7 +487,7 @@ impl<'a> Parser<'a> {
             if !matches!(keyword.name, "default" | "global") {
                 self.recoverable_errors.push(Error {
                     kind: ErrorKind::InvalidSassFlagName(keyword.name.to_string()),
-                    span: keyword.span.clone(),
+                    span: keyword.span,
                 });
             }
 
@@ -513,7 +510,7 @@ impl<'a> Parser<'a> {
                 let (ident, ident_span) = self.cursor.expect_ident()?;
                 (
                     SassInterpolatedIdentElement::Static(
-                        self.interpolable_ident_static_part(ident, ident_span.clone()),
+                        self.interpolable_ident_static_part(ident, ident_span),
                     ),
                     ident_span,
                 )
@@ -524,7 +521,7 @@ impl<'a> Parser<'a> {
             TokenWithSpan { token, span } => {
                 return Err(Error {
                     kind: ErrorKind::ExpectOneOf(vec!["<ident>", "#{"], token.symbol()),
-                    span: span.clone(),
+                    span: *span,
                 });
             }
         };
@@ -725,7 +722,7 @@ impl<'a> Parser<'a> {
             let token_with_span = self.cursor.bump()?;
             match token_with_span.token {
                 Token::Comma(..) => {
-                    let span = name.span.clone();
+                    let span = name.span;
                     parameters.push(SassParameter { name, default_value: None, span });
                     comma_spans.push(token_with_span.span);
                     continue;
@@ -755,7 +752,7 @@ impl<'a> Parser<'a> {
                     break;
                 }
                 Token::RParen(..) => {
-                    let span = name.span.clone();
+                    let span = name.span;
                     parameters.push(SassParameter { name, default_value: None, span });
                     end = token_with_span.span.end;
                     break;
@@ -849,7 +846,7 @@ impl<'a> Parse<'a> for SassAtRoot<'a> {
             SassAtRootKind::Selector(input.parse()?)
         };
 
-        let span = kind.span().clone();
+        let span = *kind.span();
         Ok(SassAtRoot { kind, span })
     }
 }
@@ -1033,7 +1030,7 @@ impl<'a> Parse<'a> for SassForward<'a> {
 
         input.eat_sass_line_continuation()?;
         let path = input.parse::<InterpolableStr>()?;
-        let mut span = path.span().clone();
+        let mut span = *path.span();
 
         let prefix = if input.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(input.source, "as")
         {
@@ -1170,13 +1167,13 @@ impl<'a> Parse<'a> for SassIfAtRule<'a> {
                             // `elseif` is deprecated by Sass
                             "elseif" => false,
                             _ => {
-                                let span = p.cursor.peek()?.span.clone();
+                                let span = p.cursor.peek()?.span;
                                 return Err(Error { kind: ErrorKind::TryParseError, span });
                             }
                         }
                     }
                     _ => {
-                        let span = p.cursor.peek()?.span.clone();
+                        let span = p.cursor.peek()?.span;
                         return Err(Error { kind: ErrorKind::TryParseError, span });
                     }
                 };
@@ -1222,7 +1219,7 @@ impl<'a> Parse<'a> for SassIfAtRule<'a> {
 impl<'a> Parse<'a> for SassImportPrelude<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<Str>()?;
-        let mut span = first.span.clone();
+        let mut span = first.span;
 
         let mut paths = input.vec1(first);
         let mut comma_spans = input.vec();
@@ -1248,7 +1245,7 @@ impl<'a> Parse<'a> for SassInclude<'a> {
 
         input.eat_sass_line_continuation()?;
         let name = input.parse::<FunctionName>()?;
-        let mut span = name.span().clone();
+        let mut span = *name.span();
 
         let arguments = if matches!(input.cursor.peek()?.token, Token::LParen(..)) {
             let arguments = input.parse::<SassIncludeArgs>()?;
@@ -1304,7 +1301,7 @@ impl<'a> Parse<'a> for SassInterpolatedStr<'a> {
         let (first, first_span) = input.cursor.expect_str_template()?;
         let quote = first.raw.bytes().next().unwrap();
         debug_assert!(quote == b'\'' || quote == b'"');
-        let mut span = first_span.clone();
+        let mut span = first_span;
         let first = input.interpolable_str_static_part(first, first_span);
         let mut elements = input.vec1(SassInterpolatedStrElement::Static(first));
 
@@ -1351,7 +1348,7 @@ impl<'a> Parse<'a> for SassInterpolatedUrl<'a> {
                 });
             }
         };
-        let mut span = first_span.clone();
+        let mut span = first_span;
         let first = input.interpolable_url_static_part(first, first_span);
         let mut elements = input.vec1(SassInterpolatedUrlElement::Static(first));
 
@@ -1484,7 +1481,7 @@ impl<'a> Parse<'a> for SassParameters<'a> {
 impl<'a> Parse<'a> for SassNestingDeclaration<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let block = input.parse::<SimpleBlock>()?;
-        let span = block.span.clone();
+        let span = block.span;
 
         Ok(SassNestingDeclaration { block, span })
     }
@@ -1528,7 +1525,7 @@ impl<'a> Parse<'a> for SassUse<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         input.eat_sass_line_continuation()?;
         let path = input.parse::<InterpolableStr>()?;
-        let mut span = path.span().clone();
+        let mut span = *path.span();
 
         let namespace =
             if input.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(input.source, "as") {
@@ -1639,7 +1636,7 @@ impl<'a> Parse<'a> for SassVariableDeclaration<'a> {
         if namespace.is_some() && flags.iter().any(|flag| flag.keyword.name == "global") {
             input
                 .recoverable_errors
-                .push(Error { kind: ErrorKind::UnexpectedSassFlag("global"), span: span.clone() });
+                .push(Error { kind: ErrorKind::UnexpectedSassFlag("global"), span });
         }
 
         Ok(SassVariableDeclaration { namespace, name, colon_span, value, flags, span })

--- a/crates/oxc_css_parser/src/parser/selector.rs
+++ b/crates/oxc_css_parser/src/parser/selector.rs
@@ -310,7 +310,7 @@ impl<'a> Parse<'a> for AnPlusB {
             }
 
             TokenWithSpan { span, .. } => {
-                Err(Error { kind: ErrorKind::InvalidAnPlusB, span: span.clone() })
+                Err(Error { kind: ErrorKind::InvalidAnPlusB, span: *span })
             }
         }
     }
@@ -348,7 +348,7 @@ impl<'a> Parse<'a> for AttributeSelector<'a> {
                         span: Span { start, end },
                     }
                 } else {
-                    let span = ident_span.clone();
+                    let span = *ident_span;
                     WqName { name: ident, prefix: None, span }
                 }
             }
@@ -386,7 +386,7 @@ impl<'a> Parse<'a> for AttributeSelector<'a> {
                 }
             }
             TokenWithSpan { span, .. } => {
-                return Err(Error { kind: ErrorKind::ExpectWqName, span: span.clone() });
+                return Err(Error { kind: ErrorKind::ExpectWqName, span: *span });
             }
         };
 
@@ -419,10 +419,7 @@ impl<'a> Parse<'a> for AttributeSelector<'a> {
                 })
             }
             TokenWithSpan { span, .. } => {
-                return Err(Error {
-                    kind: ErrorKind::ExpectAttributeSelectorMatcher,
-                    span: span.clone(),
-                });
+                return Err(Error { kind: ErrorKind::ExpectAttributeSelectorMatcher, span: *span });
             }
         };
 
@@ -457,10 +454,9 @@ impl<'a> Parse<'a> for AttributeSelector<'a> {
                     Some(AttributeSelectorValue::LessEscapedStr(input.parse()?))
                 }
                 TokenWithSpan { token: Token::RBracket(..), span } => {
-                    input.recoverable_errors.push(Error {
-                        kind: ErrorKind::ExpectAttributeSelectorValue,
-                        span: span.clone(),
-                    });
+                    input
+                        .recoverable_errors
+                        .push(Error { kind: ErrorKind::ExpectAttributeSelectorValue, span: *span });
                     None
                 }
                 // An unusual value like `[attr=;]` is invalid per the
@@ -484,7 +480,7 @@ impl<'a> Parse<'a> for AttributeSelector<'a> {
                 token_with_span => {
                     return Err(Error {
                         kind: ErrorKind::ExpectAttributeSelectorValue,
-                        span: token_with_span.span.clone(),
+                        span: token_with_span.span,
                     });
                 }
             }
@@ -496,7 +492,7 @@ impl<'a> Parse<'a> for AttributeSelector<'a> {
             match &input.cursor.peek()?.token {
                 Token::Ident(..) | Token::HashLBrace(..) => {
                     let ident = input.parse::<InterpolableIdent>()?;
-                    let span = ident.span().clone();
+                    let span = *ident.span();
                     Some(AttributeSelectorModifier { ident, span })
                 }
                 _ => None,
@@ -561,7 +557,7 @@ impl<'a> Parse<'a> for ComplexSelector<'a> {
         {
             let end = input.cursor.tokenizer.current_offset();
             if let Some(combinator) = input.parse_combinator(end)? {
-                (combinator.span.clone(), ComplexSelectorChild::Combinator(combinator), true)
+                (combinator.span, ComplexSelectorChild::Combinator(combinator), true)
             } else {
                 return Err(Error {
                     kind: ErrorKind::ExpectSimpleSelector,
@@ -571,7 +567,7 @@ impl<'a> Parse<'a> for ComplexSelector<'a> {
         } else {
             let compound_selector = input.parse::<CompoundSelector>()?;
             (
-                compound_selector.span.clone(),
+                compound_selector.span,
                 ComplexSelectorChild::CompoundSelector(compound_selector),
                 false,
             )
@@ -612,10 +608,11 @@ impl<'a> Parse<'a> for ComplexSelector<'a> {
                 end = compound_selector.span.end;
                 children.push(ComplexSelectorChild::CompoundSelector(compound_selector));
             } else if let Some(combinator) = input.parse_combinator(end)? {
-                if is_less && combinator.kind == CombinatorKind::Descendant {
-                    if input.cursor.peek()?.is_ident_raw(input.source, "when") {
-                        break;
-                    }
+                if is_less
+                    && combinator.kind == CombinatorKind::Descendant
+                    && input.cursor.peek()?.is_ident_raw(input.source, "when")
+                {
+                    break;
                 }
                 children.push(ComplexSelectorChild::Combinator(combinator));
             } else {
@@ -689,7 +686,7 @@ impl<'a> Parse<'a> for CompoundSelector<'a> {
 impl<'a> Parse<'a> for CompoundSelectorList<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<CompoundSelector>()?;
-        let mut span = first.span.clone();
+        let mut span = first.span;
 
         let mut selectors = input.vec1(first);
         let mut comma_spans = input.vec();
@@ -721,7 +718,7 @@ impl<'a> Parse<'a> for IdSelector<'a> {
                 {
                     input
                         .recoverable_errors
-                        .push(Error { kind: ErrorKind::InvalidIdSelectorName, span: span.clone() });
+                        .push(Error { kind: ErrorKind::InvalidIdSelectorName, span });
                 }
                 let value =
                     if token.escaped { util::handle_escape_in(raw, input.allocator) } else { raw };
@@ -777,7 +774,7 @@ impl<'a> Parse<'a> for LanguageRange<'a> {
 impl<'a> Parse<'a> for LanguageRangeList<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<LanguageRange>()?;
-        let mut span = first.span().clone();
+        let mut span = *first.span();
 
         let mut ranges = input.vec1(first);
         let mut comma_spans = input.vec();
@@ -845,7 +842,7 @@ impl<'a> Parse<'a> for NestingSelector<'a> {
 impl<'a> Parse<'a> for Nth<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let index = input.parse::<NthIndex>()?;
-        let mut span = index.span().clone();
+        let mut span = *index.span();
         let matcher = if input.cursor.peek()?.is_ident_name_eq_ignore_ascii_case(input.source, "of")
         {
             let matcher = input.parse::<NthMatcher>()?;
@@ -919,7 +916,7 @@ impl<'a> Parse<'a> for PseudoClassSelector<'a> {
 
         let arg = match input.cursor.peek()? {
             TokenWithSpan { token: Token::LParen(..), span: l_paren } if l_paren.start == end => {
-                let l_paren = l_paren.clone();
+                let l_paren = *l_paren;
                 input.cursor.bump()?;
                 let kind = match &name {
                     InterpolableIdent::Literal(Ident { name, .. })
@@ -952,10 +949,9 @@ impl<'a> Parse<'a> for PseudoClassSelector<'a> {
                                 .map(PseudoClassSelectorArgKind::TokenSeq)?;
                         };
                         if let Some(NthMatcher { span, .. }) = &nth.matcher {
-                            input.recoverable_errors.push(Error {
-                                kind: ErrorKind::UnexpectedNthMatcher,
-                                span: span.clone(),
-                            });
+                            input
+                                .recoverable_errors
+                                .push(Error { kind: ErrorKind::UnexpectedNthMatcher, span: *span });
                         }
                         PseudoClassSelectorArgKind::Nth(nth)
                     }
@@ -1051,7 +1047,7 @@ impl<'a> Parse<'a> for PseudoElementSelector<'a> {
 
         let arg = match input.cursor.peek()? {
             TokenWithSpan { token: Token::LParen(..), span: l_paren } if l_paren.start == end => {
-                let l_paren = l_paren.clone();
+                let l_paren = *l_paren;
                 input.cursor.bump()?;
                 let kind = match &name {
                     InterpolableIdent::Literal(Ident { name, .. })
@@ -1099,7 +1095,7 @@ impl<'a> Parse<'a> for RelativeSelector<'a> {
             combinator => combinator,
         };
         let complex_selector = input.parse::<ComplexSelector>()?;
-        let mut span = complex_selector.span.clone();
+        let mut span = complex_selector.span;
         if let Some(combinator) = &combinator {
             span.start = combinator.span.start;
         }
@@ -1111,7 +1107,7 @@ impl<'a> Parse<'a> for RelativeSelector<'a> {
 impl<'a> Parse<'a> for RelativeSelectorList<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<RelativeSelector>()?;
-        let mut span = first.span.clone();
+        let mut span = first.span;
 
         let mut selectors = input.vec1(first);
         let mut comma_spans = input.vec();
@@ -1135,7 +1131,7 @@ impl<'a> Parse<'a> for RelativeSelectorList<'a> {
 impl<'a> Parse<'a> for SelectorList<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<ComplexSelector>()?;
-        let mut span = first.span.clone();
+        let mut span = first.span;
 
         let mut selectors = input.vec_with_capacity(2);
         selectors.push(first);
@@ -1230,16 +1226,15 @@ impl<'a> Parse<'a> for SimpleSelector<'a> {
             }
             TokenWithSpan { token: Token::Placeholder(..), .. } => {
                 let name = input.parse::<InterpolableIdent>()?;
-                let span = name.span().clone();
+                let span = *name.span();
                 Ok(SimpleSelector::Type(TypeSelector::TagName(TagNameSelector {
-                    name: WqName { name, prefix: None, span: span.clone() },
+                    name: WqName { name, prefix: None, span },
                     span,
                 })))
             }
-            token_with_span => Err(Error {
-                kind: ErrorKind::ExpectSimpleSelector,
-                span: token_with_span.span.clone(),
-            }),
+            token_with_span => {
+                Err(Error { kind: ErrorKind::ExpectSimpleSelector, span: token_with_span.span })
+            }
         }
     }
 }
@@ -1281,12 +1276,12 @@ impl<'a> Parse<'a> for TypeSelector<'a> {
 
                 let prefix = match ident_or_asterisk {
                     Some(IdentOrAsterisk::Ident(ident)) => {
-                        let mut span = ident.span().clone();
+                        let mut span = *ident.span();
                         span.end = bar_token_span.end;
                         NsPrefix { kind: Some(NsPrefixKind::Ident(ident)), span }
                     }
                     Some(IdentOrAsterisk::Asterisk(asterisk_span)) => {
-                        let mut span = asterisk_span.clone();
+                        let mut span = asterisk_span;
                         span.end = bar_token_span.end;
                         NsPrefix {
                             kind: Some(NsPrefixKind::Universal(NsPrefixUniversal {
@@ -1305,7 +1300,7 @@ impl<'a> Parse<'a> for TypeSelector<'a> {
                         util::assert_no_ws(input.source, &prefix.span, name_span)?;
                         let span = Span { start: prefix.span.start, end: name_span.end };
                         Ok(TypeSelector::TagName(TagNameSelector {
-                            name: WqName { name, prefix: Some(prefix), span: span.clone() },
+                            name: WqName { name, prefix: Some(prefix), span },
                             span,
                         }))
                     }
@@ -1319,16 +1314,16 @@ impl<'a> Parse<'a> for TypeSelector<'a> {
                         }))
                     }
                     TokenWithSpan { span, .. } => {
-                        Err(Error { kind: ErrorKind::ExpectTypeSelector, span: span.clone() })
+                        Err(Error { kind: ErrorKind::ExpectTypeSelector, span: *span })
                     }
                 }
             }
 
             _ => match ident_or_asterisk {
                 Some(IdentOrAsterisk::Ident(ident)) => {
-                    let span = ident.span().clone();
+                    let span = *ident.span();
                     Ok(TypeSelector::TagName(TagNameSelector {
-                        name: WqName { name: ident, prefix: None, span: span.clone() },
+                        name: WqName { name: ident, prefix: None, span },
                         span,
                     }))
                 }
@@ -1416,7 +1411,7 @@ impl<'a> Parser<'a> {
                         TokenWithSpan { span, .. } => {
                             return Err(Error {
                                 kind: ErrorKind::TryParseError,
-                                span: span.clone(),
+                                span: *span,
                             });
                         }
                     };
@@ -1429,7 +1424,7 @@ impl<'a> Parser<'a> {
                         }
                         TokenWithSpan { span, .. } => Err(Error {
                             kind: ErrorKind::TryParseError,
-                            span: span.clone(),
+                            span: *span,
                         }),
                     }
                 });

--- a/crates/oxc_css_parser/src/parser/stmt.rs
+++ b/crates/oxc_css_parser/src/parser/stmt.rs
@@ -147,10 +147,7 @@ impl<'a> Parse<'a> for Declaration<'a> {
                         if at_declaration_value_end(&next.token) {
                             Ok((values, important))
                         } else {
-                            Err(Error {
-                                kind: ErrorKind::ExpectComponentValue,
-                                span: next.span.clone(),
-                            })
+                            Err(Error { kind: ErrorKind::ExpectComponentValue, span: next.span })
                         }
                     });
                     match typed {
@@ -458,10 +455,8 @@ impl<'a> Parser<'a> {
                         Some(ComponentValue::SassNestingDeclaration(..))
                     );
                     if is_top_level {
-                        self.recoverable_errors.push(Error {
-                            kind: ErrorKind::TopLevelDeclaration,
-                            span: decl.span.clone(),
-                        });
+                        self.recoverable_errors
+                            .push(Error { kind: ErrorKind::TopLevelDeclaration, span: decl.span });
                     }
                     Ok((Statement::Declaration(decl), is_block_element))
                 }
@@ -858,7 +853,7 @@ impl<'a> Parser<'a> {
                         } else {
                             ErrorKind::ExpectRule
                         },
-                        span: span.clone(),
+                        span: *span,
                     });
                 }
             };

--- a/crates/oxc_css_parser/src/parser/token_seq.rs
+++ b/crates/oxc_css_parser/src/parser/token_seq.rs
@@ -20,7 +20,7 @@ impl<'a> Parser<'a> {
                 // preprocessor dialects give it real syntax (`$var`, Less
                 // `^`), and their reference compilers reject it here.
                 Token::Unknown(..) if self.syntax != Syntax::Css => {
-                    let span = self.cursor.peek()?.span.clone();
+                    let span = self.cursor.peek()?.span;
                     return Err(Error { kind: ErrorKind::UnknownToken, span });
                 }
                 // An interpolated string (`("min-width:#{$foo}")`) must be

--- a/crates/oxc_css_parser/src/parser/value.rs
+++ b/crates/oxc_css_parser/src/parser/value.rs
@@ -212,11 +212,8 @@ impl<'a> Parser<'a> {
                             && span.start == ident_end =>
                     {
                         if let InterpolableIdent::Literal(module) = &ident {
-                            let module = Ident {
-                                name: module.name,
-                                raw: module.raw,
-                                span: module.span.clone(),
-                            };
+                            let module =
+                                Ident { name: module.name, raw: module.raw, span: module.span };
                             // A namespaced member is `foo.$var` or a glued
                             // call `foo.bar(...)`.
                             let qualified = self.try_parse(|parser| {
@@ -404,10 +401,7 @@ impl<'a> Parser<'a> {
                 let (placeholder, span) = self.cursor.expect_placeholder()?;
                 Ok(ComponentValue::Placeholder((placeholder, span).into()))
             }
-            _ => Err(Error {
-                kind: ErrorKind::ExpectComponentValue,
-                span: token_with_span.span.clone(),
-            }),
+            _ => Err(Error { kind: ErrorKind::ExpectComponentValue, span: token_with_span.span }),
         }
     }
 
@@ -417,7 +411,7 @@ impl<'a> Parser<'a> {
         match &ident {
             InterpolableIdent::Literal(ident) if !ident.name.starts_with("--") => {
                 self.recoverable_errors
-                    .push(Error { kind: ErrorKind::ExpectDashedIdent, span: ident.span.clone() });
+                    .push(Error { kind: ErrorKind::ExpectDashedIdent, span: ident.span });
             }
             _ => {}
         }
@@ -475,7 +469,7 @@ impl<'a> Parser<'a> {
                             if matches!(&p.cursor.peek()?.token, Token::RParen(..)) {
                                 Ok(values)
                             } else {
-                                let span = p.cursor.peek()?.span.clone();
+                                let span = p.cursor.peek()?.span;
                                 Err(Error { kind: ErrorKind::TryParseError, span })
                             }
                         });
@@ -573,7 +567,7 @@ impl<'a> Parser<'a> {
     /// (dart-sass special functions carry raw text: `element(/**/ c)`,
     /// `-c-calc(@#$)`, `url(fn("s"))`), re-parse the contents as raw tokens.
     pub(super) fn parse_function_typed_or_raw(&mut self, name: Ident<'a>) -> PResult<Function<'a>> {
-        let name_copy = Ident { name: name.name, raw: name.raw, span: name.span.clone() };
+        let name_copy = Ident { name: name.name, raw: name.raw, span: name.span };
         match self.try_parse(|p| p.parse_function(InterpolableIdent::Literal(name))) {
             Ok(function) => Ok(function),
             Err(_) => self.parse_raw_function(InterpolableIdent::Literal(name_copy)),
@@ -683,7 +677,7 @@ impl<'a> Parser<'a> {
                 // preprocessor dialects give it real syntax and their
                 // reference compilers reject it in function arguments.
                 Token::Unknown(..) if self.syntax != Syntax::Css => {
-                    let span = self.cursor.peek()?.span.clone();
+                    let span = self.cursor.peek()?.span;
                     return Err(Error { kind: ErrorKind::UnknownToken, span });
                 }
                 _ => {
@@ -733,10 +727,8 @@ impl<'a> Parser<'a> {
         let (_, solidus_span) = self.cursor.expect_solidus()?;
         let denominator = self.parse::<Number>()?;
         if denominator.value <= 0.0 {
-            self.recoverable_errors.push(Error {
-                kind: ErrorKind::InvalidRatioDenominator,
-                span: denominator.span.clone(),
-            });
+            self.recoverable_errors
+                .push(Error { kind: ErrorKind::InvalidRatioDenominator, span: denominator.span });
         }
 
         let span = Span { start: numerator.span.start, end: denominator.span.end };
@@ -863,9 +855,9 @@ impl<'a> Parser<'a> {
                 return Err(Error { kind: ErrorKind::InvalidUnicodeRange, span });
             }
             let start = u32::from_str_radix(left, 16)
-                .map_err(|_| Error { kind: ErrorKind::InvalidUnicodeRange, span: span.clone() })?;
+                .map_err(|_| Error { kind: ErrorKind::InvalidUnicodeRange, span })?;
             let end = u32::from_str_radix(&replace_unicode_range_wildcards(right, 'F'), 16)
-                .map_err(|_| Error { kind: ErrorKind::InvalidUnicodeRange, span: span.clone() })?;
+                .map_err(|_| Error { kind: ErrorKind::InvalidUnicodeRange, span })?;
             UnicodeRange { prefix, start, start_raw: left, end, end_raw: Some(right), span }
         } else {
             if source.len() > 6
@@ -874,9 +866,9 @@ impl<'a> Parser<'a> {
                 return Err(Error { kind: ErrorKind::InvalidUnicodeRange, span });
             }
             let start = u32::from_str_radix(&replace_unicode_range_wildcards(source, '0'), 16)
-                .map_err(|_| Error { kind: ErrorKind::InvalidUnicodeRange, span: span.clone() })?;
+                .map_err(|_| Error { kind: ErrorKind::InvalidUnicodeRange, span })?;
             let end = u32::from_str_radix(&replace_unicode_range_wildcards(source, 'F'), 16)
-                .map_err(|_| Error { kind: ErrorKind::InvalidUnicodeRange, span: span.clone() })?;
+                .map_err(|_| Error { kind: ErrorKind::InvalidUnicodeRange, span })?;
             UnicodeRange { prefix, start, start_raw: source, end, end_raw: None, span }
         };
         // Value-level checks (end > U+10FFFF, start > end) are deliberately
@@ -929,7 +921,7 @@ impl<'a> Parse<'a> for ComponentValues<'a> {
     /// This is for public-use only. For internal code of oxc-css-parser, **DO NOT** use.
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let first = input.parse::<ComponentValue>()?;
-        let mut span = first.span().clone();
+        let mut span = *first.span();
 
         let mut values = input.vec_with_capacity(4);
         values.push(first);
@@ -998,7 +990,7 @@ impl<'a> Parse<'a> for Function<'a> {
                 }
             }
             TokenWithSpan { token, span } => {
-                Err(Error { kind: ErrorKind::Unexpected("(", token.symbol()), span: span.clone() })
+                Err(Error { kind: ErrorKind::Unexpected("(", token.symbol()), span: *span })
             }
         }
     }
@@ -1095,13 +1087,9 @@ impl<'a> Parse<'a> for InterpolableStr<'a> {
             TokenWithSpan { token: Token::StrTemplate(..), span } => match input.syntax {
                 Syntax::Scss | Syntax::Sass => input.parse().map(InterpolableStr::SassInterpolated),
                 Syntax::Less => input.parse().map(InterpolableStr::LessInterpolated),
-                Syntax::Css => {
-                    Err(Error { kind: ErrorKind::UnexpectedTemplateInCss, span: span.clone() })
-                }
+                Syntax::Css => Err(Error { kind: ErrorKind::UnexpectedTemplateInCss, span: *span }),
             },
-            TokenWithSpan { span, .. } => {
-                Err(Error { kind: ErrorKind::ExpectString, span: span.clone() })
-            }
+            TokenWithSpan { span, .. } => Err(Error { kind: ErrorKind::ExpectString, span: *span }),
         }
     }
 }
@@ -1113,7 +1101,7 @@ impl<'a> Parse<'a> for Number<'a> {
         number
             .raw
             .parse()
-            .map_err(|_| Error { kind: ErrorKind::InvalidNumber, span: span.clone() })
+            .map_err(|_| Error { kind: ErrorKind::InvalidNumber, span })
             .map(|value| Self { value, raw: number.raw, span })
     }
 }
@@ -1156,14 +1144,14 @@ impl<'a> Parse<'a> for Url<'a> {
             return Err(Error { kind: ErrorKind::ExpectUrl, span: prefix_span });
         }
         let prefix_start = prefix_span.start;
-        let name = input.ident(prefix, prefix_span.clone());
+        let name = input.ident(prefix, prefix_span);
 
         match input.cursor.peek()? {
             TokenWithSpan { token: Token::LParen(..), span } if prefix_span.end == span.start => {
                 input.cursor.bump()?;
             }
             TokenWithSpan { span, .. } => {
-                return Err(Error { kind: ErrorKind::TryParseError, span: span.clone() });
+                return Err(Error { kind: ErrorKind::TryParseError, span: *span });
             }
         }
 


### PR DESCRIPTION
## Summary

`Span` and the compacted token data became `Copy` in #98, leaving the parser with 145 `.clone()` calls that clippy flags as `clone_on_copy`. This removes them, along with the follow-on warnings they exposed:

- **145 `clone_on_copy`** — `span.clone()` → `span` / `*span`
- **19 `redundant_field_names`** — surfaced once the clones were gone (`Error { span: span }` → `Error { span }`)
- **1 `collapsible_if`** — nested `if` in the selector parser collapsed into a single `&&` chain

All changes are behavior-neutral: dropping `.clone()` on a `Copy` type is a no-op, and the collapsed `if` short-circuits on `&&` exactly where the nested `if` guarded the fallible `peek()?`.

## Verification

- `cargo clippy --all-targets --all-features` — **0 warnings** (was 146)
- `cargo test --all-features` — all pass
- `cargo fmt --check` — clean
