### PR TITLE
chore: set MSRV to 1.95.0

### DIFF
--- a/crates/oxc_css_parser/Cargo.toml
+++ b/crates/oxc_css_parser/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxc-css-parser"
 version = "0.0.6"
 edition = "2024"
+rust-version = "1.95.0"
 authors = []
 description = "Parser for CSS, SCSS, Sass, and Less."
 repository = "https://github.com/oxc-project/oxc-css-parser"


### PR DESCRIPTION
Declares `rust-version = "1.95.0"` on the published crate.

This gives cargo's MSRV-aware dependency resolution (`resolver = "3"`) a declared floor and caps clippy's MSRV-gated suggestions at 1.95. Verified the whole workspace compiles with `cargo +1.95.0 check --workspace --all-targets --all-features`.