### PR TITLE
fix(parser): parse `:host` and `:host-context` args as selector list

### DIFF
--- a/crates/oxc_css_parser/src/parser/selector.rs
+++ b/crates/oxc_css_parser/src/parser/selector.rs
@@ -999,7 +999,9 @@ impl<'a> Parse<'a> for PseudoClassSelector<'a> {
                         if name.eq_ignore_ascii_case("host")
                             || name.eq_ignore_ascii_case("host-context") =>
                     {
-                        input.parse().map(PseudoClassSelectorArgKind::CompoundSelector)?
+                        // formally a single compound selector, but Angular's ShadowCss
+                        // supports combinators and lists (`:host-context(.parent .child)`)
+                        input.parse().map(PseudoClassSelectorArgKind::SelectorList)?
                     }
                     InterpolableIdent::Literal(Ident { name, .. })
                         if input.syntax == Syntax::Less && *name == "extend" =>

--- a/crates/oxc_css_parser/tests/ast/selectors/pseudo_class_selector.css
+++ b/crates/oxc_css_parser/tests/ast/selectors/pseudo_class_selector.css
@@ -158,6 +158,10 @@ h1:-webkit-any(.h1class, #bar) {}
 :host {}
 :host-context(h1) {}
 :host-context(   h1   ) {}
+:host-context(.parent .child) {}
+:host-context(app-render pl-part) {}
+:host-context(.a, .b) {}
+:host(.a .b) {}
 
 :unknown {}
 :unknown() {}


### PR DESCRIPTION
For https://github.com/oxc-project/oxc/issues/24726, to handle Angular ShadowCss.
