### PR TITLE
fix(parser): don't report an error for @color-profile device-cmyk

### DIFF
--- a/crates/oxc_css_parser/src/parser/at_rule/color_profile.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/color_profile.rs
@@ -1,16 +1,31 @@
 use super::Parser;
-use crate::{Parse, ast::*, error::PResult};
+use crate::{
+    Parse,
+    ast::*,
+    error::{Error, ErrorKind, PResult},
+};
 
 // https://www.w3.org/TR/css-color-5/#at-profile
 //
 // @color-profile [ <dashed-ident> | device-cmyk ] { <declaration-list> }
 impl<'a> Parse<'a> for ColorProfilePrelude<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        match input.parse_dashed_ident()? {
+        // Not `parse_dashed_ident`: the predefined `device-cmyk` name is
+        // valid without leading dashes and must not report its error.
+        match input.parse()? {
             InterpolableIdent::Literal(ident) if ident.name.eq_ignore_ascii_case("device-cmyk") => {
                 Ok(ColorProfilePrelude::DeviceCmyk(ident))
             }
-            ident => Ok(ColorProfilePrelude::DashedIdent(ident)),
+            ident => {
+                if let InterpolableIdent::Literal(ident) = &ident
+                    && !ident.name.starts_with("--")
+                {
+                    input
+                        .recoverable_errors
+                        .push(Error { kind: ErrorKind::ExpectDashedIdent, span: ident.span });
+                }
+                Ok(ColorProfilePrelude::DashedIdent(ident))
+            }
         }
     }
 }

--- a/crates/oxc_css_parser/tests/ast/at-rule/color-profile.css
+++ b/crates/oxc_css_parser/tests/ast/at-rule/color-profile.css
@@ -1,0 +1,4 @@
+@color-profile --swop5c { src: url("swop.icc"); }
+@color-profile device-cmyk { src: url("cmyk.icc"); }
+@color-profile DEVICE-CMYK { components: c m y k }
+@color-profile device-cmyk{a:b}

--- a/crates/oxc_css_parser/tests/recoverable/at-rule/color-profile.css
+++ b/crates/oxc_css_parser/tests/recoverable/at-rule/color-profile.css
@@ -1,0 +1,1 @@
+@color-profile foo { src: url("x.icc"); }

--- a/crates/oxc_css_parser/tests/recoverable/at-rule/color-profile.css.error.snap
+++ b/crates/oxc_css_parser/tests/recoverable/at-rule/color-profile.css.error.snap
@@ -1,0 +1,8 @@
+---
+source: crates/oxc_css_parser/tests/recoverable.rs
+---
+error: dashed identifier is expected
+  ┌─ color-profile.css:1:16
+  │
+1 │ @color-profile foo { src: url("x.icc"); }
+  │                ^^^


### PR DESCRIPTION
Fixes OXC-COLOR-001 from #109: CSS Color 5 allows `device-cmyk` as a predefined `@color-profile` name (`@color-profile [ <dashed-ident> | device-cmyk ]`), but the prelude parser routed through `parse_dashed_ident`, which pushed its recoverable `dashed identifier is expected` error before the `device-cmyk` match ever ran — so the AST was right but the parse wasn't clean.

The prelude now checks `device-cmyk` (ASCII case-insensitive) before applying the dashed-ident requirement; other non-dashed names still report the recoverable error (covered by a new recoverable-fixture snapshot).

Full test suite passes and conformance snapshots are unchanged.