### PR TITLE
refactor(conformance): use slice::as_chunks for UTF-16 decoding

### DIFF
--- a/tasks/conformance/src/main.rs
+++ b/tasks/conformance/src/main.rs
@@ -240,9 +240,9 @@ fn parse_outcome(source: &str, syntax: Syntax, options: ParserOptions) -> Outcom
 /// falling back to UTF-8. Returns `None` for undecodable (binary) content.
 fn decode_text(bytes: &[u8]) -> Option<String> {
     fn utf16(bytes: &[u8], le: bool) -> Option<String> {
-        let units = bytes.chunks_exact(2).map(|c| {
-            if le { u16::from_le_bytes([c[0], c[1]]) } else { u16::from_be_bytes([c[0], c[1]]) }
-        });
+        let (pairs, _) = bytes.as_chunks::<2>();
+        let units =
+            pairs.iter().map(|&c| if le { u16::from_le_bytes(c) } else { u16::from_be_bytes(c) });
         char::decode_utf16(units).collect::<Result<String, _>>().ok()
     }
     match bytes {


### PR DESCRIPTION
Replaces `chunks_exact(2)` + manual `[c[0], c[1]]` re-arraying with `slice::as_chunks::<2>()` (stable since Rust 1.88, within the new 1.95.0 MSRV from #111) — the `&[u8; 2]` chunks feed `u16::from_le_bytes`/`from_be_bytes` directly.

Remainder handling is unchanged (both forms drop a trailing odd byte), and regenerating all conformance snapshots produces zero diff.