### PR TITLE
refactor: deduplicate parser loops and drop dead conversions

### DIFF
--- a/crates/oxc_css_parser/src/parser/convert.rs
+++ b/crates/oxc_css_parser/src/parser/convert.rs
@@ -1,27 +1,9 @@
 use crate::{
     Span,
-    ast::{
-        Dimension, DimensionKind, Ident, InterpolableIdentStaticPart, InterpolableStrStaticPart,
-        InterpolableUrlStaticPart, Number, Placeholder, Str,
-    },
+    ast::{DimensionKind, Number, Placeholder},
     error::{Error, ErrorKind, PResult},
     tokenizer::token,
 };
-
-impl<'a> TryFrom<(token::Dimension<'a>, Span)> for Dimension<'a> {
-    type Error = Error;
-
-    fn try_from((token, span): (token::Dimension<'a>, Span)) -> PResult<Self> {
-        let value_span = Span { start: span.start, end: span.start + token.value.raw.len() };
-        let unit_span = Span { start: span.start + token.value.raw.len(), end: span.end };
-
-        let value = (token.value, value_span).try_into()?;
-        let unit = Ident::from((token.unit, unit_span));
-        let kind = dimension_kind(unit.name);
-
-        Ok(Dimension { value, unit, kind, span })
-    }
-}
 
 pub(super) fn dimension_kind(unit_name: &str) -> DimensionKind {
     if unit_name.eq_ignore_ascii_case("px")
@@ -91,21 +73,9 @@ pub(super) fn dimension_kind(unit_name: &str) -> DimensionKind {
     }
 }
 
-impl<'a> From<(token::Ident<'a>, Span)> for Ident<'a> {
-    fn from((token, span): (token::Ident<'a>, Span)) -> Self {
-        Ident { name: token.raw, raw: token.raw, span }
-    }
-}
-
 impl<'a> From<(token::Placeholder<'a>, Span)> for Placeholder<'a> {
     fn from((token, span): (token::Placeholder<'a>, Span)) -> Self {
         Placeholder { index: token.index, suffix: token.suffix, span }
-    }
-}
-
-impl<'a> From<(token::Ident<'a>, Span)> for InterpolableIdentStaticPart<'a> {
-    fn from((token, span): (token::Ident<'a>, Span)) -> Self {
-        InterpolableIdentStaticPart { value: token.raw, raw: token.raw, span }
     }
 }
 
@@ -118,34 +88,5 @@ impl<'a> TryFrom<(token::Number<'a>, Span)> for Number<'a> {
             .parse()
             .map_err(|_| Error { kind: ErrorKind::InvalidNumber, span })
             .map(|value| Self { value, raw: token.raw, span })
-    }
-}
-
-impl<'a> From<(token::StrTemplate<'a>, Span)> for InterpolableStrStaticPart<'a> {
-    fn from((token, span): (token::StrTemplate<'a>, Span)) -> Self {
-        let raw_without_quotes = if token.tail {
-            unsafe { token.raw.get_unchecked(0..token.raw.len() - 1) }
-        } else if token.head {
-            unsafe { token.raw.get_unchecked(1..token.raw.len()) }
-        } else {
-            token.raw
-        };
-        let value = raw_without_quotes;
-        Self { value, raw: token.raw, span }
-    }
-}
-
-impl<'a> From<(token::UrlTemplate<'a>, Span)> for InterpolableUrlStaticPart<'a> {
-    fn from((token, span): (token::UrlTemplate<'a>, Span)) -> Self {
-        let value = token.raw;
-        Self { value, raw: token.raw, span }
-    }
-}
-
-impl<'a> From<(token::Str<'a>, Span)> for Str<'a> {
-    fn from((str, span): (token::Str<'a>, Span)) -> Self {
-        let raw_without_quotes = unsafe { str.raw.get_unchecked(1..str.raw.len() - 1) };
-        let value = raw_without_quotes;
-        Self { value, raw: str.raw, span }
     }
 }

--- a/crates/oxc_css_parser/src/parser/sass.rs
+++ b/crates/oxc_css_parser/src/parser/sass.rs
@@ -1048,34 +1048,14 @@ impl<'a> Parse<'a> for SassForward<'a> {
             let keyword_span = input.cursor.peek()?.span;
             let start = keyword_span.start;
             let name = keyword.name();
-            if name.eq_ignore_ascii_case("hide") {
-                let keyword_span = input.cursor.bump()?.span;
-                let mut members = input.vec();
-                let mut comma_spans = input.vec();
-                loop {
-                    input.eat_sass_line_continuation()?;
-                    match &input.cursor.peek()?.token {
-                        Token::Ident(..) => {
-                            members.push(input.parse().map(SassForwardMember::Ident)?)
-                        }
-                        _ => members.push(input.parse().map(SassForwardMember::Variable)?),
-                    }
-                    if let Some((_, span)) = input.cursor.eat_comma()? {
-                        comma_spans.push(span);
-                    } else {
-                        break;
-                    }
-                }
-                Some(SassForwardVisibility {
-                    modifier: SassForwardVisibilityModifier {
-                        kind: SassForwardVisibilityModifierKind::Hide,
-                        span: keyword_span,
-                    },
-                    members,
-                    comma_spans,
-                    span: Span { start, end: input.cursor.tokenizer.current_offset() },
-                })
+            let kind = if name.eq_ignore_ascii_case("hide") {
+                Some(SassForwardVisibilityModifierKind::Hide)
             } else if name.eq_ignore_ascii_case("show") {
+                Some(SassForwardVisibilityModifierKind::Show)
+            } else {
+                None
+            };
+            if let Some(kind) = kind {
                 let keyword_span = input.cursor.bump()?.span;
                 let mut members = input.vec();
                 let mut comma_spans = input.vec();
@@ -1094,10 +1074,7 @@ impl<'a> Parse<'a> for SassForward<'a> {
                     }
                 }
                 Some(SassForwardVisibility {
-                    modifier: SassForwardVisibilityModifier {
-                        kind: SassForwardVisibilityModifierKind::Show,
-                        span: keyword_span,
-                    },
+                    modifier: SassForwardVisibilityModifier { kind, span: keyword_span },
                     members,
                     comma_spans,
                     span: Span { start, end: input.cursor.tokenizer.current_offset() },

--- a/crates/oxc_css_parser/src/parser/value.rs
+++ b/crates/oxc_css_parser/src/parser/value.rs
@@ -408,12 +408,11 @@ impl<'a> Parser<'a> {
     // <dashed-ident> = <ident-token> whose name starts with '--'
     pub(super) fn parse_dashed_ident(&mut self) -> PResult<InterpolableIdent<'a>> {
         let ident = self.parse()?;
-        match &ident {
-            InterpolableIdent::Literal(ident) if !ident.name.starts_with("--") => {
-                self.recoverable_errors
-                    .push(Error { kind: ErrorKind::ExpectDashedIdent, span: ident.span });
-            }
-            _ => {}
+        if let InterpolableIdent::Literal(ident) = &ident
+            && !ident.name.starts_with("--")
+        {
+            self.recoverable_errors
+                .push(Error { kind: ErrorKind::ExpectDashedIdent, span: ident.span });
         }
         Ok(ident)
     }
@@ -770,6 +769,20 @@ impl<'a> Parser<'a> {
         Ok(Url { name, value, modifiers, span })
     }
 
+    // Consume `?` tokens glued directly onto `end` (no whitespace gap),
+    // advancing `end` past each — the wildcard run in `<urange>` (`U+4??`).
+    fn consume_glued_questions(&mut self, end: &mut usize) -> PResult<()> {
+        loop {
+            match self.cursor.peek()? {
+                TokenWithSpan { token: Token::Question(..), span } if span.start == *end => {
+                    *end = self.cursor.bump()?.span.end;
+                }
+                _ => break,
+            }
+        }
+        Ok(())
+    }
+
     // <urange> = u '+' <ident-token> '?'* | u <dimension-token> '?'* | u <number-token> …
     // Written `U+0-10FFFF`, `U+4??`, etc. https://drafts.csswg.org/css-syntax-3/#urange-syntax
     fn parse_unicode_range(&mut self, prefix_ident: Ident<'a>) -> PResult<UnicodeRange<'a>> {
@@ -788,27 +801,13 @@ impl<'a> Parser<'a> {
                         });
                     }
                 };
-                loop {
-                    match self.cursor.peek()? {
-                        TokenWithSpan { token: Token::Question(..), span } if span.start == end => {
-                            end = self.cursor.bump()?.span.end;
-                        }
-                        _ => break,
-                    }
-                }
+                self.consume_glued_questions(&mut end)?;
                 (start, end)
             }
             TokenWithSpan { token: Token::Dimension(..), span: dimension_token_span } => {
                 let start = dimension_token_span.start;
                 let mut end = dimension_token_span.end;
-                loop {
-                    match self.cursor.peek()? {
-                        TokenWithSpan { token: Token::Question(..), span } if span.start == end => {
-                            end = self.cursor.bump()?.span.end;
-                        }
-                        _ => break,
-                    }
-                }
+                self.consume_glued_questions(&mut end)?;
                 (start, end)
             }
             TokenWithSpan { token: Token::Number(..), span: number_token_span } => {
@@ -817,16 +816,7 @@ impl<'a> Parser<'a> {
                 match &self.cursor.peek()?.token {
                     Token::Question(..) => {
                         end = self.cursor.bump()?.span.end;
-                        loop {
-                            match self.cursor.peek()? {
-                                TokenWithSpan { token: Token::Question(..), span }
-                                    if span.start == end =>
-                                {
-                                    end = self.cursor.bump()?.span.end;
-                                }
-                                _ => break,
-                            }
-                        }
+                        self.consume_glued_questions(&mut end)?;
                     }
                     Token::Dimension(..) | Token::Number(..) => {
                         end = self.cursor.bump()?.span.end;

--- a/crates/oxc_css_parser/src/tokenizer/mod.rs
+++ b/crates/oxc_css_parser/src/tokenizer/mod.rs
@@ -486,7 +486,6 @@ impl<'a> Tokenizer<'a> {
         allow_leading_digit: bool,
     ) -> PResult<(Ident<'a>, Span)> {
         let start;
-        let end;
         let mut escaped = false;
         match self.state.chars.peek() {
             Some((i, c)) if c.is_ascii_alphabetic() || *c == b'_' || !c.is_ascii() => {
@@ -515,27 +514,7 @@ impl<'a> Tokenizer<'a> {
             _ => unreachable!(),
         }
 
-        loop {
-            match self.state.chars.peek() {
-                Some((_, c))
-                    if c.is_ascii_alphanumeric() || *c == b'-' || *c == b'_' || !c.is_ascii() =>
-                {
-                    self.state.chars.next();
-                }
-                Some((_, b'\\')) => {
-                    escaped = true;
-                    self.scan_escape(/* backslash_consumed */ false)?;
-                }
-                Some((i, _)) => {
-                    end = *i;
-                    break;
-                }
-                None => {
-                    end = self.source.len();
-                    break;
-                }
-            }
-        }
+        let end = self.consume_name_run(&mut escaped)?;
 
         debug_assert!(start < end);
         let raw = unsafe { self.source.get_unchecked(start..end) };
@@ -580,6 +559,43 @@ impl<'a> Tokenizer<'a> {
         }
     }
 
+    // Consume a run of ASCII digits, returning the offset just past them
+    // (the source length if the run reaches EOF).
+    #[inline]
+    fn consume_digits(&mut self) -> usize {
+        loop {
+            match self.state.chars.peek() {
+                Some((_, c)) if c.is_ascii_digit() => {
+                    self.state.chars.next();
+                }
+                Some((i, _)) => return *i,
+                None => return self.source.len(),
+            }
+        }
+    }
+
+    // Consume a run of name code points (`-`, `_`, ASCII alphanumerics,
+    // non-ASCII, or escapes), returning the offset just past them (the source
+    // length at EOF). Sets `escaped` if any escape sequence was consumed.
+    #[inline]
+    fn consume_name_run(&mut self, escaped: &mut bool) -> PResult<usize> {
+        loop {
+            match self.state.chars.peek() {
+                Some((_, c))
+                    if c.is_ascii_alphanumeric() || *c == b'-' || *c == b'_' || !c.is_ascii() =>
+                {
+                    self.state.chars.next();
+                }
+                Some((_, b'\\')) => {
+                    *escaped = true;
+                    self.scan_escape(/* backslash_consumed */ false)?;
+                }
+                Some((i, _)) => return Ok(*i),
+                None => return Ok(self.source.len()),
+            }
+        }
+    }
+
     // <number-token> = [ '+' | '-' ]? <digits> [ '.' <digits> ]? [ e [ '+' | '-' ]? <digits> ]?
     // https://drafts.csswg.org/css-syntax-3/#consume-number
     fn scan_number(&mut self) -> PResult<(Number<'a>, Span)> {
@@ -603,21 +619,7 @@ impl<'a> Tokenizer<'a> {
             _ => unreachable!(),
         }
 
-        loop {
-            match self.state.chars.peek() {
-                Some((_, c)) if c.is_ascii_digit() => {
-                    self.state.chars.next();
-                }
-                Some((i, _)) => {
-                    end = *i;
-                    break;
-                }
-                None => {
-                    end = self.source.len();
-                    break;
-                }
-            }
-        }
+        end = self.consume_digits();
         if !is_start_with_dot && matches!(self.state.chars.peek(), Some((_, b'.'))) {
             // Length of the dot run right after the digits decides who owns
             // the first `.`:
@@ -631,21 +633,7 @@ impl<'a> Tokenizer<'a> {
             if dot_run == 1 || dot_run == 4 {
                 // bump '.'
                 self.state.chars.next();
-                loop {
-                    match self.state.chars.peek() {
-                        Some((_, c)) if c.is_ascii_digit() => {
-                            self.state.chars.next();
-                        }
-                        Some((i, _)) => {
-                            end = *i;
-                            break;
-                        }
-                        None => {
-                            end = self.source.len();
-                            break;
-                        }
-                    }
-                }
+                end = self.consume_digits();
             }
         }
 
@@ -659,21 +647,7 @@ impl<'a> Tokenizer<'a> {
                     self.state.chars.next();
                 }
 
-                loop {
-                    match self.state.chars.peek() {
-                        Some((_, c)) if c.is_ascii_digit() => {
-                            self.state.chars.next();
-                        }
-                        Some((i, _)) => {
-                            end = *i;
-                            break;
-                        }
-                        None => {
-                            end = self.source.len();
-                            break;
-                        }
-                    }
-                }
+                end = self.consume_digits();
             }
             _ => {}
         }
@@ -908,28 +882,7 @@ impl<'a> Tokenizer<'a> {
         let start = self.current_offset();
         let mut escaped = false;
 
-        let end;
-        loop {
-            match self.state.chars.peek() {
-                Some((_, c))
-                    if c.is_ascii_alphanumeric() || *c == b'-' || *c == b'_' || !c.is_ascii() =>
-                {
-                    self.state.chars.next();
-                }
-                Some((_, b'\\')) => {
-                    escaped = true;
-                    self.scan_escape(/* backslash_consumed */ false)?;
-                }
-                Some((i, _)) => {
-                    end = *i;
-                    break;
-                }
-                None => {
-                    end = self.source.len();
-                    break;
-                }
-            }
-        }
+        let end = self.consume_name_run(&mut escaped)?;
         if end > start {
             let raw = unsafe { self.source.get_unchecked(start..end) };
             Ok(Some((Ident { escaped, raw }, Span { start, end })))
@@ -1083,7 +1036,6 @@ impl<'a> Tokenizer<'a> {
         let (start, c) = self.state.chars.next().unwrap();
         debug_assert_eq!(c, b'#');
 
-        let end;
         let mut escaped = false;
         match self.state.chars.next() {
             Some((_, c))
@@ -1102,27 +1054,7 @@ impl<'a> Tokenizer<'a> {
                 return Err(self.build_eof_error());
             }
         }
-        loop {
-            match self.state.chars.peek() {
-                Some((_, c))
-                    if c.is_ascii_alphanumeric() || *c == b'-' || *c == b'_' || !c.is_ascii() =>
-                {
-                    self.state.chars.next();
-                }
-                Some((_, b'\\')) => {
-                    escaped = true;
-                    self.scan_escape(/* backslash_consumed */ false)?;
-                }
-                Some((i, _)) => {
-                    end = *i;
-                    break;
-                }
-                None => {
-                    end = self.source.len();
-                    break;
-                }
-            }
-        }
+        let end = self.consume_name_run(&mut escaped)?;
 
         debug_assert!(end > start + 1);
         Ok(TokenWithSpan { token: Token::Hash(HashMeta { escaped }), span: Span { start, end } })


### PR DESCRIPTION
## Summary

Cleanup pass over the parser crate: factor out duplicated scanner/parser loops and remove dead code. **−160 net lines**, no behavior change.

### Deduplication (identical code, extracted to helpers)
- **tokenizer** — `consume_digits` replaces the three identical digit-run loops in `scan_number`; `consume_name_run` replaces the three identical name-code-point loops in `scan_ident_sequence` / `scan_ident_template` / `scan_hash`. Both `#[inline]` so the hot scan path is unchanged.
- **value** — `consume_glued_questions` replaces the three identical `<urange>` `?`-run loops in `parse_unicode_range`.
- **sass** — the `@forward` `show` / `hide` branches were byte-for-byte identical except the visibility `kind`; collapsed into one body that picks the `kind` up front.

### Dead code
- **convert** — removed six `From`/`TryFrom` `(token, Span)` impls that had no in-crate call site. They also duplicated the escape-aware `Parser::{ident, str, dimension, …}` methods but *dropped* the unescaping step, so they were subtly wrong footguns. Only the live `From<Placeholder>` and `TryFrom<Number>` impls (plus `dimension_kind`) remain. The crate compiles clean without the removed impls, which confirms they were unused.

### Idiom
- **value** — `parse_dashed_ident`'s single-arm `match` with a guard is now an `if let … && …` chain (matches the let-chain style used elsewhere in the crate).

## Verification
- `cargo clippy --all-targets --all-features` — 0 warnings
- `cargo test --all-features` — all pass
- `cargo fmt --check` — clean

The extracted helpers are the original loop bodies verbatim (`return` in place of `end = …; break`), so each is behavior-identical.
