### PR TITLE
refactor(ast)!: remove unused `PseudoClassSelectorArgKind::CompoundSelector`

### DIFF
--- a/crates/oxc_css_parser/src/ast.rs
+++ b/crates/oxc_css_parser/src/ast.rs
@@ -1602,7 +1602,6 @@ pub struct PseudoClassSelectorArg<'a> {
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum PseudoClassSelectorArgKind<'a> {
-    CompoundSelector(CompoundSelector<'a>),
     CompoundSelectorList(CompoundSelectorList<'a>),
     Ident(InterpolableIdent<'a>),
     LanguageRangeList(LanguageRangeList<'a>),

--- a/crates/oxc_css_parser/src/ast_generated.rs
+++ b/crates/oxc_css_parser/src/ast_generated.rs
@@ -1211,7 +1211,6 @@ impl<'a> PseudoClassSelectorArgKind<'a> {
     #[inline]
     pub fn span(&self) -> &Span {
         match self {
-            Self::CompoundSelector(value) => value.span(),
             Self::CompoundSelectorList(value) => value.span(),
             Self::Ident(value) => value.span(),
             Self::LanguageRangeList(value) => value.span(),


### PR DESCRIPTION
`:host` and `:host-context` were the last survivors.