### PR TITLE
feat(parser): accept functional pseudo-pages (@page::slot())

### DIFF
--- a/crates/oxc_css_parser/src/ast.rs
+++ b/crates/oxc_css_parser/src/ast.rs
@@ -1637,6 +1637,9 @@ pub enum PseudoElementSelectorArgKind<'a> {
 pub struct PseudoPage<'a> {
     pub span: Span,
     pub name: InterpolableIdent<'a>,
+    /// The raw argument of a functional pseudo-page, e.g. `g` in
+    /// `@page::slot(g)` (CSS Template Layout).
+    pub arg: Option<TokenSeq<'a>>,
 }
 
 #[derive(Debug)]

--- a/crates/oxc_css_parser/src/parser/at_rule/page.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/page.rs
@@ -18,7 +18,7 @@ impl<'a> Parse<'a> for PageSelector<'a> {
         let start;
         let mut end;
 
-        if let Token::Colon(..) = &input.cursor.peek()?.token {
+        if let Token::Colon(..) | Token::ColonColon(..) = &input.cursor.peek()?.token {
             let first = input.parse::<PseudoPage>()?;
             start = first.span.start;
             end = first.span.end;
@@ -33,7 +33,9 @@ impl<'a> Parse<'a> for PageSelector<'a> {
 
         loop {
             match input.cursor.peek()? {
-                TokenWithSpan { token: Token::Colon(..), span } if span.start == end => {
+                TokenWithSpan { token: Token::Colon(..) | Token::ColonColon(..), span }
+                    if span.start == end =>
+                {
                     let item = input.parse::<PseudoPage>()?;
                     end = item.span.end;
                     pseudo.push(item);
@@ -67,15 +69,32 @@ impl<'a> Parse<'a> for PageSelectorList<'a> {
 }
 
 // <pseudo-page> = ':' [ left | right | first | blank ]
+//
+// CSS Template Layout additionally uses a pseudo-element-style functional
+// form: `@page::slot(g)`.
 impl<'a> Parse<'a> for PseudoPage<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
-        let (_, colon_span) = input.cursor.expect_colon()?;
+        let colon_span = match &input.cursor.peek()?.token {
+            Token::ColonColon(..) => input.cursor.expect_colon_colon()?.1,
+            _ => input.cursor.expect_colon()?.1,
+        };
         let name = input.parse::<InterpolableIdent>()?;
 
         let name_span = name.span();
         util::assert_no_ws_or_comment(&colon_span, name_span)?;
+        let mut end = name_span.end;
 
-        let span = Span { start: colon_span.start, end: name_span.end };
-        Ok(PseudoPage { name, span })
+        let arg = match input.cursor.peek()? {
+            TokenWithSpan { token: Token::LParen(..), span } if span.start == end => {
+                input.cursor.bump()?;
+                let tokens = input.parse_tokens_in_parens()?;
+                end = input.cursor.expect_r_paren()?.1.end;
+                Some(tokens)
+            }
+            _ => None,
+        };
+
+        let span = Span { start: colon_span.start, end };
+        Ok(PseudoPage { name, arg, span })
     }
 }

--- a/crates/oxc_css_parser/tests/ast/at-rule/page.css
+++ b/crates/oxc_css_parser/tests/ast/at-rule/page.css
@@ -43,3 +43,6 @@
 
     margin: 20px;
 }
+@page::slot(g){}
+@page main::slot(header) { color: red }
+@page :first::slot(a) {}


### PR DESCRIPTION
Fixes DRAFT-TEMPLATE-001 from #109: CSS Template Layout 1 uses a pseudo-element-style functional pseudo-page — `@page::slot(g)` — which the parser rejected with `expect token ;, but found ::` (postcss and Prettier accept it; it's draft syntax, but a parser-only tool shouldn't hard-error).

Pseudo-pages now accept both `:` and `::` prefixes and an optional raw parenthesized argument, stored as `PseudoPage.arg: Option<TokenSeq>`. The standard `:left`/`:right`/`:first`/`:blank` forms are unchanged.

Full test suite passes and conformance snapshots are unchanged.