### PR TITLE
feat(parser): accept empty @scope () roots and limits

### DIFF
--- a/crates/oxc_css_parser/src/ast.rs
+++ b/crates/oxc_css_parser/src/ast.rs
@@ -2251,7 +2251,7 @@ pub struct ScopeEnd<'a> {
     pub span: Span,
     pub to_span: Span,
     pub lparen_span: Span,
-    pub selector: SelectorList<'a>,
+    pub selector: Option<SelectorList<'a>>,
 }
 
 #[derive(Debug)]
@@ -2268,7 +2268,7 @@ pub enum ScopePrelude<'a> {
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 pub struct ScopeStart<'a> {
     pub span: Span,
-    pub selector: SelectorList<'a>,
+    pub selector: Option<SelectorList<'a>>,
 }
 
 #[derive(Debug)]

--- a/crates/oxc_css_parser/src/parser/at_rule/scope.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/scope.rs
@@ -18,7 +18,14 @@ impl<'a> Parse<'a> for ScopeEnd<'a> {
         };
 
         let (_, lparen_span) = input.cursor.expect_l_paren()?;
-        let selector = input.parse()?;
+        // An empty scope root/limit (`@scope ()`, `to ()`) is accepted:
+        // <scope-start>/<scope-end> are forgiving selector lists, and
+        // lightningcss emits this form when every selector is dropped.
+        let selector = if let Token::RParen(..) = input.cursor.peek()?.token {
+            None
+        } else {
+            Some(input.parse()?)
+        };
         let (_, Span { end, .. }) = input.cursor.expect_r_paren()?;
 
         let span = Span { start: to_span.start, end };
@@ -63,7 +70,12 @@ impl<'a> Parse<'a> for ScopePrelude<'a> {
 impl<'a> Parse<'a> for ScopeStart<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         let (_, Span { start, .. }) = input.cursor.expect_l_paren()?;
-        let selector = input.parse()?;
+        // See `ScopeEnd`: an empty `@scope ()` root is accepted.
+        let selector = if let Token::RParen(..) = input.cursor.peek()?.token {
+            None
+        } else {
+            Some(input.parse()?)
+        };
         let (_, Span { end, .. }) = input.cursor.expect_r_paren()?;
 
         Ok(ScopeStart { selector, span: Span { start, end } })

--- a/crates/oxc_css_parser/tests/ast/at-rule/scope-empty.css
+++ b/crates/oxc_css_parser/tests/ast/at-rule/scope-empty.css
@@ -1,0 +1,2 @@
+@scope(){a{color:red}}
+@scope () to () { a { color: red } }


### PR DESCRIPTION
Fixes LC-SCOPE-002 from #109: lightningcss accepts `@scope (.x || a)` and re-emits it as `@scope ()`; this parser rejected the emitted form with `simple selector is expected` while postcss, Prettier, and lightningcss accept it.

`<scope-start>`/`<scope-end>` are forgiving selector lists, so the empty form is now represented as `selector: None` (`ScopeStart.selector`/`ScopeEnd.selector` become `Option<SelectorList>`). `to ()` is accepted symmetrically.

Full test suite passes and conformance snapshots are unchanged.