### PR TITLE
refactor: replace guarded single-arm matches with let chains

### DIFF
--- a/crates/oxc_css_parser/src/parser/at_rule/counter_style.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/counter_style.rs
@@ -11,15 +11,11 @@ impl<'a> Parser<'a> {
     // <counter-style-name> = <custom-ident>  (excludes CSS-wide keywords and `none`)
     pub(super) fn parse_counter_style_prelude(&mut self) -> PResult<InterpolableIdent<'a>> {
         let ident = self.parse()?;
-        match &ident {
-            InterpolableIdent::Literal(ident)
-                if util::is_css_wide_keyword(ident.name)
-                    || ident.name.eq_ignore_ascii_case("none") =>
-            {
-                self.recoverable_errors
-                    .push(Error { kind: ErrorKind::CSSWideKeywordDisallowed, span: ident.span });
-            }
-            _ => {}
+        if let InterpolableIdent::Literal(ident) = &ident
+            && (util::is_css_wide_keyword(ident.name) || ident.name.eq_ignore_ascii_case("none"))
+        {
+            self.recoverable_errors
+                .push(Error { kind: ErrorKind::CSSWideKeywordDisallowed, span: ident.span });
         }
         Ok(ident)
     }

--- a/crates/oxc_css_parser/src/parser/at_rule/keyframes.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/keyframes.rs
@@ -42,17 +42,14 @@ impl<'a> Parse<'a> for KeyframeSelector<'a> {
             Token::Percentage(..) => Ok(KeyframeSelector::Percentage(input.parse()?)),
             _ => {
                 let ident = input.parse()?;
-                match &ident {
-                    InterpolableIdent::Literal(ident)
-                        if !ident.name.eq_ignore_ascii_case("from")
-                            && !ident.name.eq_ignore_ascii_case("to") =>
-                    {
-                        input.recoverable_errors.push(Error {
-                            kind: ErrorKind::UnknownKeyframeSelectorIdent,
-                            span: ident.span,
-                        });
-                    }
-                    _ => {}
+                if let InterpolableIdent::Literal(ident) = &ident
+                    && !ident.name.eq_ignore_ascii_case("from")
+                    && !ident.name.eq_ignore_ascii_case("to")
+                {
+                    input.recoverable_errors.push(Error {
+                        kind: ErrorKind::UnknownKeyframeSelectorIdent,
+                        span: ident.span,
+                    });
                 }
                 Ok(KeyframeSelector::Ident(ident))
             }
@@ -69,17 +66,14 @@ impl<'a> Parse<'a> for KeyframesName<'a> {
         match &input.cursor.peek()?.token {
             Token::Ident(..) | Token::HashLBrace(..) | Token::AtLBraceVar(..) => {
                 let ident = input.parse()?;
-                match &ident {
-                    InterpolableIdent::Literal(ident)
-                        if util::is_css_wide_keyword(ident.name)
-                            || ident.name.eq_ignore_ascii_case("default") =>
-                    {
-                        input.recoverable_errors.push(Error {
-                            kind: ErrorKind::CSSWideKeywordDisallowed,
-                            span: ident.span,
-                        });
-                    }
-                    _ => {}
+                if let InterpolableIdent::Literal(ident) = &ident
+                    && (util::is_css_wide_keyword(ident.name)
+                        || ident.name.eq_ignore_ascii_case("default"))
+                {
+                    input.recoverable_errors.push(Error {
+                        kind: ErrorKind::CSSWideKeywordDisallowed,
+                        span: ident.span,
+                    });
                 }
                 Ok(KeyframesName::Ident(ident))
             }

--- a/crates/oxc_css_parser/src/parser/value.rs
+++ b/crates/oxc_css_parser/src/parser/value.rs
@@ -408,12 +408,11 @@ impl<'a> Parser<'a> {
     // <dashed-ident> = <ident-token> whose name starts with '--'
     pub(super) fn parse_dashed_ident(&mut self) -> PResult<InterpolableIdent<'a>> {
         let ident = self.parse()?;
-        match &ident {
-            InterpolableIdent::Literal(ident) if !ident.name.starts_with("--") => {
-                self.recoverable_errors
-                    .push(Error { kind: ErrorKind::ExpectDashedIdent, span: ident.span });
-            }
-            _ => {}
+        if let InterpolableIdent::Literal(ident) = &ident
+            && !ident.name.starts_with("--")
+        {
+            self.recoverable_errors
+                .push(Error { kind: ErrorKind::ExpectDashedIdent, span: ident.span });
         }
         Ok(ident)
     }

--- a/crates/oxc_css_parser/src/tokenizer/mod.rs
+++ b/crates/oxc_css_parser/src/tokenizer/mod.rs
@@ -649,33 +649,30 @@ impl<'a> Tokenizer<'a> {
             }
         }
 
-        match self.peek_two_bytes() {
-            Some((_, b'e' | b'E', second))
-                if second == b'-' || second == b'+' || second.is_ascii_digit() =>
-            {
+        if let Some((_, b'e' | b'E', second)) = self.peek_two_bytes()
+            && (second == b'-' || second == b'+' || second.is_ascii_digit())
+        {
+            self.state.chars.next();
+
+            if let Some((_, b'-' | b'+')) = self.state.chars.peek() {
                 self.state.chars.next();
+            }
 
-                if let Some((_, b'-' | b'+')) = self.state.chars.peek() {
-                    self.state.chars.next();
-                }
-
-                loop {
-                    match self.state.chars.peek() {
-                        Some((_, c)) if c.is_ascii_digit() => {
-                            self.state.chars.next();
-                        }
-                        Some((i, _)) => {
-                            end = *i;
-                            break;
-                        }
-                        None => {
-                            end = self.source.len();
-                            break;
-                        }
+            loop {
+                match self.state.chars.peek() {
+                    Some((_, c)) if c.is_ascii_digit() => {
+                        self.state.chars.next();
+                    }
+                    Some((i, _)) => {
+                        end = *i;
+                        break;
+                    }
+                    None => {
+                        end = self.source.len();
+                        break;
                     }
                 }
             }
-            _ => {}
         }
 
         debug_assert!(start < end);


### PR DESCRIPTION
Rewrites five `match { pattern if guard => { .. }, _ => {} }` blocks as `if let .. && guard` chains (stable since Rust 1.88, within the new 1.95.0 MSRV from #111):

- `parser/value.rs` — `parse_dashed_ident`
- `parser/at_rule/counter_style.rs` — counter-style name check
- `parser/at_rule/keyframes.rs` — keyframe selector + keyframes name checks
- `tokenizer/mod.rs` — scientific-notation scan in number tokenization

Clippy's `single_match` bails on arms with guards, so these sites kept the heavier match form until now. Net −14 lines.

No behavior change: the full test suite passes and regenerating all conformance snapshots produces zero diff.