### PR TITLE
fix(parser): correct signed-value handling in Less operations and Sass calculations

### DIFF
--- a/crates/oxc_css_parser/src/parser/less.rs
+++ b/crates/oxc_css_parser/src/parser/less.rs
@@ -416,6 +416,13 @@ impl<'a> Parser<'a> {
             self.parse_less_operation_recursively(allow_mixin_call, precedence + 1)?
         };
 
+        // delimiter can't be calculated (same guard as the SassScript path):
+        // `func(20px, +20px)` / `func(20px,-20px)` are two args in lessc,
+        // never a `,`-left operation
+        if matches!(left, ComponentValue::Delimiter(..)) {
+            return Ok(left);
+        }
+
         loop {
             let op = match self.cursor.peek()? {
                 TokenWithSpan { token: Token::Asterisk(..), .. }
@@ -472,12 +479,15 @@ impl<'a> Parser<'a> {
                         span: self.cursor.bump()?.span,
                     }
                 }
+                // A sign the lexer folded into a number/dimension token is a
+                // binary operator only when glued to the left operand, for `+` and `-` alike:
+                // lessc reads `10px+20px` as `30px` but `10px +20px` as the two-value list `10px 20px`.
                 token @ TokenWithSpan { token: Token::Number(..), span }
                     if precedence == PRECEDENCE_PLUS
-                        && token.number_raw(self.source).is_some_and(|raw| {
-                            raw.starts_with('+')
-                                || raw.starts_with('-') && span.start == left.span().end
-                        }) =>
+                        && token
+                            .number_raw(self.source)
+                            .is_some_and(|raw| raw.starts_with('+') || raw.starts_with('-'))
+                        && span.start == left.span().end =>
                 {
                     let (number, number_span) = self.cursor.expect_number()?;
                     let op = LessOperationOperator {
@@ -506,10 +516,10 @@ impl<'a> Parser<'a> {
                 }
                 token @ TokenWithSpan { token: Token::Dimension(..), span }
                     if precedence == PRECEDENCE_PLUS
-                        && token.dimension_value_raw(self.source).is_some_and(|raw| {
-                            raw.starts_with('+')
-                                || raw.starts_with('-') && span.start == left.span().end
-                        }) =>
+                        && token
+                            .dimension_value_raw(self.source)
+                            .is_some_and(|raw| raw.starts_with('+') || raw.starts_with('-'))
+                        && span.start == left.span().end =>
                 {
                     let (dimension, dimension_span) = self.cursor.expect_dimension()?;
                     let op = LessOperationOperator {

--- a/crates/oxc_css_parser/src/parser/value.rs
+++ b/crates/oxc_css_parser/src/parser/value.rs
@@ -96,6 +96,90 @@ impl<'a> Parser<'a> {
             self.parse_calc_expr_recursively(precedence + 1, allow_modulo)?
         };
 
+        // SassScript: a sign the lexer folded into a number/dimension token,
+        // glued to a function-call operand, is a binary operator (`max(map-get($m, a)-1, 0)` is `... - 1`).
+        // The same as the `parse_sass_bin_expr` value path.
+        // dart-sass rejects the glued form inside calculations outright,
+        // so structuring the operation keeps the intended subtraction instead of splitting off a signed value.
+        // Function-call lefts ONLY, deliberately:
+        // - word-glued runs (`100%-20px`, `10px+1px`) stay separate values and print verbatim as one postcss word
+        // - a parenthesized left can never glue-match anyway (its span ends before the `)`, see the `eat_l_paren` arm above)
+        // This can only fire right after `left` is parsed (a formed `Calc` is never a `Function`),
+        // so it lives before the operator loop.
+        if precedence == PRECEDENCE_PLUS
+            && matches!(self.syntax, Syntax::Scss | Syntax::Sass)
+            && matches!(left, ComponentValue::Function(..))
+        {
+            let left_end = left.span().end;
+            let split_op = |raw: &str, start: usize| CalcOperator {
+                kind: if raw.starts_with('+') {
+                    CalcOperatorKind::Plus
+                } else {
+                    CalcOperatorKind::Minus
+                },
+                span: Span { start, end: start + 1 },
+            };
+            match self.cursor.peek()? {
+                token @ TokenWithSpan { token: Token::Number(..), span }
+                    if token
+                        .number_raw(self.source)
+                        .is_some_and(|raw| raw.starts_with('+') || raw.starts_with('-'))
+                        && span.start == left_end =>
+                {
+                    let (number, number_span) = self.cursor.expect_number()?;
+                    let op = split_op(number.raw, number_span.start);
+                    let right = {
+                        let span = Span { start: number_span.start + 1, end: number_span.end };
+                        let raw = unsafe { number.raw.get_unchecked(1..number.raw.len()) };
+                        Number::try_from((crate::token::Number { raw }, span))
+                            .map(ComponentValue::Number)?
+                    };
+                    let right = self.parse_calc_mul_tail(right, allow_modulo)?;
+                    let span = Span { start: left.span().start, end: right.span().end };
+                    left = ComponentValue::Calc(Calc {
+                        left: self.alloc(left),
+                        op,
+                        right: self.alloc(right),
+                        span,
+                    });
+                }
+                token @ TokenWithSpan { token: Token::Dimension(..), span }
+                    if token
+                        .dimension_value_raw(self.source)
+                        .is_some_and(|raw| raw.starts_with('+') || raw.starts_with('-'))
+                        && span.start == left_end =>
+                {
+                    let (dimension, dimension_span) = self.cursor.expect_dimension()?;
+                    let op = split_op(dimension.value.raw, dimension_span.start);
+                    let right = self
+                        .dimension(
+                            crate::token::Dimension {
+                                value: crate::token::Number {
+                                    raw: unsafe {
+                                        dimension
+                                            .value
+                                            .raw
+                                            .get_unchecked(1..dimension.value.raw.len())
+                                    },
+                                },
+                                unit: dimension.unit,
+                            },
+                            Span { start: dimension_span.start + 1, end: dimension_span.end },
+                        )
+                        .map(ComponentValue::Dimension)?;
+                    let right = self.parse_calc_mul_tail(right, allow_modulo)?;
+                    let span = Span { start: left.span().start, end: right.span().end };
+                    left = ComponentValue::Calc(Calc {
+                        left: self.alloc(left),
+                        op,
+                        right: self.alloc(right),
+                        span,
+                    });
+                }
+                _ => {}
+            }
+        }
+
         loop {
             let operator = match &self.cursor.peek()?.token {
                 Token::Asterisk(..) if precedence == PRECEDENCE_MULTIPLY => CalcOperator {
@@ -132,6 +216,33 @@ impl<'a> Parser<'a> {
         }
 
         Ok(left)
+    }
+
+    // Multiplicative continuation for an already-parsed left operand:
+    // `*`, `/` (and `%` for the legacy `min`/`max`) bind tighter than a split-off sign,
+    // so `max(x()-1px*2)` is `x() - (1px * 2)`.
+    fn parse_calc_mul_tail(
+        &mut self,
+        mut left: ComponentValue<'a>,
+        allow_modulo: bool,
+    ) -> PResult<ComponentValue<'a>> {
+        loop {
+            let kind = match &self.cursor.peek()?.token {
+                Token::Asterisk(..) => CalcOperatorKind::Multiply,
+                Token::Solidus(..) => CalcOperatorKind::Division,
+                Token::Percent(..) if allow_modulo => CalcOperatorKind::Modulo,
+                _ => return Ok(left),
+            };
+            let op = CalcOperator { kind, span: self.cursor.bump()?.span };
+            let right = self.parse_calc_expr_recursively(PRECEDENCE_MULTIPLY + 1, allow_modulo)?;
+            let span = Span { start: left.span().start, end: right.span().end };
+            left = ComponentValue::Calc(Calc {
+                left: self.alloc(left),
+                op,
+                right: self.alloc(right),
+                span,
+            });
+        }
     }
 
     // A single CSS `<component-value>`: a function, a `[]`/`()` block, or a

--- a/crates/oxc_css_parser/tests/signed_value_operations.rs
+++ b/crates/oxc_css_parser/tests/signed_value_operations.rs
@@ -34,11 +34,9 @@ fn first_function_args<'a>(ss: &'a Stylesheet<'static>) -> &'a [ComponentValue<'
 // `LessBinaryOperation`.
 #[test]
 fn less_comma_is_never_an_operand() {
-    for code in [
-        "a { p: func(20px, +20px); }",
-        "a { p: func(20px,+20px); }",
-        "a { p: func(20px,-20px); }",
-    ] {
+    for code in
+        ["a { p: func(20px, +20px); }", "a { p: func(20px,+20px); }", "a { p: func(20px,-20px); }"]
+    {
         let ss = parse(code, Syntax::Less);
         let [
             ComponentValue::Dimension(_),
@@ -58,8 +56,7 @@ fn less_comma_is_never_an_operand() {
 #[test]
 fn less_folded_plus_requires_glue() {
     let ss = parse("a { p: 10px +20px; }", Syntax::Less);
-    let [ComponentValue::Dimension(_), ComponentValue::Dimension(_)] =
-        first_declaration_value(&ss)
+    let [ComponentValue::Dimension(_), ComponentValue::Dimension(_)] = first_declaration_value(&ss)
     else {
         panic!("expected two values, got {:?}", first_declaration_value(&ss));
     };

--- a/crates/oxc_css_parser/tests/signed_value_operations.rs
+++ b/crates/oxc_css_parser/tests/signed_value_operations.rs
@@ -1,0 +1,138 @@
+use oxc_css_parser::{Allocator, ParserBuilder, Syntax, ast::*};
+
+fn parse(code: &'static str, syntax: Syntax) -> Stylesheet<'static> {
+    let allocator = Box::leak(Box::new(Allocator::default()));
+    let mut parser = ParserBuilder::new(allocator, code).syntax(syntax).build();
+    let ss = parser.parse::<Stylesheet>().unwrap();
+    assert!(
+        parser.recoverable_errors().is_empty(),
+        "recoverable errors: {:?}",
+        parser.recoverable_errors()
+    );
+    ss
+}
+
+fn first_declaration_value<'a>(ss: &'a Stylesheet<'static>) -> &'a [ComponentValue<'static>] {
+    let Statement::QualifiedRule(rule) = &ss.statements[0] else {
+        panic!("expected qualified rule");
+    };
+    let Statement::Declaration(decl) = &rule.block.statements[0] else {
+        panic!("expected declaration");
+    };
+    &decl.value
+}
+
+fn first_function_args<'a>(ss: &'a Stylesheet<'static>) -> &'a [ComponentValue<'static>] {
+    let [ComponentValue::Function(function)] = first_declaration_value(ss) else {
+        panic!("expected a single function value");
+    };
+    &function.args
+}
+
+// lessc: a comma can never be an operand, `func(20px, +20px)` is two args
+// (`+20px` is a signed value); previously this ASTed as a comma-left
+// `LessBinaryOperation`.
+#[test]
+fn less_comma_is_never_an_operand() {
+    for code in [
+        "a { p: func(20px, +20px); }",
+        "a { p: func(20px,+20px); }",
+        "a { p: func(20px,-20px); }",
+    ] {
+        let ss = parse(code, Syntax::Less);
+        let [
+            ComponentValue::Dimension(_),
+            ComponentValue::Delimiter(comma),
+            ComponentValue::Dimension(_),
+        ] = first_function_args(&ss)
+        else {
+            panic!("expected dim/comma/dim for {code:?}, got {:?}", first_function_args(&ss));
+        };
+        assert!(matches!(comma.kind, DelimiterKind::Comma));
+    }
+}
+
+// lessc glue rules are symmetric for `+` and `-`: a sign folded into the
+// number token is a binary operator only when glued to the left operand
+// (`10px+20px` is `30px`, `10px +20px` is the list `10px 20px`).
+#[test]
+fn less_folded_plus_requires_glue() {
+    let ss = parse("a { p: 10px +20px; }", Syntax::Less);
+    let [ComponentValue::Dimension(_), ComponentValue::Dimension(_)] =
+        first_declaration_value(&ss)
+    else {
+        panic!("expected two values, got {:?}", first_declaration_value(&ss));
+    };
+
+    let ss = parse("a { p: 10px+20px; }", Syntax::Less);
+    let [ComponentValue::LessBinaryOperation(op)] = first_declaration_value(&ss) else {
+        panic!("expected a binary operation, got {:?}", first_declaration_value(&ss));
+    };
+    assert!(matches!(op.op.kind, LessOperationOperatorKind::Plus));
+}
+
+// SassScript: a sign glued to a function-call operand inside a calculation is
+// a folded binary operator (`max(map-get($m, a)-1, 0)` is `... - 1`), same as
+// the value-position path; previously the `-1` split off as a signed value.
+#[test]
+fn scss_calc_arg_glued_sign_is_subtraction() {
+    let ss = parse("a { w: max(map-get($m, a)-1, 0); }", Syntax::Scss);
+    let [ComponentValue::Calc(calc), ComponentValue::Delimiter(_), ComponentValue::Number(_)] =
+        first_function_args(&ss)
+    else {
+        panic!("expected calc/comma/number, got {:?}", first_function_args(&ss));
+    };
+    assert!(matches!(calc.op.kind, CalcOperatorKind::Minus));
+    assert!(matches!(&*calc.left, ComponentValue::Function(_)));
+    assert!(matches!(&*calc.right, ComponentValue::Number(_)));
+}
+
+// Dimension right operand + the multiplicative tail: `*` binds tighter than
+// the split-off sign, `max(f()-1px*2, ...)` is `f() - (1px * 2)`.
+#[test]
+fn scss_calc_arg_glued_dimension_and_mul_tail() {
+    let ss = parse("a { w: max(map-get($m, a)-1px*2, 0px); }", Syntax::Scss);
+    let [ComponentValue::Calc(calc), ComponentValue::Delimiter(_), ComponentValue::Dimension(_)] =
+        first_function_args(&ss)
+    else {
+        panic!("expected calc/comma/dim, got {:?}", first_function_args(&ss));
+    };
+    assert!(matches!(calc.op.kind, CalcOperatorKind::Minus));
+    assert!(matches!(&*calc.left, ComponentValue::Function(_)));
+    let ComponentValue::Calc(mul) = &*calc.right else {
+        panic!("expected mul-bound right, got {:?}", calc.right);
+    };
+    assert!(matches!(mul.op.kind, CalcOperatorKind::Multiply));
+}
+
+// A spaced `-1` stays a signed value (dart-sass reads `x -1` as two list
+// elements, not subtraction).
+#[test]
+fn scss_calc_arg_spaced_sign_stays_a_value() {
+    let ss = parse("a { w: max(map-get($m, a) -1, 0); }", Syntax::Scss);
+    let [
+        ComponentValue::Function(_),
+        ComponentValue::Number(_),
+        ComponentValue::Delimiter(_),
+        ComponentValue::Number(_),
+    ] = first_function_args(&ss)
+    else {
+        panic!("expected fn/number/comma/number, got {:?}", first_function_args(&ss));
+    };
+}
+
+// Word-glued runs stay separate values (they print verbatim as one postcss
+// word); only a function-call left operand folds the sign into an operator.
+#[test]
+fn scss_calc_word_glued_run_stays_values() {
+    let ss = parse("a { w: max(100%-20px, 0px); }", Syntax::Scss);
+    let [
+        ComponentValue::Percentage(_),
+        ComponentValue::Dimension(_),
+        ComponentValue::Delimiter(_),
+        ComponentValue::Dimension(_),
+    ] = first_function_args(&ss)
+    else {
+        panic!("expected pct/dim/comma/dim, got {:?}", first_function_args(&ss));
+    };
+}


### PR DESCRIPTION
Two mis-parses around signed values.

Less: a delimiter is never an operand, and a folded `+` requires glue

```less
.x {
p1: func(20px, +20px); // two args: `+20px` is a signed value, NOT `, + 20px` operation
p2: 10px +20px;        // two-value list `10px 20px`, NOT `30px`
p3: 10px+20px;         // 30px (glued on both sides = operation, unchanged)
}
```

Previously `func(20px, +20px)` built a `LessBinaryOperation` with the comma as its left operand, and a space-preceded `+20px` was folded into an operation. lessc's glue rules are symmetric for `+` and `-`; the `-` side already required glue.

Sass: a sign glued to a function call inside a calculation is a binary operator

```scss
.x {
width: max(map-get($m, a)-1, 0); // `map-get($m, a) - 1`, NOT the two values `map-get($m, a)` `-1`
}
```

Same rule as the value-position path. Word-glued runs `(100%-20px)` and spaced signs (`x -1`, a two-element list) are unaffected.
