### PR TITLE
perf(ast): box the fat `SimpleSelector`, `MediaFeature` and `MediaQuery` variants

### DIFF
--- a/crates/oxc_css_parser/src/ast.rs
+++ b/crates/oxc_css_parser/src/ast.rs
@@ -2330,9 +2330,9 @@ pub enum SimpleSelector<'a> {
     Class(ClassSelector<'a>),
     Id(IdSelector<'a>),
     Type(TypeSelector<'a>),
-    Attribute(AttributeSelector<'a>),
-    PseudoClass(PseudoClassSelector<'a>),
-    PseudoElement(PseudoElementSelector<'a>),
+    Attribute(Box<'a, AttributeSelector<'a>>),
+    PseudoClass(Box<'a, PseudoClassSelector<'a>>),
+    PseudoElement(Box<'a, PseudoElementSelector<'a>>),
     Nesting(NestingSelector<'a>),
     SassPlaceholder(SassPlaceholderSelector<'a>),
 }

--- a/crates/oxc_css_parser/src/ast.rs
+++ b/crates/oxc_css_parser/src/ast.rs
@@ -1312,10 +1312,10 @@ pub enum MediaConditionKind<'a> {
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum MediaFeature<'a> {
-    Plain(MediaFeaturePlain<'a>),
+    Plain(Box<'a, MediaFeaturePlain<'a>>),
     Boolean(MediaFeatureBoolean<'a>),
-    Range(MediaFeatureRange<'a>),
-    RangeInterval(MediaFeatureRangeInterval<'a>),
+    Range(Box<'a, MediaFeatureRange<'a>>),
+    RangeInterval(Box<'a, MediaFeatureRangeInterval<'a>>),
 }
 
 #[derive(Debug)]
@@ -1426,7 +1426,7 @@ pub struct MediaOr<'a> {
 #[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum MediaQuery<'a> {
     ConditionOnly(MediaCondition<'a>),
-    WithType(MediaQueryWithType<'a>),
+    WithType(Box<'a, MediaQueryWithType<'a>>),
     Function(Function<'a>),
     LessVariable(LessVariable<'a>),
     LessNamespaceValue(Box<'a, LessNamespaceValue<'a>>),

--- a/crates/oxc_css_parser/src/ast.rs
+++ b/crates/oxc_css_parser/src/ast.rs
@@ -2639,3 +2639,10 @@ pub struct WqName<'a> {
     pub name: InterpolableIdent<'a>,
     pub prefix: Option<NsPrefix<'a>>,
 }
+
+#[cfg(target_pointer_width = "64")]
+const _: () = {
+    assert!(size_of::<SimpleSelector<'static>>() == 160);
+    assert!(size_of::<MediaFeature<'static>>() == 88);
+    assert!(size_of::<MediaQuery<'static>>() == 96);
+};

--- a/crates/oxc_css_parser/src/parser/at_rule/media.rs
+++ b/crates/oxc_css_parser/src/parser/at_rule/media.rs
@@ -52,7 +52,9 @@ impl<'a> Parse<'a> for MediaFeature<'a> {
     fn parse(input: &mut Parser<'a>) -> PResult<Self> {
         match input.parse_media_feature_value()? {
             ComponentValue::InterpolableIdent(ident) => match &input.cursor.peek()?.token {
-                Token::Colon(..) => input.parse_media_feature_plain(ident).map(MediaFeature::Plain),
+                Token::Colon(..) => input
+                    .parse_media_feature_plain(ident)
+                    .map(|f| MediaFeature::Plain(input.alloc(f))),
                 Token::LessThan(..)
                 | Token::LessThanEqual(..)
                 | Token::GreaterThan(..)
@@ -423,23 +425,23 @@ impl<'a> Parser<'a> {
                     let right_comparison = self.parse()?;
                     let right = self.parse_media_feature_value()?;
                     let span = Span { start: left.span().start, end: right.span().end };
-                    Ok(MediaFeature::RangeInterval(MediaFeatureRangeInterval {
+                    Ok(MediaFeature::RangeInterval(self.alloc(MediaFeatureRangeInterval {
                         left,
                         left_comparison: comparison,
                         name: MediaFeatureName::Ident(ident),
                         right_comparison,
                         right,
                         span,
-                    }))
+                    })))
                 }
                 _ => {
                     let span = Span { start: left.span().start, end: ident.span().end };
-                    Ok(MediaFeature::Range(MediaFeatureRange {
+                    Ok(MediaFeature::Range(self.alloc(MediaFeatureRange {
                         left,
                         comparison,
                         right: ComponentValue::InterpolableIdent(ident),
                         span,
-                    }))
+                    })))
                 }
             }
         } else {
@@ -452,12 +454,12 @@ impl<'a> Parser<'a> {
                 });
             }
             let span = Span { start: left.span().start, end: name_or_right.span().end };
-            Ok(MediaFeature::Range(MediaFeatureRange {
+            Ok(MediaFeature::Range(self.alloc(MediaFeatureRange {
                 left,
                 comparison,
                 right: name_or_right,
                 span,
-            }))
+            })))
         }
     }
 
@@ -504,7 +506,9 @@ impl<'a> Parser<'a> {
                     span: Span { start: mq_span.start, end },
                 }))
             }
-            (media_query_with_type, _) => Ok(MediaQuery::WithType(media_query_with_type)),
+            (media_query_with_type, _) => {
+                Ok(MediaQuery::WithType(self.alloc(media_query_with_type)))
+            }
         }
     }
 }

--- a/crates/oxc_css_parser/src/parser/selector.rs
+++ b/crates/oxc_css_parser/src/parser/selector.rs
@@ -1218,13 +1218,16 @@ impl<'a> Parse<'a> for SimpleSelector<'a> {
                 input.parse().map(SimpleSelector::Id)
             }
             TokenWithSpan { token: Token::LBracket(..), .. } => {
-                input.parse().map(SimpleSelector::Attribute)
+                let selector = input.parse()?;
+                Ok(SimpleSelector::Attribute(input.alloc(selector)))
             }
             TokenWithSpan { token: Token::Colon(..), .. } => {
-                input.parse().map(SimpleSelector::PseudoClass)
+                let selector = input.parse()?;
+                Ok(SimpleSelector::PseudoClass(input.alloc(selector)))
             }
             TokenWithSpan { token: Token::ColonColon(..), .. } => {
-                input.parse().map(SimpleSelector::PseudoElement)
+                let selector = input.parse()?;
+                Ok(SimpleSelector::PseudoElement(input.alloc(selector)))
             }
             TokenWithSpan {
                 token:


### PR DESCRIPTION
AI Disclosure: Generated with Claude Code, Opus 5. Reviewed and tested by me.

Two AST-only changes that box the fattest enum variants. A Rust enum is as large as its largest variant, so a single oversized variant inflates *every* instance of that enum — including the ones stored inline in arena `Vec`s. Boxing the outliers shrinks the whole enum.

| type | before | after |
|---|---|---|
| `SimpleSelector` | 368 B | 160 B |
| `MediaFeature` | 392 B | 88 B |
| `MediaQuery` | 224 B | 96 B |

`SimpleSelector` was pinned by `AttributeSelector` (368 B) being stored inline;
`MediaFeature` by `MediaFeaturePlain`/`Range`/`RangeInterval`.

## Results

Measured on the `benches/self.rs` fixtures. Time is criterion's mean estimate,
`main` as saved baseline; arena is `Allocator::used_bytes()` after a full parse.

| fixture | time (main → branch) | arena (main → branch) |
|---|---|---|
| `css-media.css` | 93.15 → 92.54 µs (−0.6%, p = 0.70) | 423,224 → 378,480 B (**−10.6%**) |
| `less-mixin-definition.less` | 40.87 → 40.17 µs (**−1.7%**) | 199,608 → 170,904 B (**−14.4%**) |
| `scss-interpolation.scss` | 77.55 → 76.45 µs (**−1.4%**) | 468,145 → 386,328 B (**−17.5%**) |
| `sass-map.sass` | 1.936 → 1.928 µs (**−0.4%**) | 6,424 → 6,424 B (0%) |

The `css-media.css` timing run was noisy and its change is not statistically
significant; the other three are (p < 0.05). The memory numbers are
deterministic — no run-to-run variance.

The win is memory more than speed, which is expected: the parser is bump-
allocated, so smaller nodes mean fewer arena chunks, but the time saved is only
the reduced memcpy and cache pressure.

## Risk

Pure AST shape change — no parser logic touched beyond the construction sites
that now wrap in `input.alloc(..)`. Full test suite passes, clippy is clean, and
all conformance snapshots are byte-identical.

## Note

This is a public API break for anyone matching on these enums: the affected
variants now hold `Box<'a, T>` instead of `T`.
