### PR TITLE
feat(parser): support scroll-driven keyframe timeline-range selectors

### DIFF
--- a/crates/oxc_css_parser/src/ast.rs
+++ b/crates/oxc_css_parser/src/ast.rs
@@ -669,6 +669,18 @@ pub struct KeyframeBlock<'a> {
 pub enum KeyframeSelector<'a> {
     Ident(InterpolableIdent<'a>),
     Percentage(Percentage<'a>),
+    TimelineRange(KeyframeTimelineRange<'a>),
+}
+
+/// A scroll-driven animations keyframe selector: `<timeline-range-name>
+/// <percentage>` (`entry 0%`, `exit-crossing 100%`).
+#[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
+pub struct KeyframeTimelineRange<'a> {
+    pub span: Span,
+    pub name: InterpolableIdent<'a>,
+    pub percentage: Percentage<'a>,
 }
 
 #[derive(Debug)]

--- a/crates/oxc_css_parser/src/ast_generated.rs
+++ b/crates/oxc_css_parser/src/ast_generated.rs
@@ -468,7 +468,15 @@ impl<'a> KeyframeSelector<'a> {
         match self {
             Self::Ident(value) => value.span(),
             Self::Percentage(value) => value.span(),
+            Self::TimelineRange(value) => value.span(),
         }
+    }
+}
+
+impl<'a> KeyframeTimelineRange<'a> {
+    #[inline]
+    pub fn span(&self) -> &Span {
+        &self.span
     }
 }
 

--- a/crates/oxc_css_parser/src/parser/at_rule/keyframes.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/keyframes.rs
@@ -35,13 +35,43 @@ impl<'a> Parse<'a> for KeyframeBlock<'a> {
     }
 }
 
+// https://drafts.csswg.org/scroll-animations-1/#named-ranges
+fn is_timeline_range_name(name: &str) -> bool {
+    name.eq_ignore_ascii_case("cover")
+        || name.eq_ignore_ascii_case("contain")
+        || name.eq_ignore_ascii_case("entry")
+        || name.eq_ignore_ascii_case("exit")
+        || name.eq_ignore_ascii_case("entry-crossing")
+        || name.eq_ignore_ascii_case("exit-crossing")
+}
+
 // <keyframe-selector> = from | to | <percentage [0,100]>
+//                     | <timeline-range-name> <percentage [0,100]>
 impl<'a> Parse<'a> for KeyframeSelector<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match &input.cursor.peek()?.token {
             Token::Percentage(..) => Ok(KeyframeSelector::Percentage(input.parse()?)),
             _ => {
-                let ident = input.parse()?;
+                let ident = input.parse::<InterpolableIdent>()?;
+                // Scroll-driven animations attach keyframes to a named
+                // timeline range: `entry 0%`, `exit-crossing 100%`.
+                if let Token::Percentage(..) = &input.cursor.peek()?.token {
+                    if let InterpolableIdent::Literal(ident) = &ident
+                        && !is_timeline_range_name(ident.name)
+                    {
+                        input.recoverable_errors.push(Error {
+                            kind: ErrorKind::UnknownKeyframeSelectorIdent,
+                            span: ident.span,
+                        });
+                    }
+                    let percentage = input.parse::<Percentage>()?;
+                    let span = Span { start: ident.span().start, end: percentage.span.end };
+                    return Ok(KeyframeSelector::TimelineRange(KeyframeTimelineRange {
+                        name: ident,
+                        percentage,
+                        span,
+                    }));
+                }
                 if let InterpolableIdent::Literal(ident) = &ident
                     && !ident.name.eq_ignore_ascii_case("from")
                     && !ident.name.eq_ignore_ascii_case("to")

--- a/crates/oxc_css_parser/tests/ast/at-rule/keyframes.css
+++ b/crates/oxc_css_parser/tests/ast/at-rule/keyframes.css
@@ -58,3 +58,9 @@
 @keyframes abc { \66rom {} }
 @keyframes a\2c c { \66rom {} }
 @keyframes a\,c { \66rom {} }
+@keyframes k { entry 0% {} }
+@keyframes k { exit 100% { opacity: 0 } }
+@keyframes k { cover 25%, contain 75% {} }
+@keyframes k { entry-crossing 0%, exit-crossing 100% {} }
+@keyframes k { from {} entry 50% {} to {} }
+@keyframes k{entry 0%{}}

--- a/crates/oxc_css_parser/tests/recoverable/at-rule/keyframes.css
+++ b/crates/oxc_css_parser/tests/recoverable/at-rule/keyframes.css
@@ -1,3 +1,6 @@
 @keyframes kf {
   form {}
 }
+@keyframes kf2 {
+  bogus-range 50% {}
+}

--- a/crates/oxc_css_parser/tests/recoverable/at-rule/keyframes.css.error.snap
+++ b/crates/oxc_css_parser/tests/recoverable/at-rule/keyframes.css.error.snap
@@ -7,4 +7,8 @@ error: unknown keyframe selector
 2 │   form {}
   │   ^^^^
 
-
+error: unknown keyframe selector
+  ┌─ keyframes.css:5:3
+  │
+5 │   bogus-range 50% {}
+  │   ^^^^^^^^^^^


### PR DESCRIPTION
Fixes OXC-SCROLL-001 from #109: scroll-driven animations extend `<keyframe-selector>` with `<timeline-range-name> <percentage [0,100]>` (`@keyframes k { entry 0% {} }`); the parser rejected the percentage after the range name with `expect token :`.

- New `KeyframeSelector::TimelineRange(KeyframeTimelineRange)` AST variant holding the range name and percentage.
- Names outside the six ranges defined by scroll-animations-1 (`cover`, `contain`, `entry`, `exit`, `entry-crossing`, `exit-crossing`) still parse but report the existing `unknown keyframe selector` recoverable error, consistent with how non-`from`/`to` idents are handled.

Full test suite passes and conformance snapshots are unchanged.