### PR TITLE
fix(tokenizer,parser): misc fixes for less-test-suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Owner: less.js. No postcss-less leniency.
 - No raw fallback for a normal property's value
 - Root declarations parse: less.js accepts them at parse time and fails only at eval
 - The IE `*color` hack as a name prefix and digit-only names (`5: x`), as less.js accepts them
+- Variable and property names are `[\w-]+` (`@-`, `@1`, `$-`), not CSS idents
+- A string interpolates only on an exact `@{name}` / `${name}`; `"@{box"` and the outer `@{box-` of `"@{box-@{suffix}}"` are text
+- An unquoted `url()` body runs to `)`, whitespace and newlines included
+- A variable declaration must reach `;` / `}`: `@page :first { ... }` is an at-rule, and the permissive `@this: () => { ... };` read is tried only when no typed value parses
 
 ### css-in-js parse mode
 

--- a/crates/oxc_css_parser/src/ast.rs
+++ b/crates/oxc_css_parser/src/ast.rs
@@ -141,6 +141,15 @@ pub struct Calc<'a> {
     pub right: Box<'a, ComponentValue<'a>>,
 }
 
+/// `( <calc-sum> )` inside a math function: the parens are kept so a redundant pair (`((a + b))`) survives.
+#[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
+pub struct CalcParenthesized<'a> {
+    pub span: Span,
+    pub expr: Box<'a, ComponentValue<'a>>,
+}
+
 #[derive(Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
@@ -199,6 +208,8 @@ pub enum CombinatorKind {
     Column,
     /// `/deep/` (deprecated shadow-piercing descendant)
     Deep,
+    /// Any other `/name/` (`/shadow/`): less.js's slashed combinator
+    Slashed,
     /// `^` (deprecated shadow child)
     ShadowChild,
     /// `^^` (deprecated shadow descendant)
@@ -227,6 +238,7 @@ pub enum ComplexSelectorChild<'a> {
 pub enum ComponentValue<'a> {
     BracketBlock(BracketBlock<'a>),
     Calc(Calc<'a>),
+    CalcParenthesized(CalcParenthesized<'a>),
     Delimiter(Delimiter),
     Dimension(Dimension<'a>),
     Function(Function<'a>),
@@ -1177,6 +1189,8 @@ pub struct LessOperationOperator {
 pub enum LessOperationOperatorKind {
     Multiply,
     Division,
+    /// `./`, the explicit division of `math=parens-division`
+    DotDivision,
     Plus,
     Minus,
 }

--- a/crates/oxc_css_parser/src/ast_generated.rs
+++ b/crates/oxc_css_parser/src/ast_generated.rs
@@ -90,6 +90,13 @@ impl<'a> Calc<'a> {
     }
 }
 
+impl<'a> CalcParenthesized<'a> {
+    #[inline]
+    pub fn span(&self) -> &Span {
+        &self.span
+    }
+}
+
 impl<'a> ColorProfilePrelude<'a> {
     #[inline]
     pub fn span(&self) -> &Span {
@@ -123,6 +130,7 @@ impl<'a> ComponentValue<'a> {
         match self {
             Self::BracketBlock(value) => value.span(),
             Self::Calc(value) => value.span(),
+            Self::CalcParenthesized(value) => value.span(),
             Self::Delimiter(value) => &value.span,
             Self::Dimension(value) => value.span(),
             Self::Function(value) => value.span(),

--- a/crates/oxc_css_parser/src/parser/less.rs
+++ b/crates/oxc_css_parser/src/parser/less.rs
@@ -446,12 +446,12 @@ impl<'a> Parser<'a> {
                 TokenWithSpan { token: Token::Dot(..), .. }
                     if precedence == PRECEDENCE_MULTIPLY =>
                 {
-                    // `./` is also division
+                    // `./`: the explicit division of `math=parens-division`
                     let Span { start, .. } = self.cursor.bump()?.span;
                     let (_, Span { end, .. }) =
                         self.cursor.expect_solidus_without_ws_or_comments()?;
                     LessOperationOperator {
-                        kind: LessOperationOperatorKind::Division,
+                        kind: LessOperationOperatorKind::DotDivision,
                         span: Span { start, end },
                     }
                 }
@@ -662,13 +662,14 @@ impl<'a> Parser<'a> {
         let attempt = self.try_parse(|parser| {
             let hex_color = parser.parse::<HexColor>()?;
             match parser.cursor.peek()? {
-                TokenWithSpan { token: Token::LParen(..), span } => {
+                // `#ns()` / `#ns[key]`, the lookup also apart from its namespace
+                // (`#ns [key]`: less.js skips that whitespace)
+                TokenWithSpan { token: Token::LParen(..) | Token::LBracket(..), span } => {
                     Err(Error { kind: ErrorKind::TryParseError, span: *span })
                 }
-                TokenWithSpan {
-                    token: Token::LBracket(..) | Token::Dot(..) | Token::Hash(..),
-                    span,
-                } if hex_color.span.end == span.start => {
+                TokenWithSpan { token: Token::Dot(..) | Token::Hash(..), span }
+                    if hex_color.span.end == span.start =>
+                {
                     Err(Error { kind: ErrorKind::TryParseError, span: *span })
                 }
                 _ => Ok(hex_color),
@@ -1021,8 +1022,8 @@ impl<'a> Parse<'a> for LessInterpolatedStr<'a> {
             } else {
                 // '@' or '$' is consumed, so '{' left only
                 let start = input.cursor.expect_l_brace()?.1.start - 1;
-                // Less interpolation names may start with a digit (`@{3}`).
-                let (name, name_span) = input.cursor.expect_ident_without_ws_or_comments(true)?;
+                let (name, name_span) =
+                    input.cursor.expect_name_without_ws_or_comments(/* less_name */ true)?;
 
                 let end = input.cursor.expect_r_brace()?.1.end;
                 elements.push(match input.source.as_bytes().get(start) {
@@ -1562,8 +1563,7 @@ impl<'a> Parse<'a> for LessMixinName<'a> {
                 }))
             }
             TokenWithSpan { token: Token::Dot(..), span: dot_span } => {
-                let (ident, ident_span) =
-                    input.cursor.expect_ident_without_ws_or_comments(false)?;
+                let (ident, ident_span) = input.cursor.expect_ident_without_ws_or_comments()?;
                 let ident = input.ident(ident, ident_span);
                 let span = Span { start: dot_span.start, end: ident.span.end };
                 Ok(LessMixinName::ClassSelector(ClassSelector {
@@ -1791,31 +1791,17 @@ impl<'a> Parse<'a> for LessVariableDeclaration<'a> {
             ComponentValue::LessDetachedRuleset(input.parse()?)
         } else {
             let typed = input.try_parse(|p| {
-                let value = p
-                    .with_state(ParserState {
-                        less_ctx: p.state.less_ctx | LESS_CTX_ALLOW_DIV,
-                        ..p.state.clone()
-                    })
-                    .parse_maybe_less_list(/* allow_comma */ true)?;
-                // The declaration must account for everything up to a
-                // statement boundary — `@page :first {` is an at-rule, not a
-                // variable named `@page` with the value `first`.
-                if !matches!(
-                    &p.cursor.peek()?.token,
-                    Token::Semicolon(..) | Token::RBrace(..) | Token::Eof(..)
-                ) {
-                    let span = p.cursor.peek()?.span;
-                    return Err(Error { kind: ErrorKind::TryParseError, span });
-                }
-                Ok(value)
+                p.with_state(ParserState {
+                    less_ctx: p.state.less_ctx | LESS_CTX_ALLOW_DIV,
+                    ..p.state.clone()
+                })
+                .parse_maybe_less_list(/* allow_comma */ true)
             });
-            match typed {
+            let value = match typed {
                 Ok(value) => value,
+                // No typed value: only then does less.js `permissiveValue` take any
+                // balanced token run (`@this: () => { ... };`), and only one ending in `;`
                 Err(error) => {
-                    // less.js `permissiveValue`: a variable's value may be any
-                    // balanced token run (`@this: () => { ... };`), but only
-                    // when explicitly terminated by `;` — otherwise
-                    // `@page :first { ... }` would be swallowed too.
                     let start = input.cursor.peek()?.span.start;
                     let values = input
                         .parse_declaration_value_tokens(/* stop_at_top_level_brace */ false)?;
@@ -1832,7 +1818,18 @@ impl<'a> Parse<'a> for LessVariableDeclaration<'a> {
                         span: Span { start, end },
                     })
                 }
+            };
+            // less.js `declaration`: a value that stops short of the statement boundary is
+            // no declaration (it backtracks): `@page :first {` is an at-rule, not `@page`
+            // with the value `first`, even with a `;` somewhere later
+            if !matches!(
+                &input.cursor.peek()?.token,
+                Token::Semicolon(..) | Token::RBrace(..) | Token::Eof(..)
+            ) {
+                let span = input.cursor.peek()?.span;
+                return Err(Error { kind: ErrorKind::TryParseError, span });
             }
+            value
         };
         let span = Span { start: name.span.start, end: value.span().end };
         Ok(LessVariableDeclaration { name, colon_span, value, span })

--- a/crates/oxc_css_parser/src/parser/mod.rs
+++ b/crates/oxc_css_parser/src/parser/mod.rs
@@ -367,15 +367,22 @@ impl<'a> ParserCursor<'a> {
     }
 
     #[inline]
-    fn expect_ident_without_ws_or_comments(
+    fn expect_ident_without_ws_or_comments(&mut self) -> PResult<(token::Ident<'a>, Span)> {
+        self.expect_name_without_ws_or_comments(/* less_name */ false)
+    }
+
+    fn expect_name_without_ws_or_comments(
         &mut self,
-        allow_leading_digit: bool,
+        less_name: bool,
     ) -> PResult<(token::Ident<'a>, Span)> {
         debug_assert!(self.cached_token.is_none());
-        if self.tokenizer.is_start_of_ident()
-            || (allow_leading_digit && self.tokenizer.is_start_of_digit())
-        {
-            self.tokenizer.scan_ident_sequence(allow_leading_digit)
+        let starts = if less_name {
+            self.tokenizer.is_start_of_less_name()
+        } else {
+            self.tokenizer.is_start_of_ident()
+        };
+        if starts {
+            self.tokenizer.scan_ident_sequence(less_name)
         } else {
             let TokenWithSpan { token, span } = self.tokenizer.bump_without_ws_or_comments()?;
             Err(Error { kind: ErrorKind::Unexpected("<ident>", token.symbol()), span })

--- a/crates/oxc_css_parser/src/parser/sass.rs
+++ b/crates/oxc_css_parser/src/parser/sass.rs
@@ -957,8 +957,7 @@ impl<'a> Parse<'a> for SassExtend<'a> {
         let mut end = selectors.span.end;
 
         let optional = if let Some((_, exclamation_span)) = input.cursor.eat_exclamation()? {
-            let (keyword, keyword_span) =
-                input.cursor.expect_ident_without_ws_or_comments(false)?;
+            let (keyword, keyword_span) = input.cursor.expect_ident_without_ws_or_comments()?;
             if keyword.name().eq_ignore_ascii_case("optional") {
                 end = keyword_span.end;
                 let span = Span { start: exclamation_span.start, end: keyword_span.end };

--- a/crates/oxc_css_parser/src/parser/selector.rs
+++ b/crates/oxc_css_parser/src/parser/selector.rs
@@ -117,8 +117,7 @@ impl<'a> Parse<'a> for AnPlusB {
 
             TokenWithSpan { token: Token::Plus(..), .. } => {
                 let plus_span = input.cursor.bump()?.span;
-                let (ident, ident_span) =
-                    input.cursor.expect_ident_without_ws_or_comments(false)?;
+                let (ident, ident_span) = input.cursor.expect_ident_without_ws_or_comments()?;
                 let ident_name = ident.name();
                 if ident_name.eq_ignore_ascii_case("n") {
                     match &input.cursor.peek()?.token {
@@ -526,7 +525,7 @@ impl<'a> Parse<'a> for ClassSelector<'a> {
             end = span.end;
             InterpolableIdent::Placeholder((placeholder, span).into())
         } else if input.syntax == Syntax::Css {
-            let (ident, ident_span) = input.cursor.expect_ident_without_ws_or_comments(false)?;
+            let (ident, ident_span) = input.cursor.expect_ident_without_ws_or_comments()?;
             end = ident_span.end;
             InterpolableIdent::Literal(input.ident(ident, ident_span))
         } else {
@@ -1425,11 +1424,18 @@ impl<'a> Parser<'a> {
             {
                 let deep = self.try_parse(|p| {
                     let start = p.cursor.bump()?.span; // `/`
-                    let ident_end = match p.cursor.peek()? {
+                    let (ident_end, kind) = match p.cursor.peek()? {
                         TokenWithSpan { token: Token::Ident(..), span }
                             if span.start == start.end =>
                         {
-                            p.cursor.bump()?.span.end
+                            let ident = p.cursor.bump()?;
+                            let kind = if ident.is_ident_name_eq_ignore_ascii_case(p.source, "deep")
+                            {
+                                CombinatorKind::Deep
+                            } else {
+                                CombinatorKind::Slashed
+                            };
+                            (ident.span.end, kind)
                         }
                         TokenWithSpan { span, .. } => {
                             return Err(Error {
@@ -1443,7 +1449,7 @@ impl<'a> Parser<'a> {
                             if span.start == ident_end =>
                         {
                             let end = p.cursor.bump()?.span.end;
-                            Ok(Span { start: start.start, end })
+                            Ok((Span { start: start.start, end }, kind))
                         }
                         TokenWithSpan { span, .. } => Err(Error {
                             kind: ErrorKind::TryParseError,
@@ -1452,7 +1458,7 @@ impl<'a> Parser<'a> {
                     }
                 });
                 match deep {
-                    Ok(span) => Ok(Some(Combinator { kind: CombinatorKind::Deep, span })),
+                    Ok((span, kind)) => Ok(Some(Combinator { kind, span })),
                     Err(_) => Ok(None),
                 }
             }

--- a/crates/oxc_css_parser/src/parser/value.rs
+++ b/crates/oxc_css_parser/src/parser/value.rs
@@ -52,10 +52,13 @@ impl<'a> Parser<'a> {
         allow_modulo: bool,
     ) -> PResult<ComponentValue<'a>> {
         let mut left = if precedence >= PRECEDENCE_MULTIPLY {
-            if self.cursor.eat_l_paren()?.is_some() {
+            if let Some((_, lparen_span)) = self.cursor.eat_l_paren()? {
                 let expr = self.parse_calc_expr(allow_modulo)?;
-                self.cursor.expect_r_paren()?;
-                expr
+                let end = self.cursor.expect_r_paren()?.1.end;
+                ComponentValue::CalcParenthesized(CalcParenthesized {
+                    expr: self.alloc(expr),
+                    span: Span { start: lparen_span.start, end },
+                })
             } else if matches!(self.syntax, Syntax::Scss | Syntax::Sass)
                 && matches!(&self.cursor.peek()?.token, Token::Minus(..) | Token::Plus(..))
                 && {

--- a/crates/oxc_css_parser/src/tokenizer/mod.rs
+++ b/crates/oxc_css_parser/src/tokenizer/mod.rs
@@ -214,14 +214,7 @@ impl<'a> Tokenizer<'a> {
                 self.scan_hash()
             }
             (Some((_, b'\'' | b'"')), ..) => self.scan_string_or_template(),
-            (Some((_, b'@')), Some((_, c)))
-                // A leading `-` only starts an identifier if the next code point does too
-                // (`@-webkit-*`, `@--custom`); a lone `@-` is a delimiter, not an at-keyword.
-                // Less also allows digit-led variable names (`@3`).
-                if (is_start_of_ident(c)
-                    && (c != b'-' || matches!(chars.peek(), Some((_, c2)) if is_start_of_ident(*c2))))
-                    || (self.syntax == Syntax::Less && c.is_ascii_digit()) =>
-            {
+            (Some((_, b'@')), Some((_, c))) if self.starts_var_name(c, &mut chars) => {
                 self.scan_at_keyword()
             }
             (Some((start, b'-')), Some((_, b'-'))) => {
@@ -241,11 +234,7 @@ impl<'a> Tokenizer<'a> {
                 let (number, span) = self.scan_number()?;
                 self.scan_dimension_or_percentage(number, span)
             }
-            (Some((_, b'$')), Some((_, c)))
-                // Same as `@`: a lone `$-` is not the start of a Sass variable.
-                if is_start_of_ident(c)
-                    && (c != b'-' || matches!(chars.peek(), Some((_, c2)) if is_start_of_ident(*c2))) =>
-            {
+            (Some((_, b'$')), Some((_, c))) if self.starts_var_name(c, &mut chars) => {
                 self.scan_dollar_var()
             }
             (Some((_, b'-')), Some((_, b'#')))
@@ -256,7 +245,7 @@ impl<'a> Tokenizer<'a> {
             }
             (Some((_, b'@' | b'$')), Some((_, b'{')))
                 if self.syntax == Syntax::Less
-                    && matches!(chars.peek(), Some((_, c)) if is_start_of_ident(*c) || c.is_ascii_digit()) =>
+                    && matches!(chars.peek(), Some((_, c)) if is_less_name_start(*c)) =>
             {
                 self.scan_less_lbrace_var()
             }
@@ -513,10 +502,9 @@ impl<'a> Tokenizer<'a> {
 
     // <ident-sequence> (a run of name code points / escapes).
     // https://drafts.csswg.org/css-syntax-3/#consume-name
-    pub(crate) fn scan_ident_sequence(
-        &mut self,
-        allow_leading_digit: bool,
-    ) -> PResult<(Ident<'a>, Span)> {
+    /// `less_name`: a less.js `[\w-]+` name instead (`@name`, `${name}`, `@{name}`, inside strings too),
+    /// which may also start with a digit (`@3`) or a bare hyphen (`@-`, `@-1`).
+    pub(crate) fn scan_ident_sequence(&mut self, less_name: bool) -> PResult<(Ident<'a>, Span)> {
         let start;
         let end;
         let mut escaped = false;
@@ -525,18 +513,27 @@ impl<'a> Tokenizer<'a> {
                 start = *i;
                 self.state.chars.next();
             }
-            // Less variable names may start with a digit (`@3`, `@{3}`); CSS idents may not.
-            Some((i, c)) if allow_leading_digit && c.is_ascii_digit() => {
+            // Less variable names may start with a digit (`@3`, `@{3}`); CSS idents may not
+            Some((i, c)) if less_name && c.is_ascii_digit() => {
                 start = *i;
                 self.state.chars.next();
             }
             Some((i, b'-')) => {
                 start = *i;
                 self.state.chars.next();
-                if let Some((_, c)) = self.state.chars.next() {
-                    debug_assert!(is_start_of_ident(c));
-                } else {
-                    return Err(self.build_eof_error());
+                match self.state.chars.peek() {
+                    // `-\31 x`: the escape after the hyphen is one too
+                    Some((_, b'\\')) => {
+                        escaped = true;
+                        self.scan_escape(/* backslash_consumed */ false)?;
+                    }
+                    Some((_, c)) if is_start_of_ident(*c) => {
+                        self.state.chars.next();
+                    }
+                    // `@-`, `@-1`, `@{-}`: a less.js name needs nothing behind the hyphen
+                    _ if less_name => {}
+                    Some(..) => unreachable!(),
+                    None => return Err(self.build_eof_error()),
                 }
             }
             Some((i, b'\\')) => {
@@ -909,11 +906,28 @@ impl<'a> Tokenizer<'a> {
                 is_start
             }
             Syntax::Less => {
-                // Less interpolation names may start with a digit (`@{3}`), like `@3`.
-                (c == b'@' || c == b'$')
-                    && matches!(self.peek_two_bytes(), Some((_, b'{', second)) if is_start_of_ident(second) || second.is_ascii_digit())
+                // less.js `Quoted` substitutes exactly `@{name}` / `${name}`;
+                // anything else (`"@{box"`, the outer `@{box-` of `"@{box-@{suffix}}"`) is text
+                (c == b'@' || c == b'$') && self.less_interpolation_ahead()
             }
         }
+    }
+
+    /// Whether a less.js variable / property name (`[\w-]+`) starts here (`is_less_name_start`)
+    pub(crate) fn is_start_of_less_name(&mut self) -> bool {
+        matches!(self.state.chars.peek(), Some((_, c)) if is_less_name_start(*c))
+    }
+
+    /// `{` <less name> `}` next (the `@` / `$` already consumed); nothing is consumed.
+    fn less_interpolation_ahead(&mut self) -> bool {
+        // `scan_ident_sequence` moves only the byte cursor, so that is all to restore
+        let saved = self.state.chars.clone();
+        let ahead = matches!(self.state.chars.next(), Some((_, b'{')))
+            && self.is_start_of_less_name()
+            && self.scan_ident_sequence(/* less_name */ true).is_ok()
+            && matches!(self.state.chars.next(), Some((_, b'}')));
+        self.state.chars = saved;
+        ahead
     }
 
     // An ident-like token: <ident-token>, <function-token> (`name(`), or <url-token>.
@@ -1002,20 +1016,9 @@ impl<'a> Tokenizer<'a> {
                     });
                 }
                 Some((i, c)) if c.is_ascii_whitespace() => {
-                    self.skip_ws();
-                    match self.state.chars.next() {
-                        Some((_, b')')) => {
-                            self.state.paren_depth = self.state.paren_depth.saturating_sub(1);
-                            end = i;
-                            break;
-                        }
-                        Some((i, _)) => {
-                            return Err(Error {
-                                kind: ErrorKind::InvalidUrl,
-                                span: Span { start: i, end: i + 1 },
-                            });
-                        }
-                        None => return Err(self.build_eof_error()),
+                    if self.url_body_ws_run_ends()? {
+                        end = i;
+                        break;
                     }
                 }
                 Some((i, b'(' | b'"' | b'\'')) => {
@@ -1032,6 +1035,25 @@ impl<'a> Tokenizer<'a> {
         debug_assert!(start <= end);
         let span = Span { start, end };
         Ok(TokenWithSpan { token: Token::UrlRaw(UrlRawMeta { escaped }), span })
+    }
+
+    /// A whitespace run inside an unquoted url() body: `true` when it ends the body at `)`.
+    /// CSS allows nothing else there; less.js (`[^()'"]+`) reads on, and the byte after
+    /// the run is left to the caller's loop.
+    fn url_body_ws_run_ends(&mut self) -> PResult<bool> {
+        self.skip_ws();
+        match self.state.chars.peek() {
+            Some((_, b')')) => {
+                self.state.chars.next();
+                self.state.paren_depth = self.state.paren_depth.saturating_sub(1);
+                Ok(true)
+            }
+            Some(..) if self.syntax == Syntax::Less => Ok(false),
+            Some((i, _)) => {
+                Err(Error { kind: ErrorKind::InvalidUrl, span: Span { start: *i, end: *i + 1 } })
+            }
+            None => Err(self.build_eof_error()),
+        }
     }
 
     // The next static piece of an unquoted url() body interleaved with interpolation.
@@ -1058,26 +1080,15 @@ impl<'a> Tokenizer<'a> {
                     return Ok((UrlTemplate { raw, escaped, tail: false }, span));
                 }
                 Some((end, c)) if c.is_ascii_whitespace() => {
-                    self.skip_ws();
-                    match self.state.chars.next() {
-                        Some((_, b')')) => {
-                            self.state.paren_depth = self.state.paren_depth.saturating_sub(1);
-                            return Ok((
-                                UrlTemplate {
-                                    raw: unsafe { self.source.get_unchecked(start..end) },
-                                    escaped,
-                                    tail: true,
-                                },
-                                Span { start, end },
-                            ));
-                        }
-                        Some((i, _)) => {
-                            return Err(Error {
-                                kind: ErrorKind::InvalidUrl,
-                                span: Span { start: i, end: i + 1 },
-                            });
-                        }
-                        None => return Err(self.build_eof_error()),
+                    if self.url_body_ws_run_ends()? {
+                        return Ok((
+                            UrlTemplate {
+                                raw: unsafe { self.source.get_unchecked(start..end) },
+                                escaped,
+                                tail: true,
+                            },
+                            Span { start, end },
+                        ));
                     }
                 }
                 Some((i, b'(' | b'"' | b'\'')) => {
@@ -1160,7 +1171,8 @@ impl<'a> Tokenizer<'a> {
     fn scan_dollar_var(&mut self) -> PResult<TokenWithSpan<'a>> {
         let (start, c) = self.state.chars.next().expect("expect char `$`");
         debug_assert_eq!(c, b'$');
-        let (ident, span) = self.scan_ident_sequence(false)?;
+        let (ident, span) =
+            self.scan_ident_sequence(/* less_name */ self.syntax == Syntax::Less)?;
         Ok(TokenWithSpan {
             token: Token::DollarVar(IdentMeta { escaped: ident.escaped }),
             span: Span { start, end: span.end },
@@ -1174,8 +1186,7 @@ impl<'a> Tokenizer<'a> {
         let (_, c) = self.state.chars.next().expect("expect char `{`");
         debug_assert_eq!(c, b'{');
 
-        // Less allows digit-led variable names, so `@{3}` interpolates `@3`.
-        let (ident, _) = self.scan_ident_sequence(true)?;
+        let (ident, _) = self.scan_ident_sequence(/* less_name */ true)?;
         match self.state.chars.next() {
             Some((i, b'}')) => {
                 let span = Span { start, end: i + 1 };
@@ -1205,8 +1216,8 @@ impl<'a> Tokenizer<'a> {
         let (start, c) = self.state.chars.next().expect("expect char `@`");
         debug_assert_eq!(c, b'@');
 
-        // Less allows digit-led variable names like `@3`.
-        let (ident, span) = self.scan_ident_sequence(self.syntax == Syntax::Less)?;
+        let (ident, span) =
+            self.scan_ident_sequence(/* less_name */ self.syntax == Syntax::Less)?;
         Ok(TokenWithSpan {
             token: Token::AtKeyword(IdentMeta { escaped: ident.escaped }),
             span: Span { start, end: span.end },
@@ -1640,10 +1651,15 @@ impl<'a> Tokenizer<'a> {
         }
     }
 
-    /// Whether the next code point is an ASCII digit — the start of a Less
-    /// digit-led variable name (`@3`, `@{3}`).
-    pub(crate) fn is_start_of_digit(&mut self) -> bool {
-        matches!(self.state.chars.peek(), Some((_, c)) if c.is_ascii_digit())
+    /// Whether `c`, the byte after `@` / `$` (`chars` positioned after it), starts a variable name:
+    /// a CSS ident whose leading `-` needs an ident start behind it (`@-webkit-*`; a lone `@-` is a
+    /// delimiter), or in Less a `[\w-]+` name (`@3`, `$-`).
+    fn starts_var_name(&self, c: u8, chars: &mut Peekable<ByteIndices<'a>>) -> bool {
+        if self.syntax == Syntax::Less {
+            return is_less_name_start(c);
+        }
+        is_start_of_ident(c)
+            && (c != b'-' || matches!(chars.peek(), Some((_, c2)) if is_start_of_ident(*c2)))
     }
 
     pub(crate) fn is_start_of_url_string(&mut self) -> bool {
@@ -1652,7 +1668,12 @@ impl<'a> Tokenizer<'a> {
     }
 }
 
+/// The first byte of a less.js `[\w-]+` name: an ident start (`-` included) or a digit.
 #[inline]
+fn is_less_name_start(c: u8) -> bool {
+    is_start_of_ident(c) || c.is_ascii_digit()
+}
+
 fn is_start_of_ident(c: u8) -> bool {
     c.is_ascii_alphabetic() || c == b'-' || c == b'_' || !c.is_ascii() || c == b'\\'
 }

--- a/crates/oxc_css_parser/tests/ast/declaration/escaped.css
+++ b/crates/oxc_css_parser/tests/ast/declaration/escaped.css
@@ -8,3 +8,10 @@ a {
   color: #f00000\9\0;
   color: #f00000\9\0\;
 }
+
+/* an escape right after a leading hyphen is part of the ident (`-\31 x` is `-1x`) */
+.hyphen-escape {
+  a: -\31 x;
+  b: -\31 0px;
+  c: --\31 x;
+}

--- a/crates/oxc_css_parser/tests/ast/less/at-rule/page.less
+++ b/crates/oxc_css_parser/tests/ast/less/at-rule/page.less
@@ -1,0 +1,6 @@
+// `@page :first` has the `@name :` shape of a variable, but its value stops at `{`:
+// an at-rule, and the later `;` must not pull the block into a variable
+@page :first {
+  margin: 3cm;
+}
+@x: 1;

--- a/crates/oxc_css_parser/tests/ast/less/namespace.less
+++ b/crates/oxc_css_parser/tests/ast/less/namespace.less
@@ -25,3 +25,10 @@
 & when (#ns.options[option]) {}
 & when (#ns.options[option] = true) {}
 & when (@ns[@options][option]) {}
+
+// less.js skips the whitespace before `[` and inside the brackets
+.spaced {
+  indirect-prop: #ns[ $@p ];
+  indirect-prop: #ns   [   $@p   ];
+  chained: #ns [@v] [key];
+}

--- a/crates/oxc_css_parser/tests/ast/less/selectors/slashed-combinator.less
+++ b/crates/oxc_css_parser/tests/ast/less/selectors/slashed-combinator.less
@@ -1,0 +1,3 @@
+.parent /deep/ .child {}
+.container /shadow/ .content {}
+.a /DEEP/ .b {}

--- a/crates/oxc_css_parser/tests/ast/less/value/string.less
+++ b/crates/oxc_css_parser/tests/ast/less/value/string.less
@@ -7,3 +7,14 @@
 .mix-mul (@a: green) {
   color: ~"@{a}";
 }
+
+/* only an exact `@{[\w-]+}` is an interpolation node; the rest is literal text to the parser */
+.mixin {
+  width: ~"@{box-@{suffix}}";
+  weird: ~"@{box}-@{suffix}}";
+  width-str: "@{box-@{suffix}}";
+  weird-str: "@{box}-@{suffix}}";
+  @box: ~"@{box";
+  @open: "@{box";
+  hyphen: "@{-}" "${-}";
+}

--- a/crates/oxc_css_parser/tests/ast/less/value/url.less
+++ b/crates/oxc_css_parser/tests/ast/less/value/url.less
@@ -4,3 +4,16 @@
   background: url(@{a});
   background: url(~"");
 }
+
+/* less.js reads the body up to `)`: whitespace and newlines included */
+.data {
+  background: url(data:image/png;charset=utf-8;base64,
+    kiVBORw0KGgoAAAANSUhEUgAAABAAAAAQAQMAAAAlPW0iAAAABlBMVEUAAAD/
+    kg9C9zwz3gVLMDA/A6P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC);
+  background: url( spaced/path.png );
+}
+
+/* an escape after the whitespace run stays in the body */
+.escaped {
+  background: url(a \) b);
+}

--- a/crates/oxc_css_parser/tests/ast/less/variable/declaration.less
+++ b/crates/oxc_css_parser/tests/ast/less/variable/declaration.less
@@ -9,3 +9,17 @@
   zero: @var;
   name: @@name;
 }
+
+.hyphen-names {
+  @-: -;
+  @--: 1;
+  @-1: 2;
+  a: @-;
+  @{a}@{-}@{bb}: 3pt;
+}
+
+// property accessors are `[\w-]+` names too
+.property-names {
+  a: $-;
+  b: $1;
+}

--- a/crates/oxc_css_parser/tests/ident_hyphen_escape.rs
+++ b/crates/oxc_css_parser/tests/ident_hyphen_escape.rs
@@ -1,0 +1,25 @@
+use oxc_css_parser::{Allocator, ParserBuilder, Syntax, ast::*};
+
+fn first_declaration_value(code: &'static str) -> &'static [ComponentValue<'static>] {
+    let allocator = Box::leak(Box::new(Allocator::default()));
+    let mut parser = ParserBuilder::new(allocator, code).syntax(Syntax::Css).build();
+    let ss: &'static Stylesheet<'static> =
+        Box::leak(Box::new(parser.parse::<Stylesheet>().unwrap()));
+    assert!(parser.recoverable_errors().is_empty(), "{:?}", parser.recoverable_errors());
+    let Statement::QualifiedRule(rule) = &ss.statements[0] else { panic!("expected rule") };
+    let Statement::Declaration(decl) = &rule.block.statements[0] else { panic!("expected decl") };
+    &decl.value
+}
+
+// A leading hyphen followed by an escape is one ident: the escape is scanned
+// (its terminating space included) and the ident is flagged escaped.
+#[test]
+fn escape_after_leading_hyphen_is_one_ident() {
+    let [ComponentValue::InterpolableIdent(InterpolableIdent::Literal(ident))] =
+        first_declaration_value("a { b: -\\31 x; }")
+    else {
+        panic!("expected one ident, got {:?}", first_declaration_value("a { b: -\\31 x; }"));
+    };
+    assert_eq!(ident.raw, "-\\31 x");
+    assert_eq!(ident.name, "-1x");
+}

--- a/crates/oxc_css_parser/tests/less_ast_shapes.rs
+++ b/crates/oxc_css_parser/tests/less_ast_shapes.rs
@@ -1,0 +1,99 @@
+//! The AST shapes behind less.js-specific syntax: calc parens, `./`, slashed combinators,
+//! the variable-declaration boundary.
+
+use oxc_css_parser::{Allocator, ParserBuilder, Syntax, ast::*};
+
+fn parse_less(code: &'static str) -> Stylesheet<'static> {
+    let allocator = Box::leak(Box::new(Allocator::default()));
+    let mut parser = ParserBuilder::new(allocator, code).syntax(Syntax::Less).build();
+    let ss = parser.parse::<Stylesheet>().unwrap();
+    assert!(
+        parser.recoverable_errors().is_empty(),
+        "recoverable errors: {:?}",
+        parser.recoverable_errors()
+    );
+    ss
+}
+
+fn first_rule<'a>(ss: &'a Stylesheet<'static>) -> &'a QualifiedRule<'static> {
+    let Statement::QualifiedRule(rule) = &ss.statements[0] else {
+        panic!("expected qualified rule");
+    };
+    rule
+}
+
+fn first_declaration_value<'a>(ss: &'a Stylesheet<'static>) -> &'a [ComponentValue<'static>] {
+    let Statement::Declaration(decl) = &first_rule(ss).block.statements[0] else {
+        panic!("expected declaration");
+    };
+    &decl.value
+}
+
+fn text<'a>(code: &'a str, span: &oxc_css_parser::pos::Span) -> &'a str {
+    &code[span.start..span.end]
+}
+
+// A parenthesized calc operand keeps its parens, redundant pairs included.
+#[test]
+fn calc_parens_are_kept() {
+    let code = "a { h: calc(50% + ((@var - 20px))); }";
+    let ss = parse_less(code);
+    let [ComponentValue::Function(func)] = first_declaration_value(&ss) else {
+        panic!("expected function");
+    };
+    let [ComponentValue::Calc(calc)] = &func.args[..] else {
+        panic!("expected calc, got {:?}", func.args);
+    };
+    let ComponentValue::CalcParenthesized(outer) = &*calc.right else {
+        panic!("expected parenthesized operand, got {:?}", calc.right);
+    };
+    assert_eq!(text(code, &outer.span), "((@var - 20px))");
+    let ComponentValue::CalcParenthesized(inner) = &*outer.expr else {
+        panic!("expected the inner parens, got {:?}", outer.expr);
+    };
+    assert_eq!(text(code, &inner.span), "(@var - 20px)");
+    assert!(matches!(&*inner.expr, ComponentValue::Calc(..)));
+}
+
+// `./` is its own operator: `math=parens-division` divides on it where a plain `/` would not.
+#[test]
+fn dot_division_is_its_own_operator() {
+    let code = "a { c: 2px ./ 2; }";
+    let ss = parse_less(code);
+    let [ComponentValue::LessBinaryOperation(op)] = first_declaration_value(&ss) else {
+        panic!("expected a binary operation, got {:?}", first_declaration_value(&ss));
+    };
+    assert!(matches!(op.op.kind, LessOperationOperatorKind::DotDivision));
+    assert_eq!(text(code, &op.op.span), "./");
+}
+
+// `/deep/` keeps its own kind; any other less.js `/name/` is `Slashed`, its name in the span.
+#[test]
+fn slashed_combinators_keep_their_name() {
+    let combinator = |code: &'static str| {
+        let ss = parse_less(code);
+        let children = &first_rule(&ss).selector.selectors[0].children;
+        let ComplexSelectorChild::Combinator(combinator) = &children[1] else {
+            panic!("expected combinator, got {children:?}");
+        };
+        (format!("{:?}", combinator.kind), text(code, &combinator.span))
+    };
+    assert_eq!(combinator(".a /deep/ .b {}"), ("Deep".to_owned(), "/deep/"));
+    assert_eq!(combinator(".a /shadow/ .b {}"), ("Slashed".to_owned(), "/shadow/"));
+}
+
+// A variable whose typed value stops before the statement end is not a declaration:
+// `@page :first { ... }` is an at-rule even when a `;` follows later.
+#[test]
+fn page_at_rule_is_not_a_variable_declaration() {
+    let ss = parse_less("@page :first { margin: 3cm; }\n@x: 1;");
+    assert!(matches!(&ss.statements[0], Statement::AtRule(at_rule) if at_rule.name.raw == "page"));
+    assert!(matches!(&ss.statements[1], Statement::LessVariableDeclaration(..)));
+}
+
+// The permissive read stays for values the typed grammar cannot start on.
+#[test]
+fn permissive_variable_value_still_parses() {
+    let ss = parse_less("@this: () => { anything; until the semi; };");
+    assert!(matches!(&ss.statements[0], Statement::LessVariableDeclaration(..)));
+}

--- a/tasks/conformance/snapshots/less.js.snap
+++ b/tasks/conformance/snapshots/less.js.snap
@@ -1,7 +1,7 @@
 suite: less.js
 sha: 8ae2cc3bfa79f0718ad6fe5f263a1d6819fe9d5c
-files: 459   success: 426   failed: 9   expected: 24
-clean: 426  recovered: 1  hard_error: 8  panic: 0
+files: 459   success: 428   failed: 7   expected: 24
+clean: 428  recovered: 1  hard_error: 6  panic: 0
 
 failures:
 ERROR    packages/test-data/tests-config/debug/all/linenumbers-all.css    expect token `:`, but found `{`
@@ -10,8 +10,6 @@ ERROR    packages/test-data/tests-unit/import/import-inline.css    expect token 
 ERROR    packages/test-data/tests-unit/import/import-reference.css    expect token `:`, but found `<ident>`
 ERROR    packages/test-data/tests-unit/import/import/invalid-css.less    expect token `(`, but found `<ident>`
 ERROR    packages/test-data/tests-unit/property-name-interp/property-name-interp.css    CSS rule is expected
-ERROR    packages/test-data/tests-unit/property-name-interp/property-name-interp.less    expect token `(`, but found `{`
-ERROR    packages/test-data/tests-unit/strings/strings.less    expect token `;`, but found `{`
 RECOVER  packages/test-data/tests-unit/urls/actual.css    unterminated string
 
 expected failures (error tests, correct behavior):

--- a/tasks/conformance/snapshots/summary.snap
+++ b/tasks/conformance/snapshots/summary.snap
@@ -8,13 +8,13 @@ wpt                         7        5       0         2       5      0        0
 webref                      0        0       0         0       0      0        0      0
 postcss-parser-tests       30       29       1         0      29      1        0      0
 sass-spec               26787    26487      11       289   26487      9        2      0
-less.js                   459      426       9        24     426      1        8      0
+less.js                   459      428       7        24     428      1        6      0
 ------------------------------------------------------------------------
-total                   27283    26947      21       315   26947     11       10      0
+total                   27283    26949      19       315   26949     11        8      0
 
 # by syntax
 syntax                  files  success  failed  expected   clean  recov  harderr  panic
 css                     11788    11751      16        21   11751     11        5      0
 scss                    14750    14519       1       230   14519      0        1      0
 sass                      439      398       1        40     398      0        1      0
-less                      306      279       3        24     279      0        3      0
+less                      306      281       1        24     281      0        1      0


### PR DESCRIPTION
- Less variable name is: `[\w-]+`, allows `@-`, etc
- Support unquoted `url()`
- Add `CalcParenthesized` to preserve `((a + b))`
- Add `CombinatorKind::Slashed` for non `/deep/` kinds