### PR TITLE
chore: restore LICENSE copyright notices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
-Copyright (c) July 2026-present VoidZero Inc. & Contributors
-Copyright (c) 2022-June 2026 Pig Fang
+Copyright (c) 2022-present Pig Fang
+Copyright (c) 2026-present VoidZero Inc. & Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Restores Pig Fang's original copyright notice and adds the VoidZero Inc. & Contributors notice.