### PR TITLE
feat(parser): allow multiple idents in ::part()

### DIFF
--- a/crates/oxc_css_parser/src/ast.rs
+++ b/crates/oxc_css_parser/src/ast.rs
@@ -1628,7 +1628,18 @@ pub enum PseudoElementSelectorArgKind<'a> {
     CompoundSelector(CompoundSelector<'a>),
     CompoundSelectorList(CompoundSelectorList<'a>),
     Ident(InterpolableIdent<'a>),
+    IdentList(IdentList<'a>),
     TokenSeq(TokenSeq<'a>),
+}
+
+/// A space-separated `<ident>+` list, e.g. the argument of `::part(tab active)`
+/// (CSS Shadow Parts).
+#[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
+pub struct IdentList<'a> {
+    pub span: Span,
+    pub idents: Vec<'a, InterpolableIdent<'a>>,
 }
 
 #[derive(Debug)]

--- a/crates/oxc_css_parser/src/ast_generated.rs
+++ b/crates/oxc_css_parser/src/ast_generated.rs
@@ -1238,8 +1238,16 @@ impl<'a> PseudoElementSelectorArgKind<'a> {
             Self::CompoundSelector(value) => value.span(),
             Self::CompoundSelectorList(value) => value.span(),
             Self::Ident(value) => value.span(),
+            Self::IdentList(value) => value.span(),
             Self::TokenSeq(value) => value.span(),
         }
+    }
+}
+
+impl<'a> IdentList<'a> {
+    #[inline]
+    pub fn span(&self) -> &Span {
+        &self.span
     }
 }
 

--- a/crates/oxc_css_parser/src/parser/selector.rs
+++ b/crates/oxc_css_parser/src/parser/selector.rs
@@ -1053,7 +1053,28 @@ impl<'a> Parse<'a> for PseudoElementSelector<'a> {
                     InterpolableIdent::Literal(Ident { name, .. })
                         if name.eq_ignore_ascii_case("part") =>
                     {
-                        input.parse().map(PseudoElementSelectorArgKind::Ident)?
+                        // ::part( <ident>+ ) — CSS Shadow Parts allows
+                        // selecting multiple part names at once.
+                        let first = input.parse::<InterpolableIdent>()?;
+                        if matches!(
+                            input.cursor.peek()?.token,
+                            Token::Ident(..) | Token::HashLBrace(..) | Token::AtLBraceVar(..)
+                        ) {
+                            let mut span = *first.span();
+                            let mut idents = input.vec_with_capacity(2);
+                            idents.push(first);
+                            while matches!(
+                                input.cursor.peek()?.token,
+                                Token::Ident(..) | Token::HashLBrace(..) | Token::AtLBraceVar(..)
+                            ) {
+                                let ident = input.parse::<InterpolableIdent>()?;
+                                span.end = ident.span().end;
+                                idents.push(ident);
+                            }
+                            PseudoElementSelectorArgKind::IdentList(IdentList { idents, span })
+                        } else {
+                            PseudoElementSelectorArgKind::Ident(first)
+                        }
                     }
                     InterpolableIdent::Literal(Ident { name, .. })
                         if name.eq_ignore_ascii_case("cue")

--- a/crates/oxc_css_parser/tests/ast/selectors/pseudo_element_selector.css
+++ b/crates/oxc_css_parser/tests/ast/selectors/pseudo_element_selector.css
@@ -55,3 +55,6 @@ video::cue-region(   #scroll   ) {}
 ::unknown(;) {}
 
 ::/**/before {}
+::part(a b){}
+::part(tab active) {}
+x-tab::part(one two three) { color: red }


### PR DESCRIPTION
Fixes OXC-SHADOW-PARTS-001 from #109: CSS Shadow Parts defines `::part( <ident>+ )`, so `::part(tab active)` selects elements exposing both part names; the parser rejected the second ident with `expect token )`.

Multiple names parse into a new `PseudoElementSelectorArgKind::IdentList` (space-separated `<ident>+` with its own span); a single name keeps the existing `Ident` shape.

Full test suite passes and conformance snapshots are unchanged.