### PR TITLE
chore: remove redundant clone on Copy type Span

### DIFF
--- a/crates/oxc_css_parser/src/parser/stmt.rs
+++ b/crates/oxc_css_parser/src/parser/stmt.rs
@@ -404,7 +404,7 @@ impl<'a> Parser<'a> {
                 // (canonically closable by appending the quote), at a newline a
                 // `<bad-string-token>`.
                 Token::BadStr(..) => {
-                    let span = self.cursor.peek()?.span.clone();
+                    let span = self.cursor.peek()?.span;
                     let kind = if span.end == self.source.len() {
                         ErrorKind::UnterminatedString
                     } else {
@@ -427,7 +427,7 @@ impl<'a> Parser<'a> {
                         break;
                     }
                     if was_empty && !pairs.is_empty() {
-                        outermost_pair_span = Some(self.cursor.peek()?.span.clone());
+                        outermost_pair_span = Some(self.cursor.peek()?.span);
                     }
                 }
             }


### PR DESCRIPTION
Fixes the two clippy `clone_on_copy` warnings in `parser/stmt.rs` — `Span` is `Copy`, so the `.clone()` calls are redundant.